### PR TITLE
Add [Index] link to package front page

### DIFF
--- a/Distribution/Server/Pages/Package.hs
+++ b/Distribution/Server/Pages/Package.hs
@@ -44,10 +44,8 @@ packagePage render headLinks top sections bottom docURL isCandidate =
                  short -> ": " ++ short
     docSubtitle = toHtml docTitle
 
-    docBody =
-        h1 <<
-           bodyTitle :
-            concat [
+    docBody = h1 << bodyTitle
+          : concat [
              renderHeads,
              top,
              pkgBody render sections,
@@ -181,7 +179,12 @@ moduleSection render docURL = maybeToList $ fmap msect (rendModules render)
   where msect lib = toHtml
             [ h2 << "Modules"
             , renderModuleForest docURL lib
+            , renderDocIndexLink docURL
             ]
+        renderDocIndexLink = maybe mempty $ \docURL' ->
+            let docIndexURL = docURL' </> "doc-index.html"
+            in  paragraph ! [thestyle "font-size: small"]
+                  << ("[" +++ anchor ! [href docIndexURL] << "Index" +++ "]")
 
 propertySection :: [(String, Html)] -> [Html]
 propertySection sections =


### PR DESCRIPTION
If there is documentation for a package, display an "[Index]" link below the list of modules, linking directly to the documentation index.

This is similar to #196, except the link is placed in the page body (as per @dcoutts) rather than the header.

[Here's a screenshot](http://i.imgur.com/xpcecxb.png).

Closes #187.
