### PR TITLE
Fix deleting maintainers, and possibly other actions using _method.

### DIFF
--- a/Distribution/Server/Util/Happstack.hs
+++ b/Distribution/Server/Util/Happstack.hs
@@ -44,7 +44,12 @@ methodOverrideHack rest
 -- | For use with 'methodOverrideHack': tries to report the original method
 -- of a request before the hack was applied.
 rqRealMethod :: Request -> Method
-rqRealMethod rq = fromMaybe (rqMethod rq) $ unsafePerformIO $ runServerPartT_hack rq $
+-- We want to look in the post data to find out if the method has been
+-- changed. But if the method has been changed to something other than
+-- POST or PUT, Happstack doesn't return any post data at all. So we
+-- set the method to POST temporarily before checking the post
+-- parameter.
+rqRealMethod rq = fromMaybe (rqMethod rq) $ unsafePerformIO $ runServerPartT_hack rq { rqMethod = POST } $
     withDataFn (liftM (not . null) $ lookInputs "_method") $ \mthd_exists ->
       return $ if mthd_exists then POST else rqMethod rq
 


### PR DESCRIPTION
The authentication hash for digest authentication includes the method, but that might have been changed by methodOverrideHack. rqRealMethod tries to find out if this was the case, and if so, returns POST instead of rqMethod. But it does this by looking at the post data, and Happstack doesn't return post data for requests other than POST and PUT.

For maintainers deletion, _method was set to DELETE, so authentication failed and users were repeatedly presented with authentication dialogs. We now set the method to POST temporarily before checking if a _method parameter was present.

Fixes #197.
