### PR TITLE
Fix #158: download counts go up and down

### DIFF
--- a/Distribution/Server/Features/DownloadCount/State.hs
+++ b/Distribution/Server/Features/DownloadCount/State.hs
@@ -63,6 +63,11 @@ newtype RecentDownloads = RecentDownloads {
   }
   deriving (CountingMap PackageName, Show, Eq, MemSize)
 
+newtype TotalDownloads = TotalDownloads {
+    totalDownloads :: SimpleCountingMap PackageName
+  }
+  deriving (CountingMap PackageName, Show, Eq, MemSize)
+
 {------------------------------------------------------------------------------
   Initial instances
 ------------------------------------------------------------------------------}
@@ -87,6 +92,13 @@ initRecentDownloads dayRange (OnDiskStats (NCM _ perPackage)) =
       case Map.lookup day perDay of
         Nothing         -> id
         Just perVersion -> cmInsert pkgName (cmTotal perVersion)
+
+initTotalDownloads :: OnDiskStats -> TotalDownloads
+initTotalDownloads (OnDiskStats (NCM _ perPackage)) =
+    foldr (.) id (map goPackage (Map.toList perPackage)) cmEmpty
+  where
+    goPackage :: (PackageName, OnDiskPerPkg) -> TotalDownloads -> TotalDownloads
+    goPackage (pkgName, OnDiskPerPkg perPkg) = cmInsert pkgName (cmTotal perPkg)
 
 {------------------------------------------------------------------------------
   Pure updates/queries

--- a/Distribution/Server/Features/Html.hs
+++ b/Distribution/Server/Features/Html.hs
@@ -411,7 +411,7 @@ mkHtmlCore HtmlUtilities{..}
            UploadFeature{guardAuthorisedAsMaintainerOrTrustee}
            TagsFeature{queryTagsForPackage}
            DocumentationFeature{documentationResource, queryHasDocumentation}
-           DownloadFeature{recentPackageDownloads}
+           DownloadFeature{recentPackageDownloads,totalPackageDownloads}
            DistroFeature{queryPackageStatus}
            RecentPackagesFeature{packageRender}
            HtmlTags{..}
@@ -475,11 +475,12 @@ mkHtmlCore HtmlUtilities{..}
         -- [reverse index disabled] revCount <- revPackageSummary realpkg
         -- We don't currently keep per-version downloads in memory
         -- (totalDown, versionDown) <- perVersionDownloads pkg
-        totalDown <- cmFind pkgname `liftM` recentPackageDownloads
+        totalDown <- cmFind pkgname `liftM` totalPackageDownloads
+        recentDown <- cmFind pkgname `liftM` recentPackageDownloads
         let distHtml = case distributions of
                 [] -> []
                 _  -> [("Distributions", concatHtml . intersperse (toHtml ", ") $ map showDist distributions)]
-            afterHtml  = distHtml ++ [Pages.renderDownloads totalDown {- versionDown $ packageVersion realpkg-}
+            afterHtml  = distHtml ++ [Pages.renderDownloads totalDown recentDown {- versionDown $ packageVersion realpkg-}
                                      -- [reverse index disabled] ,Pages.reversePackageSummary realpkg revr revCount
                                      ]
         -- bottom sections, currently only documentation

--- a/Distribution/Server/Pages/Package.hs
+++ b/Distribution/Server/Pages/Package.hs
@@ -239,10 +239,11 @@ renderVersion (PackageIdentifier pname pversion) allVersions info =
 
 -- We don't keep currently per-version downloads in memory; if we decide that
 -- it is important to show this all the time, we can reenable
-renderDownloads :: Int -> {- Int -> Version -> -} (String, Html)
-renderDownloads totalDown {- versionDown version -} =
+renderDownloads :: Int -> Int -> {- Int -> Version -> -} (String, Html)
+renderDownloads totalDown recentDown {- versionDown version -} =
     ("Downloads", toHtml $ {- show versionDown ++ " for " ++ display version ++
-                      " and " ++ -} show totalDown ++ " total")
+                      " and " ++ -} show totalDown ++ " total (" ++
+                      show recentDown ++ " in last 30 days)")
 
 renderFields :: PackageRender -> [(String, Html)]
 renderFields render = [


### PR DESCRIPTION
Display both "recent" (last 30 days) and "total" (all time) download counts on package page.
