### PR TITLE
adjusting upload limit as per suggestion in ticket https://github.com/haskell/hackage-server/issues/53

### DIFF
--- a/Distribution/Server.hs
+++ b/Distribution/Server.hs
@@ -182,7 +182,8 @@ run server = do
     handlePutPostQuotas = decodeBody bodyPolicy
       where
         tmpdir = serverTmpDir (serverEnv server)
-        quota  = 10 ^ (6 :: Int64)
+        quota  = 50 * (1024 ^ (2:: Int64))
+                -- setting quota at 50mb, though perhaps should be configurable?
         bodyPolicy = defaultBodyPolicy tmpdir quota quota quota
 
     setLogging =


### PR DESCRIPTION
set the limit to 50mb (power of 2 units). Should probably be one of those things  which have a default value but are overridable with some settings file. Once i learn more about hackage2, i'll figure out a PR for that

see ticket #53 
