### PR TITLE
Makes the title order more sensible.

### DIFF
--- a/Distribution/Server/Pages/Template.hs
+++ b/Distribution/Server/Pages/Template.hs
@@ -25,7 +25,7 @@ hackagePageWith headExtra docTitle docSubtitle docContent bodyExtra =
     toHtml [ header << (docHead ++ headExtra)
            , body   << (docBody ++ bodyExtra) ]
   where
-    docHead   = [ thetitle << ("Hackage: " ++ docTitle)
+    docHead   = [ thetitle << (docTitle ++ " | Hackage")
                 , thelink ! [ rel "stylesheet"
                             , href stylesheetURL
                             , thetype "text/css"] << noHtml

--- a/datafiles/templates/AdminFrontend/account.html.st
+++ b/datafiles/templates/AdminFrontend/account.html.st
@@ -2,7 +2,7 @@
 <html>
 <head>
 $hackageCssTheme()$
-<title>Hackage: user account $account.name$</title>
+<title>User account $account.name$ | Hackage</title>
 </head>
 
 <body>

--- a/datafiles/templates/AdminFrontend/accounts.html.st
+++ b/datafiles/templates/AdminFrontend/accounts.html.st
@@ -2,7 +2,7 @@
 <html>
 <head>
 $hackageCssTheme()$
-<title>Hackage: browse user accounts</title>
+<title>Browse user accounts | Hackage</title>
 </head>
 
 <body>

--- a/datafiles/templates/AdminFrontend/admin.html.st
+++ b/datafiles/templates/AdminFrontend/admin.html.st
@@ -2,7 +2,7 @@
 <html>
 <head>
 $hackageCssTheme()$
-<title>Hackage: admin front-end</title>
+<title>Admin front-end | Hackage</title>
 </head>
 
 <body>

--- a/datafiles/templates/AdminFrontend/legacy.html.st
+++ b/datafiles/templates/AdminFrontend/legacy.html.st
@@ -2,7 +2,7 @@
 <html>
 <head>
 $hackageCssTheme()$
-<title>Hackage: User accounts with legacy passwords</title>
+<title>User accounts with legacy passwords | Hackage</title>
 </head>
 
 <body>

--- a/datafiles/templates/AdminFrontend/resets.html.st
+++ b/datafiles/templates/AdminFrontend/resets.html.st
@@ -2,7 +2,7 @@
 <html>
 <head>
 $hackageCssTheme()$
-<title>Hackage: browse reset requests</title>
+<title>Browse reset requests | Hackage</title>
 </head>
 
 <body>

--- a/datafiles/templates/AdminFrontend/signups.html.st
+++ b/datafiles/templates/AdminFrontend/signups.html.st
@@ -2,7 +2,7 @@
 <html>
 <head>
 $hackageCssTheme()$
-<title>Hackage: browse signup requests</title>
+<title>Browse signup requests | Hackage</title>
 </head>
 
 <body>

--- a/datafiles/templates/EditCabalFile/cabalFileEditPage.html.st
+++ b/datafiles/templates/EditCabalFile/cabalFileEditPage.html.st
@@ -2,7 +2,7 @@
 <html>
 <head>
 $hackageCssTheme()$
-<title>Hackage: Edit package metadata for $pkgid$</title>
+<title>Edit package metadata for $pkgid$ | Hackage</title>
 </head>
 
 <body>

--- a/datafiles/templates/EditCabalFile/cabalFilePublished.html.st
+++ b/datafiles/templates/EditCabalFile/cabalFilePublished.html.st
@@ -2,7 +2,7 @@
 <html>
 <head>
 $hackageCssTheme()$
-<title>Hackage: Published new revision for $pkgid$</title>
+<title>Published new revision for $pkgid$ | Hackage</title>
 </head>
 
 <body>

--- a/datafiles/templates/Html/distro-monitor.html.st
+++ b/datafiles/templates/Html/distro-monitor.html.st
@@ -2,7 +2,7 @@
 <html>
 <head>
 $hackageCssTheme()$
-<title>Hackage: Tarballs for $pkgname$</title>
+<title>Tarballs for $pkgname$ | Hackage</title>
 </head>
 
 <body>

--- a/datafiles/templates/Html/maintain-candidate.html.st
+++ b/datafiles/templates/Html/maintain-candidate.html.st
@@ -2,7 +2,7 @@
 <html>
 <head>
 $hackageCssTheme()$
-<title>Hackage: Maintainers' page for $pkgname$-$pkgversion$ candidate</title>
+<title>Maintainers' page for $pkgname$-$pkgversion$ candidate | Hackage</title>
 </head>
 
 <body>

--- a/datafiles/templates/Html/maintain.html.st
+++ b/datafiles/templates/Html/maintain.html.st
@@ -2,7 +2,7 @@
 <html>
 <head>
 $hackageCssTheme()$
-<title>Hackage: Maintainers' page for $pkgname$</title>
+<title>Maintainers' page for $pkgname$ | Hackage</title>
 </head>
 
 <body>

--- a/datafiles/templates/LegacyPasswds/htpasswd-upgrade-success.html.st
+++ b/datafiles/templates/LegacyPasswds/htpasswd-upgrade-success.html.st
@@ -2,7 +2,7 @@
 <html>
 <head>
 $hackageCssTheme()$
-<title>Hackage: Account upgrade successful</title>
+<title>Account upgrade successful | Hackage</title>
 </head>
 
 <body>

--- a/datafiles/templates/LegacyPasswds/htpasswd-upgrade.html.st
+++ b/datafiles/templates/LegacyPasswds/htpasswd-upgrade.html.st
@@ -2,7 +2,7 @@
 <html>
 <head>
 $hackageCssTheme()$
-<title>Hackage: Account upgrade</title>
+<title>Account upgrade | Hackage</title>
 </head>
 
 <body>

--- a/datafiles/templates/UserSignupReset/ResetConfirm.html.st
+++ b/datafiles/templates/UserSignupReset/ResetConfirm.html.st
@@ -2,7 +2,7 @@
 <html>
 <head>
 $hackageCssTheme()$
-<title>Hackage: Account recovery</title>
+<title>Account recovery | Hackage</title>
 </head>
 
 <body>

--- a/datafiles/templates/UserSignupReset/ResetEmailSent.html.st
+++ b/datafiles/templates/UserSignupReset/ResetEmailSent.html.st
@@ -2,7 +2,7 @@
 <html>
 <head>
 $hackageCssTheme()$
-<title>Hackage: Account recovery</title>
+<title>Account recovery | Hackage</title>
 </head>
 
 <body>

--- a/datafiles/templates/UserSignupReset/ResetRequest.html.st
+++ b/datafiles/templates/UserSignupReset/ResetRequest.html.st
@@ -2,7 +2,7 @@
 <html>
 <head>
 $hackageCssTheme()$
-<title>Hackage: Account recovery</title>
+<title>Account recovery | Hackage</title>
 </head>
 
 <body>

--- a/datafiles/templates/UserSignupReset/SignupConfirm.html.st
+++ b/datafiles/templates/UserSignupReset/SignupConfirm.html.st
@@ -2,7 +2,7 @@
 <html>
 <head>
 $hackageCssTheme()$
-<title>Hackage: Register a new account</title>
+<title>Register a new account | Hackage</title>
 </head>
 
 <body>

--- a/datafiles/templates/UserSignupReset/SignupEmailSent.html.st
+++ b/datafiles/templates/UserSignupReset/SignupEmailSent.html.st
@@ -2,7 +2,7 @@
 <html>
 <head>
 $hackageCssTheme()$
-<title>Hackage: Register a new account</title>
+<title>Register a new account | Hackage</title>
 </head>
 
 <body>

--- a/datafiles/templates/UserSignupReset/SignupRequest.html.st
+++ b/datafiles/templates/UserSignupReset/SignupRequest.html.st
@@ -2,7 +2,7 @@
 <html>
 <head>
 $hackageCssTheme()$
-<title>Hackage: Register a new account</title>
+<title>Register a new account | Hackage</title>
 </head>
 
 <body>

--- a/datafiles/templates/accounts.html.st
+++ b/datafiles/templates/accounts.html.st
@@ -2,7 +2,7 @@
 <html>
 <head>
 $hackageCssTheme()$
-<title>Hackage: User accounts</title>
+<title>User accounts | Hackage</title>
 </head>
 
 <body>

--- a/datafiles/templates/hackageErrorPage.html.st
+++ b/datafiles/templates/hackageErrorPage.html.st
@@ -2,7 +2,7 @@
 <html>
 <head>
 $hackageCssTheme()$
-<title>Hackage: $errorTitle$</title>
+<title>$errorTitle$ | Hackage</title>
 </head>
 
 <body>

--- a/datafiles/templates/index.html.st
+++ b/datafiles/templates/index.html.st
@@ -2,7 +2,7 @@
 <html>
 <head>
 $hackageCssTheme()$
-<title>Hackage: introduction</title>
+<title>Introduction | Hackage</title>
 </head>
 
 <body>

--- a/datafiles/templates/upload.html.st
+++ b/datafiles/templates/upload.html.st
@@ -2,7 +2,7 @@
 <html>
 <head>
 $hackageCssTheme()$
-<title>Hackage: Uploading packages and package candidates</title>
+<title>Uploading packages and package candidates | Hackage</title>
 </head>
 
 <body>


### PR DESCRIPTION
![hackage-title-order](https://cloud.githubusercontent.com/assets/1936426/3529667/170f300c-079c-11e4-8a96-69b9e9a26fde.png)
Currently, if I'm looking at a bunch of browser tabs on Hackage at a glance, it's impossible to tell what pages I have open, due the word "Hackage" coming before the actual page's title.

This pull request flips the order of the page's title and the word "Hackage".
