### PR TITLE
Instructions for running in a docker container.

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -14,7 +14,4 @@ workdir /home/haskell/hackage-server-master
 run cabal install --only-dependencies
 run cabal configure && cabal build
 
-run ./dist/build/hackage-server/hackage-server init --static-dir=datafiles/
-
-entrypoint ["./dist/build/hackage-server/hackage-server", "run", "--static-dir=datafiles/"]
-expose 8080
+cmd echo "Binaries are in ./dist/build/hackage-*"

--- a/run-docker.sh
+++ b/run-docker.sh
@@ -1,0 +1,21 @@
+#!/bin/sh
+
+set -e
+
+ADMIN_USER=admin
+ADMIN_PASS=admin
+BUILD_RUN_TIME=30
+BUILD_INTERVAL=5
+
+DOCKER_IMAGE=zsol/hackage-server
+
+server_id=$(sudo docker run -d -p 8080 ${DOCKER_IMAGE} sh -c "./dist/build/hackage-server/hackage-server init --static-dir=datafiles --admin=\"${ADMIN_USER}:${ADMIN_PASS}\" ; ./dist/build/hackage-server/hackage-server run --static-dir=datafiles")
+
+server_ip=$(sudo docker inspect $server_id | grep IPAddress | cut -d'"' -f4)
+server_local_port=$(sudo docker port $server_id 8080)
+
+sleep 2 # TODO: poll until web server comes up
+
+sudo docker run -d ${DOCKER_IMAGE} sh -c "echo -e \"${ADMIN_USER}\n${ADMIN_PASS}\" | ./dist/build/hackage-build/hackage-build init http://${server_ip}:8080; ./dist/build/hackage-build/hackage-build build --run-time=${BUILD_RUN_TIME} --interval=${BUILD_INTERVAL} --continuous"
+
+echo "You can access your local hackage at http://localhost:${server_local_port}"


### PR DESCRIPTION
If you have docker installed, just run `docker build .` in the directory
containing `Dockerfile` and you will get an image that runs
hackage-server with the default settings in an isolated environment.

A prebuilt image is available at
https://index.docker.io/u/zsol/hackage-server/, which you can use by
running `docker run zsol/hackage-server`.
