### PR TITLE
make the email check for password recovery case-insensitive (fixes haske...

### DIFF
--- a/Distribution/Server/Features/UserSignup.hs
+++ b/Distribution/Server/Features/UserSignup.hs
@@ -606,7 +606,7 @@ userSignupFeature ServerEnv{serverBaseURI} UserFeature{..} UserDetailsFeature{..
                , errBadRequest "Missing form fields" [] ]
 
         guardEmailMatches (Just AccountDetails {accountContactEmail}) useremail
-          | accountContactEmail == useremail = return ()
+          | T.toLower accountContactEmail == T.toLower useremail = return ()
         guardEmailMatches _ _ =
           errForbidden "Wrong account details"
             [MText "Sorry, that does not match any account details we have on file."]


### PR DESCRIPTION
...ll/hackage-server#213))

The diff is trivial:

``` haskell
diff --git a/Distribution/Server/Features/UserSignup.hs b/Distribution/Server/Features/UserSignup.hs
index ff16b10..599a343 100644
--- a/Distribution/Server/Features/UserSignup.hs
+++ b/Distribution/Server/Features/UserSignup.hs
@@ -606,7 +606,7 @@ userSignupFeature ServerEnv{serverBaseURI} UserFeature{..} UserDetailsFeature{..
                , errBadRequest "Missing form fields" [] ]

         guardEmailMatches (Just AccountDetails {accountContactEmail}) useremail
-          | accountContactEmail == useremail = return ()
+          | T.toLower accountContactEmail == T.toLower useremail = return ()
         guardEmailMatches _ _ =
           errForbidden "Wrong account details"
             [MText "Sorry, that does not match any account details we have on file."]
```

It'd be nicer, I guess, to use a wrapper around Text for enforcing case insensitivity everywhere for emails, but this is a much more significant change, and I'm not sure how big of a win that would be.
