### PR TITLE
Fix valign/align HTML5 validation warnings (fixes #136)

### DIFF
--- a/Distribution/Server/Pages/Package.hs
+++ b/Distribution/Server/Pages/Package.hs
@@ -193,8 +193,8 @@ propertySection sections =
     ]
 
 tabulate :: [(String, Html)] -> Html
-tabulate items = table <<
-        [tr << [th ! [align "left", valign "top"] << t, td << d] | (t, d) <- items]
+tabulate items = table ! [theclass "properties"] <<
+        [tr << [th << t, td << d] | (t, d) <- items]
 
 
 renderDependencies :: PackageRender -> (String, Html)

--- a/datafiles/static/hackage.css
+++ b/datafiles/static/hackage.css
@@ -603,3 +603,8 @@ form.box {
 table.simpletable th, table.simpletable td {
   padding: 0.2em 1em;
 }
+
+table.properties th {
+  vertical-align: top;
+  text-align: left;
+}


### PR DESCRIPTION
I thought I'd caught all of these HTML5 validation warnings in the test suite, but there were a couple left over.
