### PR TITLE
Fix templates file glob

### DIFF
--- a/hackage-server.cabal
+++ b/hackage-server.cabal
@@ -35,7 +35,8 @@ data-files:
   templates/Html/*.html.st
   templates/LegacyPasswds/*.html.st
   templates/Search/*.xml.st
-  templates/UserSignupReset/*.st
+  templates/UserSignupReset/*.html.st
+  templates/UserSignupReset/*.email.st
 
   static/*.css
   static/*.ico


### PR DESCRIPTION
For fixing the follow build error:

[13 of 13] Compiling Main             ( BuildClient.hs, dist/dist-sandbox-d7b5c57b/build/hackage-build/hackage-build-tmp/Main.o )
Linking dist/dist-sandbox-d7b5c57b/build/hackage-build/hackage-build ...
cabal: filepath wildcard 'templates/UserSignupReset/*.st' does not match any
files.
Failed to install hackage-server-0.4
