### PR TITLE
Add "scrubbed backups" capability

### DIFF
--- a/Distribution/Server/Features/BuildReports.hs
+++ b/Distribution/Server/Features/BuildReports.hs
@@ -68,7 +68,7 @@ reportsStateComponent name stateDir = do
     , stateHandle  = st
     , getState     = query st GetBuildReports
     , putState     = update st . ReplaceBuildReports
-    , backupState  = dumpBackup
+    , backupState  = \_ -> dumpBackup
     , restoreState = restoreBackup
     , resetState   = reportsStateComponent name
     }

--- a/Distribution/Server/Features/Core.hs
+++ b/Distribution/Server/Features/Core.hs
@@ -276,7 +276,7 @@ packagesStateComponent verbosity stateDir = do
      , stateHandle  = st
      , getState     = query st GetPackagesState
      , putState     = update st . ReplacePackagesState
-     , backupState  = indexToAllVersions
+     , backupState  = \_ -> indexToAllVersions
      , restoreState = packagesBackup
      , resetState   = packagesStateComponent verbosity
      }

--- a/Distribution/Server/Features/Distro.hs
+++ b/Distribution/Server/Features/Distro.hs
@@ -60,7 +60,7 @@ distrosStateComponent stateDir = do
     , stateHandle  = st
     , getState     = query st GetDistributions
     , putState     = \(Distros dists versions) -> update st (ReplaceDistributions dists versions)
-    , backupState  = dumpBackup
+    , backupState  = \_ -> dumpBackup
     , restoreState = restoreBackup
     , resetState   = distrosStateComponent
     }

--- a/Distribution/Server/Features/Documentation.hs
+++ b/Distribution/Server/Features/Documentation.hs
@@ -97,7 +97,7 @@ documentationStateComponent name stateDir = do
     , stateHandle  = st
     , getState     = query st GetDocumentation
     , putState     = update st . ReplaceDocumentation
-    , backupState  = dumpBackup
+    , backupState  = \_ -> dumpBackup
     , restoreState = updateDocumentation (Documentation Map.empty)
     , resetState   = documentationStateComponent name
     }

--- a/Distribution/Server/Features/DownloadCount.hs
+++ b/Distribution/Server/Features/DownloadCount.hs
@@ -80,7 +80,7 @@ inMemStateComponent stateDir = do
     , stateHandle  = st
     , getState     = query st GetInMemStats
     , putState     = update st . ReplaceInMemStats
-    , backupState  = inMemBackup
+    , backupState  = \_ -> inMemBackup
     , restoreState = inMemRestore
     , resetState   = inMemStateComponent
     }
@@ -91,7 +91,7 @@ onDiskStateComponent stateDir = StateComponent {
     , stateHandle  = OnDiskState
     , getState     = readOnDiskStats (dcPath stateDir </> "ondisk")
     , putState     = writeOnDisk stateDir Nothing Nothing ReconstructLog
-    , backupState  = onDiskBackup
+    , backupState  = \_ -> onDiskBackup
     , restoreState = onDiskRestore
     , resetState   = return . onDiskStateComponent
     }

--- a/Distribution/Server/Features/HaskellPlatform.hs
+++ b/Distribution/Server/Features/HaskellPlatform.hs
@@ -65,7 +65,7 @@ platformStateComponent stateDir = do
     -- TODO: backup
     -- For now backup is just empty, as this package is basically featureless
     -- It defines state, but there is no way at all to modify this state
-    , backupState  = \_ -> []
+    , backupState  = \_ _ -> []
     , restoreState = RestoreBackup {
                          restoreEntry    = error "Unexpected backup entry for platform"
                        , restoreFinalize = return initialPlatformPackages

--- a/Distribution/Server/Features/Mirror.hs
+++ b/Distribution/Server/Features/Mirror.hs
@@ -78,7 +78,7 @@ mirrorersStateComponent stateDir = do
     , stateHandle  = st
     , getState     = query st GetMirrorClients
     , putState     = update st . ReplaceMirrorClients . mirrorClients
-    , backupState  = \(MirrorClients clients) -> [csvToBackup ["clients.csv"] $ groupToCSV clients]
+    , backupState  = \_ (MirrorClients clients) -> [csvToBackup ["clients.csv"] $ groupToCSV clients]
     , restoreState = MirrorClients <$> groupBackup ["clients.csv"]
     , resetState   = mirrorersStateComponent
     }

--- a/Distribution/Server/Features/PackageCandidates.hs
+++ b/Distribution/Server/Features/PackageCandidates.hs
@@ -134,7 +134,7 @@ candidatesStateComponent stateDir = do
     , getState     = query st GetCandidatePackages
     , putState     = update st . ReplaceCandidatePackages
     , resetState   = candidatesStateComponent
-    , backupState  = backupCandidates
+    , backupState  = \_ -> backupCandidates
     , restoreState = restoreCandidates
   }
 

--- a/Distribution/Server/Features/PreferredVersions.hs
+++ b/Distribution/Server/Features/PreferredVersions.hs
@@ -109,7 +109,7 @@ preferredStateComponent stateDir = do
     , getState     = query st GetPreferredVersions
     , putState     = update st . ReplacePreferredVersions
     , resetState   = preferredStateComponent
-    , backupState  = backupPreferredVersions
+    , backupState  = \_ -> backupPreferredVersions
     , restoreState = restorePreferredVersions
     }
 

--- a/Distribution/Server/Features/Tags.hs
+++ b/Distribution/Server/Features/Tags.hs
@@ -107,7 +107,7 @@ tagsStateComponent stateDir = do
     , stateHandle  = st
     , getState     = query st GetPackageTags
     , putState     = update st . ReplacePackageTags
-    , backupState  = \pkgTags -> [csvToBackup ["tags.csv"] $ tagsToCSV pkgTags]
+    , backupState  = \_ pkgTags -> [csvToBackup ["tags.csv"] $ tagsToCSV pkgTags]
     , restoreState = tagsBackup
     , resetState   = tagsStateComponent
     }

--- a/Distribution/Server/Features/TarIndexCache.hs
+++ b/Distribution/Server/Features/TarIndexCache.hs
@@ -46,7 +46,7 @@ tarIndexCacheStateComponent stateDir = do
     , putState     = update st . ReplaceTarIndexCache
     , resetState   = tarIndexCacheStateComponent
     -- We don't backup the tar indices, but reconstruct them on demand
-    , backupState  = \_ -> []
+    , backupState  = \_ _ -> []
     , restoreState = RestoreBackup {
                          restoreEntry    = error "The impossible happened"
                        , restoreFinalize = return initialTarIndexCache

--- a/Distribution/Server/Features/Upload.hs
+++ b/Distribution/Server/Features/Upload.hs
@@ -147,7 +147,7 @@ trusteesStateComponent stateDir = do
     , stateHandle  = st
     , getState     = query st GetHackageTrustees
     , putState     = update st . ReplaceHackageTrustees . trusteeList
-    , backupState  = \(HackageTrustees trustees) -> [csvToBackup ["trustees.csv"] $ groupToCSV trustees]
+    , backupState  = \_ (HackageTrustees trustees) -> [csvToBackup ["trustees.csv"] $ groupToCSV trustees]
     , restoreState = HackageTrustees <$> groupBackup ["trustees.csv"]
     , resetState   = trusteesStateComponent
     }
@@ -160,7 +160,7 @@ uploadersStateComponent stateDir = do
     , stateHandle  = st
     , getState     = query st GetHackageUploaders
     , putState     = update st . ReplaceHackageUploaders . uploaderList
-    , backupState  = \(HackageUploaders uploaders) -> [csvToBackup ["uploaders.csv"] $ groupToCSV uploaders]
+    , backupState  = \_ (HackageUploaders uploaders) -> [csvToBackup ["uploaders.csv"] $ groupToCSV uploaders]
     , restoreState = HackageUploaders <$> groupBackup ["uploaders.csv"]
     , resetState   = uploadersStateComponent
     }
@@ -173,7 +173,7 @@ maintainersStateComponent stateDir = do
     , stateHandle  = st
     , getState     = query st AllPackageMaintainers
     , putState     = update st . ReplacePackageMaintainers
-    , backupState  = \(PackageMaintainers mains) -> [maintToExport mains]
+    , backupState  = \_ (PackageMaintainers mains) -> [maintToExport mains]
     , restoreState = maintainerBackup
     , resetState   = maintainersStateComponent
     }

--- a/Distribution/Server/Features/Users.hs
+++ b/Distribution/Server/Features/Users.hs
@@ -231,7 +231,8 @@ usersStateComponent stateDir = do
     , stateHandle  = st
     , getState     = query st GetUserDb
     , putState     = update st . ReplaceUserDb
-    , backupState  = \users -> [csvToBackup ["users.csv"] (usersToCSV users)]
+    , backupState  = \backuptype users ->
+        [csvToBackup ["users.csv"] (usersToCSV backuptype users)]
     , restoreState = userBackup
     , resetState   = usersStateComponent
     }
@@ -244,7 +245,7 @@ adminsStateComponent stateDir = do
     , stateHandle  = st
     , getState     = query st GetHackageAdmins
     , putState     = update st . ReplaceHackageAdmins . adminList
-    , backupState  = \(HackageAdmins admins) -> [csvToBackup ["admins.csv"] (groupToCSV admins)]
+    , backupState  = \_ (HackageAdmins admins) -> [csvToBackup ["admins.csv"] (groupToCSV admins)]
     , restoreState = HackageAdmins <$> groupBackup ["admins.csv"]
     , resetState   = adminsStateComponent
     }


### PR DESCRIPTION
Adds a --scrubbed-backup flag for backup generation for development use.  This generates backups with all user-identifying and authentication information (email addresses, passwords, password reset nonces) removed.  Email addresses are replaced with a non-existent address, and all user accounts in the backup are given the password "test".

You can use a scrubbed backup to restore into a database that you can interact with just like the main Hackage database.  This is a more effective means of making a development test database than mirroring individual packages from the main Hackage server since it reproduces all package download statistics from the main server, along with all user accounts and other information from the main server.
