### PR TITLE
Use foldVersionRange' in MemSize VersionRange instance

### DIFF
--- a/Distribution/Server/Framework/MemSize.hs
+++ b/Distribution/Server/Framework/MemSize.hs
@@ -26,7 +26,7 @@ import qualified Data.Vector.Unboxed as V.U
 
 import Distribution.Package  (PackageIdentifier(..), PackageName(..))
 import Distribution.PackageDescription (FlagName(..))
-import Distribution.Version  (Version(..), VersionRange(..))
+import Distribution.Version  (Version(..), VersionRange, foldVersionRange')
 import Distribution.System   (Arch(..), OS(..))
 import Distribution.Compiler (CompilerFlavor(..), CompilerId(..))
 
@@ -55,7 +55,7 @@ memSize6 :: (MemSize a5, MemSize a4, MemSize a3, MemSize a2, MemSize a1, MemSize
 memSize7 :: (MemSize a6, MemSize a5, MemSize a4, MemSize a3, MemSize a2, MemSize a1, MemSize a) => a -> a1 -> a2 -> a3 -> a4 -> a5 -> a6 -> Int
 memSize10 :: (MemSize a9, MemSize a8, MemSize a7, MemSize a6, MemSize a5, MemSize a4, MemSize a3, MemSize a2, MemSize a1, MemSize a) => a -> a1 -> a2 -> a3 -> a4 -> a5 -> a6 -> a7 -> a8 -> a9 -> Int
 
-                           
+
 memSize0             = 0
 memSize1 a           = 2 + memSize a
 memSize2 a b         = 3 + memSize a + memSize b
@@ -168,14 +168,17 @@ instance MemSize Version where
     memSize (Version a b) = memSize2 a b
 
 instance MemSize VersionRange where
-    memSize (AnyVersion)                   = memSize0
-    memSize (ThisVersion v)                = memSize1 v
-    memSize (LaterVersion v)               = memSize1 v
-    memSize (EarlierVersion v)             = memSize1 v
-    memSize (WildcardVersion v)            = memSize1 v
-    memSize (UnionVersionRanges v1 v2)     = memSize2 v1 v2
-    memSize (IntersectVersionRanges v1 v2) = memSize2 v1 v2
-    memSize (VersionRangeParens v)         = memSize1 v
+    memSize =
+      foldVersionRange' memSize0 -- any
+                        memSize1 -- == v
+                        memSize1 -- > v
+                        memSize1 -- < v
+                        memSize1 -- >= v
+                        memSize1 -- <= v
+                        memSize2 -- == v.*
+                        memSize2 -- _ || _
+                        memSize2 -- _ && _
+                        memSize1 -- (_)
 
 instance MemSize PackageIdentifier where
     memSize (PackageIdentifier a b) = memSize2 a b


### PR DESCRIPTION
Cabal deprecates using explicit constructors, instead recommending
foldVersionRange'.
