### PR TITLE
Check that haddock docs build completed before uploading (fixes #119).

### DIFF
--- a/BuildClient.hs
+++ b/BuildClient.hs
@@ -586,8 +586,10 @@ buildPackage verbosity opts config docInfo = do
                                 </> "build-reports.log"
             handleDoesNotExist (return ()) $ removeFile simple_report_log
 
-        docs_generated <- liftM2 (&&) (doesDirectoryExist doc_dir_html)
-                                      (doesFileExist (doc_dir_html </> "doc-index.html"))
+        docs_generated <- fmap and $ sequence [
+            doesDirectoryExist doc_dir_html,
+            doesFileExist (doc_dir_html </> "doc-index.html"),
+            doesFileExist (doc_dir_html </> display (docInfoPackageName docInfo) <.> "haddock")]
         if docs_generated
             then do
                 notice verbosity $ "Docs generated for " ++ display (docInfoPackage docInfo)


### PR DESCRIPTION
I've created a patch which extends the existing checks in BuildClient.hs:buildPackage to check that the desired-package-name.haddock file exists in the output before uploading docs.tar. The existing check was insufficient and allowed hackage-build to upload docs even when the package has failed to build, provided that at least one dependency succeeded. This fixes issue #119 insofar as hackage-build should stop uploading bad docs.
