### PR TITLE
issue #48 : support rendering of bzr tags

### DIFF
--- a/Distribution/Server/Pages/Package.hs
+++ b/Distribution/Server/Pages/Package.hs
@@ -293,10 +293,13 @@ sourceRepositoryToHtml sr
                           Just sd -> toHtml ("(" ++ sd ++ ")")
                           Nothing   -> noHtml]
       Just Bazaar
-       | (Just url, Nothing, Nothing, Nothing) <-
-         (repoLocation sr, repoModule sr, repoBranch sr, repoTag sr) ->
+       | (Just url, Nothing, Nothing) <-
+         (repoLocation sr, repoModule sr, repoBranch sr) ->
           concatHtml [toHtml "bzr branch ",
                       anchor ! [href url] << toHtml url,
+                      case repoTag sr of
+                          Just tag' -> toHtml (" -r " ++ tag')
+                          Nothing -> noHtml,
                       case repoSubdir sr of
                           Just sd -> toHtml ("(" ++ sd ++ ")")
                           Nothing   -> noHtml]


### PR DESCRIPTION
This fixes the rendering issue for Bazaar repository information with a tag.
The SVN issue at http://beta.hackage.haskell.org/package/omega-1.5.2 is a bit more complicated. As the tag is already a part of the URL the additional tag field is not necessary and should be omitted.
Currently if the SourceRepo contains some data not needed for a kind of repo, the code performs the fallback rendering. Maybe the code should expect all of fields to be set, render the checkout command with all the meaningful data and display the rest as additional information.
