### PR TITLE
Add AdminFrontend to datafiles in .cabal

### DIFF
--- a/hackage-server.cabal
+++ b/hackage-server.cabal
@@ -37,6 +37,7 @@ data-files:
   templates/Search/*.xml.st
   templates/UserSignupReset/*.html.st
   templates/UserSignupReset/*.email.st
+  templates/AdminFrontend/*.html.st
 
   static/*.css
   static/*.ico


### PR DESCRIPTION
Cabal file needs to export files in templates/AdminFrontend folder in order to run hackage-server properly
