### PR TITLE
Fix URL for new-hackage mirror source

### DIFF
--- a/MirrorClient.hs
+++ b/MirrorClient.hs
@@ -289,12 +289,12 @@ mirrorPackages verbosity opts pkgsToMirror = do
     extractCredentials _ = Nothing
 
     mirrorPackage pkginfo@(PkgIndexInfo pkgid _ _ _) = do
-      let srcBase = srcURI opts
-                    <//> (if isOldHackageURI (srcURI opts)
-                           then "packages" </> "archive"
-                           else "package")
+      let srcPackage = if isOldHackageURI (srcURI opts)
+              then "packages" </> "archive"
                     </> display (packageName pkgid)
                     </> display (packageVersion pkgid)
+              else "package" </> display pkgid
+          srcBase = srcURI opts <//> srcPackage
           dstBase = dstURI opts
                     <//> "package"
                     </> display pkgid


### PR DESCRIPTION
Tested against hackage.haskell.org and beta.hackage.haskell.org.
