### PR TITLE
Add Flags section to package view (refs #66)

### DIFF
--- a/Distribution/Server/Packages/Render.hs
+++ b/Distribution/Server/Packages/Render.hs
@@ -50,6 +50,7 @@ data PackageRender = PackageRender {
     rendHasChangeLog :: Bool,
     rendUploadInfo   :: (UTCTime, Maybe UserInfo),
     rendPkgUri       :: String,
+    rendFlags        :: [Flag],
     -- rendOther contains other useful fields which are merely strings, possibly empty
     --     for example: description, home page, copyright, author, stability
     -- If PackageRender is the One True Resource Representation, should they
@@ -78,6 +79,7 @@ doPackageRender users info hasChangeLog = return $ PackageRender
     , rendUploadInfo   = let (utime, uid) = pkgUploadData info
                          in (utime, Users.lookupUserId uid users)
     , rendPkgUri       = pkgUri
+    , rendFlags        = genPackageFlags genDesc
     , rendOther        = desc
     }
   where
@@ -241,4 +243,3 @@ unionDisjunct :: Disjunct -> Disjunct -> Disjunct
 unionDisjunct xs ys = xs' ++ ys'
   where ys' = [y | y <- ys, not (or [subConjunct y x | x <- xs])]
         xs' = [x | x <- xs, not (or [subConjunct x y | y <- ys'])]
-

--- a/datafiles/static/hackage.css
+++ b/datafiles/static/hackage.css
@@ -568,3 +568,20 @@ ul.links li form button:hover {
 strong.warning { color: red; }
 
 /* @end */
+
+
+/* * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * */
+/* Flags table */
+
+.flags-table td {
+  padding-right: 1em;
+  padding-bottom: 0.25em;
+}
+
+.flags-table .flag-disabled {
+  color: #888;
+}
+
+.code {
+  font-family: monospace;
+}


### PR DESCRIPTION
See #66 for more info. Uses the already existing flag information from the general package description and prints out a table of flags, if there are any, with a little tip about how to enable/disable flags. Example from the `jack` package:

![flags](https://f.cloud.github.com/assets/11019/1649665/557ddf26-5a1a-11e3-8952-7a25e5af7b3e.png)
