### PR TITLE
Added support for etags when downloading the package index.

### DIFF
--- a/Distribution/Server/Features/Documentation.hs
+++ b/Distribution/Server/Features/Documentation.hs
@@ -203,9 +203,10 @@ documentationFeature name
     serveDocumentationTar :: DynamicPath -> ServerPartE Response
     serveDocumentationTar dpath =
       withDocumentation (packageDocsWhole documentationResource)
-                        dpath $ \_ blob _ -> do
-        file <- liftIO $ BlobStorage.fetch store blob
-        return $ toResponse $ Resource.DocTarball file blob
+                        dpath $ \_ blobid _ -> do
+        useETag (BlobStorage.blobETag blobid)
+        file <- liftIO $ BlobStorage.fetch store blobid
+        return $ toResponse $ Resource.DocTarball file blobid
 
 
     -- return: not-found error or tarball
@@ -214,7 +215,7 @@ documentationFeature name
       withDocumentation (packageDocsContent documentationResource)
                         dpath $ \pkgid blob index -> do
         let tarball = BlobStorage.filepath store blob
-            etag    = blobETag blob
+            etag    = BlobStorage.blobETag blob
         -- if given a directory, the default page is index.html
         -- the root directory within the tarball is e.g. foo-1.0-docs/
         ServerTarball.serveTarball ["index.html"] (display pkgid ++ "-docs")

--- a/Distribution/Server/Features/PackageCandidates.hs
+++ b/Distribution/Server/Features/PackageCandidates.hs
@@ -421,7 +421,7 @@ candidatesFeature ServerEnv{serverBlobStore = store}
     packageTarball PkgInfo{pkgTarball = (pkgTarball, _) : _} = do
       let blobid = pkgTarballNoGz pkgTarball
           fp     = BlobStorage.filepath store blobid
-          etag   = blobETag blobid
+          etag   = BlobStorage.blobETag blobid
       index <- cachedPackageTarIndex pkgTarball
       return $ Right (fp, etag, index)
     packageTarball _ =

--- a/Distribution/Server/Features/PackageContents.hs
+++ b/Distribution/Server/Features/PackageContents.hs
@@ -118,7 +118,7 @@ packageContentsFeature ServerEnv{serverBlobStore = store}
     packageTarball PkgInfo{pkgTarball = (pkgTarball, _) : _} = do
       let blobid = pkgTarballNoGz pkgTarball
           fp     = BlobStorage.filepath store blobid
-          etag   = blobETag blobid
+          etag   = BlobStorage.blobETag blobid
       index <- cachedPackageTarIndex pkgTarball
       return $ Right (fp, etag, index)
     packageTarball _ =

--- a/Distribution/Server/Framework/BlobStorage.hs
+++ b/Distribution/Server/Framework/BlobStorage.hs
@@ -15,6 +15,7 @@ module Distribution.Server.Framework.BlobStorage (
     BlobStorage,
     BlobId,
     blobMd5,
+    blobETag,
     open,
     add,
     addWith,
@@ -27,6 +28,7 @@ module Distribution.Server.Framework.BlobStorage (
 
 import Distribution.Server.Framework.MemSize
 import Distribution.Server.Framework.Instances ()
+import Distribution.Server.Util.Happstack (ETag(..))
 
 import qualified Data.ByteString.Lazy as BSL
 import qualified Data.Digest.Pure.MD5 as MD5
@@ -72,6 +74,9 @@ instance ToJSON BlobId where
 
 blobMd5 :: BlobId -> String
 blobMd5 (BlobId digest) = show digest
+
+blobETag :: BlobId -> ETag
+blobETag = ETag . blobMd5
 
 instance SafeCopy BlobId where
   version = 2

--- a/Distribution/Server/Framework/ResponseContentTypes.hs
+++ b/Distribution/Server/Framework/ResponseContentTypes.hs
@@ -38,23 +38,12 @@ import Text.CSV (printCSV, CSV)
 import Control.DeepSeq
 
 
-newtype ETag = ETag String
-  deriving (Eq, Ord, Show)
-
-blobETag :: BlobId -> ETag
-blobETag = ETag . blobMd5
-
-formatETag :: ETag -> String
-formatETag (ETag etag) = '"' : etag ++ ['"']
-
-
 data IndexTarball = IndexTarball !BS.Lazy.ByteString !Int !MD5Digest !UTCTime
 
 instance ToMessage IndexTarball where
   toResponse (IndexTarball bs len md5 time) = mkResponseLen bs len
     [ ("Content-Type", "application/x-gzip")
     , ("Content-MD5",   md5str)
-    , ("ETag",          formatETag (ETag md5str))
     , ("Last-modified", formatTime time)
     ]
     where md5str = show md5
@@ -72,7 +61,6 @@ instance ToMessage PackageTarball where
   toResponse (PackageTarball bs blobid time) = mkResponse bs
     [ ("Content-Type",  "application/x-gzip")
     , ("Content-MD5",   md5sum)
-    , ("ETag",          formatETag (ETag md5sum))
     , ("Last-modified", formatTime time)
     ]
     where md5sum = blobMd5 blobid
@@ -83,7 +71,6 @@ instance ToMessage DocTarball where
   toResponse (DocTarball bs blobid) = mkResponse bs
     [ ("Content-Type",  "application/x-tar")
     , ("Content-MD5",   md5sum)
-    , ("ETag",          formatETag (ETag md5sum))
     ]
     where md5sum = blobMd5 blobid
 

--- a/Distribution/Server/Util/ServeTarball.hs
+++ b/Distribution/Server/Util/ServeTarball.hs
@@ -23,7 +23,7 @@ import Happstack.Server.Monads
 import Happstack.Server.Routing (method)
 import Happstack.Server.Response
 import Happstack.Server.FileServe as Happstack (mimeTypes)
-import Distribution.Server.Util.Happstack (remainingPath)
+import Distribution.Server.Util.Happstack (remainingPath, ETag(..), formatETag)
 import Distribution.Server.Pages.Template (hackagePage)
 import Distribution.Server.Framework.ResponseContentTypes as Resource
 

--- a/tests/HackageClientUtils.hs
+++ b/tests/HackageClientUtils.hs
@@ -24,6 +24,7 @@ import HttpUtils ( ExpectedCode
                  , isOk
                  , isAccepted
                  , isSeeOther
+                 , isNotModified
                  , isUnauthorized
                  , isForbidden
                  , Authorization(..)
@@ -240,6 +241,23 @@ mkPostReq url vals =
 
 getUrl :: Authorization -> RelativeURL -> IO String
 getUrl auth url = Http.execRequest auth (mkGetReq url)
+
+getETag :: RelativeURL -> IO String
+getETag url = Http.responseHeader HdrETag (mkGetReq url)
+
+checkETag :: String -> RelativeURL -> IO ()
+checkETag etag url = void $
+  Http.execRequest' NoAuth (mkGetReqWithETag url etag) isNotModified
+
+checkETagMismatch :: String -> RelativeURL -> IO ()
+checkETagMismatch etag url = void $
+  Http.execRequest NoAuth (mkGetReqWithETag url etag)
+
+mkGetReqWithETag :: String -> RelativeURL -> Request_String
+mkGetReqWithETag url etag =
+    Request (fromJust $ parseURI $ mkUrl url) GET hdrs ""
+  where
+    hdrs = [mkHeader HdrIfNoneMatch etag]
 
 getJSONStrings :: RelativeURL -> IO [String]
 getJSONStrings url = getUrl NoAuth url >>= decodeJSON

--- a/tests/HighLevelTest.hs
+++ b/tests/HighLevelTest.hs
@@ -186,6 +186,11 @@ runPackageTests = do
                return ()
            _ ->
                die "Bad index contents"
+    do info "Getting package index with etag"
+       etag <- getETag "/packages/index.tar.gz"
+       info $ "Got etag: " ++ etag
+       checkETag etag "/packages/index.tar.gz"
+       checkETagMismatch (etag ++ "garbled123") "/packages/index.tar.gz"
     do info "Getting testpackage info"
        xs <- validate NoAuth "/package/testpackage"
        unless ("The testpackage package" `isInfixOf` xs) $


### PR DESCRIPTION
Now the server will return a 304 status code instead of a 200 (with a full
response) if a client includes an up-to-date etag in the request.

HttpUtils in cabal-install already has support for etags, so this should
immediately make consecutive "cabal update" calls significantly faster once
deployed.

ETags should also be properly supported for PackageTarball and DocTarball.

This change adds a generic helper in Distribution.Server.Util.Happstack (useETag)
that both sets the ETag header in the response and checks the response
for a matching ETag, short-circuiting with a 304 on match.
