### PR TITLE
Fix #187: add "index" link to package front page

### DIFF
--- a/Distribution/Server/Pages/Package.hs
+++ b/Distribution/Server/Pages/Package.hs
@@ -34,7 +34,7 @@ import Data.Time.Format         (formatTime)
 
 packagePage :: PackageRender -> [Html] -> [Html] -> [(String, Html)] -> [(String, Html)] -> Maybe URL -> Bool -> Html
 packagePage render headLinks top sections bottom docURL isCandidate =
-    hackagePageWith [] docTitle docSubtitle docBody [docFooter]
+    hackagePageWith [] docIndexLink docTitle docSubtitle docBody [docFooter]
   where
     pkgid = rendPkgId render
 
@@ -74,6 +74,10 @@ packagePage render headLinks top sections bottom docURL isCandidate =
 
     pair (title, content) =
         toHtml [ h2 << title, content ]
+
+    docIndexLink = case docURL of
+      Nothing -> []
+      _ -> [anchor ! [href $ docIndexURL pkgid] << "Package index"]
 
 -- | Body of the package page
 pkgBody :: PackageRender -> [(String, Html)] -> [Html]
@@ -392,6 +396,10 @@ renderModuleForest mb_url forest =
 -- | URL describing a package.
 packageURL :: PackageIdentifier -> URL
 packageURL pkgId = "/package" </> display pkgId
+
+-- | URL describing a package.
+docIndexURL :: PackageIdentifier -> URL
+docIndexURL pkgId = "/package" </> display pkgId </> "docs/doc-index.html"
 
 --cabalLogoURL :: URL
 --cabalLogoURL = "/built-with-cabal.png"

--- a/Distribution/Server/Pages/Template.hs
+++ b/Distribution/Server/Pages/Template.hs
@@ -15,13 +15,14 @@ hackagePage = hackagePageWithHead []
 
 hackagePageWithHead :: [Html] -> String -> [Html] -> Html
 hackagePageWithHead headExtra docTitle docContent =
-    hackagePageWith headExtra docTitle docSubtitle docContent bodyExtra
+    hackagePageWith headExtra [] docTitle docSubtitle docContent bodyExtra
   where
     docSubtitle = anchor ! [href introductionURL] << "Hackage :: [Package]"
     bodyExtra   = []
 
-hackagePageWith :: [Html] -> String -> Html -> [Html] -> [Html] -> Html
-hackagePageWith headExtra docTitle docSubtitle docContent bodyExtra =
+hackagePageWith :: [Html] -> [Html] -> String
+                -> Html -> [Html] -> [Html] -> Html
+hackagePageWith headExtra navExtra docTitle docSubtitle docContent bodyExtra =
     toHtml [ header << (docHead ++ headExtra)
            , body   << (docBody ++ bodyExtra) ]
   where
@@ -36,22 +37,21 @@ hackagePageWith headExtra docTitle docSubtitle docContent bodyExtra =
                 ]
     docBody   = [ thediv ! [identifier "page-header"] << docHeader
                 , thediv ! [identifier "content"] << docContent ]
-    docHeader = [ navigationBar
+    docHeader = [ navigationBar navExtra
                 , paragraph ! [theclass "caption"] << docSubtitle ]
 
-navigationBar :: Html
-navigationBar =
-    ulist ! [theclass "links", identifier "page-menu"]
-      <<  map (li <<)
-          [ anchor ! [href introductionURL] << "Home"
-          , form   ! [action "/packages/search", theclass "search", method "get"]
-                  << [ button ! [thetype "submit"] << "Search", spaceHtml
-                     , input  ! [thetype "text", name "terms" ] ]
-          , anchor ! [href pkgListURL] << "Browse"
-          , anchor ! [href recentAdditionsURL] << "What's new"
-          , anchor ! [href uploadURL]   << "Upload"
-          , anchor ! [href accountsURL] << "User accounts"
-          ]
+navigationBar :: [Html] -> Html
+navigationBar extra =
+  let links = [ anchor ! [href introductionURL] << "Home"
+              , form   ! [action "/packages/search", theclass "search", method "get"]
+                << [ button ! [thetype "submit"] << "Search", spaceHtml
+                   , input  ! [thetype "text", name "terms" ] ]
+              , anchor ! [href pkgListURL] << "Browse"
+              , anchor ! [href recentAdditionsURL] << "What's new"
+              , anchor ! [href uploadURL]   << "Upload"
+              , anchor ! [href accountsURL] << "User accounts"
+              ] ++ extra
+  in ulist ! [theclass "links", identifier "page-menu"] << map (li <<) links
 
 stylesheetURL :: URL
 stylesheetURL = "/static/hackage.css"


### PR DESCRIPTION
If there is documentation for a package, display a "Package index" link in the navigation bar of the main package page, going directly to the documentation index.
