### PR TITLE
Bump Cabal dependency to 1.20

### DIFF
--- a/Distribution/Server/Features/Tags.hs
+++ b/Distribution/Server/Features/Tags.hs
@@ -244,11 +244,14 @@ constructImmutableTags genDesc =
     licenseToTag :: License -> [Tag]
     licenseToTag l = case l of
         GPL  _ -> [Tag "gpl"]
+        AGPL _ -> [Tag "agpl"]
         LGPL _ -> [Tag "lgpl"]
+        BSD2 -> [Tag "bsd2"]
         BSD3 -> [Tag "bsd3"]
         BSD4 -> [Tag "bsd4"]
         MIT  -> [Tag "mit"]
+        MPL _ -> [Tag "mpl"]
+        Apache _ -> [Tag "apache"]
         PublicDomain -> [Tag "public-domain"]
         AllRightsReserved -> [Tag "all-rights-reserved"]
         _ -> []
-

--- a/hackage-server.cabal
+++ b/hackage-server.cabal
@@ -267,7 +267,7 @@ executable hackage-server
     aeson      == 0.6.1.*,
     unordered-containers >= 0.2.3.0,
     rss        == 3000.2.*,
-    Cabal      >= 1.18.1 && < 1.19,
+    Cabal      == 1.20.*,
     csv        == 0.1.*,
     stm        >= 2.2 && < 2.5,
     acid-state == 0.8.*,


### PR DESCRIPTION
With this change, packages with a "License" field of BSD2 or MPL pass the upload lint.

These licenses (and others that were missing) have also been added to the tag system.

I didn't do any porting other than this; if there's something I overlooked please point it out. It compiles and passes the tests though.

Fixes #182.
