### PR TITLE
Use hook updating tags in response to package change

### DIFF
--- a/Distribution/Server/Features/Tags.hs
+++ b/Distribution/Server/Features/Tags.hs
@@ -95,6 +95,7 @@ initTagsFeature ServerEnv{serverStateDir} core@CoreFeature{..} upload = do
           let pkgname = packageName pkgid
               tags = Set.fromList . constructImmutableTags . pkgDesc $ pkginfo
           updateState tagsState . SetPackageTags pkgname $ tags
+          runHook_ tagsUpdated (pkgs, tags)
 
     return feature
 


### PR DESCRIPTION
This is so that, as of currently, the library/gpl/bsd3/etc. tags get updated in PackageList in response to upload/mirror. Otherwise, the tags are displayed as ().
