### PR TITLE
Clean up test suite problems

### DIFF
--- a/datafiles/static/hackage.css
+++ b/datafiles/static/hackage.css
@@ -71,7 +71,7 @@ table {
 	font:100%;
 }
 
-pre, code, kbd, samp, tt, .src {
+pre, code, kbd, samp, .src {
 	font-family:monospace;
 	*font-size:108%;
 	line-height: 124%;

--- a/datafiles/templates/EditCabalFile/cabalFilePublished.html.st
+++ b/datafiles/templates/EditCabalFile/cabalFilePublished.html.st
@@ -12,7 +12,7 @@ $hackagePageHeader()$
 <h1>Published new revision for <a href="/package/$pkgid$">$pkgid$</a></h1>
 
 <p>The new revision has been published. It will be available to users as soon
-as they update their package index (e.g. <tt>cabal update</tt>).
+as they update their package index (e.g. <code>cabal update</code>).
 
 <pre rows="20" cols="80">$cabalfile$</pre>
 

--- a/datafiles/templates/upload.html.st
+++ b/datafiles/templates/upload.html.st
@@ -32,15 +32,15 @@ exists for a package, only its members can upload new versions of that package.
 
 <p>If there is no maintainer, the uploader can remove themselves from the group,
 and a <a href="/packages/trustees">package trustee</a> can add anyone who wishes
-to assume the responsibility. The <tt>Maintainer</tt> field of the Cabal file should be
-<tt>None</tt> in this case. If a package is being maintained, any release not approved
+to assume the responsibility. The <code>Maintainer</code> field of the Cabal file should be
+<code>None</code> in this case. If a package is being maintained, any release not approved
 and supported by the maintainer should use a different package name. Then use
-the <tt>Maintainer</tt> field as above either to commit to supporting the fork
+the <code>Maintainer</code> field as above either to commit to supporting the fork
 yourself or to mark it as unsupported.
 </p>
 
 <p>Note that all of the above is a makeshift upload policy based on the features
-available in the newer hackage-server. The <tt>Maintainer</tt> field has its uses,
+available in the newer hackage-server. The <code>Maintainer</code> field has its uses,
 as does maintainer user groups. The libraries mailing list should probably
 determine the best approach for this.
 </p>
@@ -54,9 +54,9 @@ and password.)
 
 <p>Packages must be in the form produced by Cabal's
 <a href="http://www.haskell.org/ghc/docs/latest/html/Cabal/builders.html#setup-sdist">sdist</a> command:
-a gzipped tar file <em>package</em>-<em>version</em><tt>.tar.gz</tt>
+a gzipped tar file <em>package</em>-<em>version</em><code>.tar.gz</code>
 comprising a directory <em>package</em>-<em>version</em> containing a package
-of that name and version, including <em>package</em><tt>.cabal</tt>.
+of that name and version, including <em>package</em><code>.cabal</code>.
 See the notes at the bottom of the page.
 </p>
 
@@ -67,7 +67,7 @@ See the notes at the bottom of the page.
 <ul>
 <li>You should check that your source bundle builds,
 including the haddock documentation if it's a library.</li>
-<li>Categories are determined by whatever you put in the <tt>Category</tt> field
+<li>Categories are determined by whatever you put in the <code>Category</code> field
 (there's no agreed list of category names yet).
 You can have more than one category, separated by commas. If no other versions of
 the package exist, the categories automatically become the package's tags.</li>
@@ -76,7 +76,7 @@ The means of doing this is still up in the air.</li>
 <li>We have moved to Haddock 2, and expect some glitches.
 If you notice anything broken, please report it on the
 <a href="http://trac.haskell.org/haddock">Haddock bug tracker</a>.</li>
-<li>In GHC 6.8, several modules were split from the <tt>base</tt> package
+<li>In GHC 6.8, several modules were split from the <code>base</code> package
 into other packages.
 See <a href="http://www.haskell.org/haskellwiki/Upgrading_packages">these notes</a> on making packages work with a range of versions of GHC.</li>
 <li>While <a href="http://www.haskell.org/haddock/">Haddock 2</a>

--- a/tests/HackageClientUtils.hs
+++ b/tests/HackageClientUtils.hs
@@ -95,7 +95,22 @@ runServer root args = run server args'
 ------------------------------------------------------------------------------}
 
 type User  = String
-data Group = Group { groupMembers     :: [User]
+
+data UserInfo = UserInfo { userName :: User
+                         , userId :: Int
+                         }
+              deriving Show
+
+instance FromJSON UserInfo where
+  parseJSON (Object obj) = do
+    name <- obj .: "username"
+    uid  <- obj .: "userid"
+    return UserInfo { userName = name
+                    , userId   = uid
+                    }
+  parseJSON _ = fail "Expected object"
+
+data Group = Group { groupMembers     :: [UserInfo]
                    , groupTitle       :: String
                    , groupDescription :: String
                    }
@@ -112,8 +127,8 @@ instance FromJSON Group where
                  }
   parseJSON _ = fail "Expected object"
 
-getUsers :: IO [User]
-getUsers = getJSONStrings "/users/.json"
+getUsers :: IO [UserInfo]
+getUsers = getUrl NoAuth "/users/.json" >>= decodeJSON
 
 getAdmins :: IO Group
 getAdmins = getGroup "/users/admins/.json"

--- a/tests/HttpUtils.hs
+++ b/tests/HttpUtils.hs
@@ -6,6 +6,7 @@ module HttpUtils (
     ExpectedCode
   , isOk
   , isAccepted
+  , isNoContent
   , isSeeOther
   , isUnauthorized
   , isForbidden
@@ -36,9 +37,11 @@ import Util
 
 type ExpectedCode = (Int, Int, Int) -> Bool
 
-isOk, isAccepted, isSeeOther, isUnauthorized, isForbidden :: ExpectedCode
+isOk, isAccepted, isNoContent, isSeeOther :: ExpectedCode
+isUnauthorized, isForbidden :: ExpectedCode
 isOk           = (== (2, 0, 0))
 isAccepted     = (== (2, 0, 2))
+isNoContent    = (== (2, 0, 4))
 isSeeOther     = (== (3, 0, 3))
 isUnauthorized = (== (4, 0, 1))
 isForbidden    = (== (4, 0, 3))


### PR DESCRIPTION
1. Fix HTML5 validation warnings (by replacing `<tt>` with `<code>`).
2. Update user JSON response processing (to match
   a16d386c3c171de5a787a403039f284f4177f75e).
3. Update user deletion status code processing to recognise 204 "No
   content" response (to match af329c1241cc555696c46b2c120ecfaa33f24230).
