### PR TITLE
Removed support for ETags from serveTarball.

### DIFF
--- a/Distribution/Server/Features/Documentation.hs
+++ b/Distribution/Server/Features/Documentation.hs
@@ -215,11 +215,10 @@ documentationFeature name
       withDocumentation (packageDocsContent documentationResource)
                         dpath $ \pkgid blob index -> do
         let tarball = BlobStorage.filepath store blob
-            etag    = BlobStorage.blobETag blob
         -- if given a directory, the default page is index.html
         -- the root directory within the tarball is e.g. foo-1.0-docs/
         ServerTarball.serveTarball ["index.html"] (display pkgid ++ "-docs")
-                                   tarball index etag
+                                   tarball index
 
     -- return: not-found error (parsing) or see other uri
     uploadDocumentation :: DynamicPath -> ServerPartE Response

--- a/Distribution/Server/Features/PackageContents.hs
+++ b/Distribution/Server/Features/PackageContents.hs
@@ -26,8 +26,8 @@ data PackageContentsFeature = PackageContentsFeature {
     packageContentsResource :: PackageContentsResource,
 
     -- Functionality exported to other features
-    packageTarball   :: PkgInfo -> IO (Either String (FilePath, ETag, TarIndex.TarIndex)),
-    packageChangeLog :: PkgInfo -> IO (Either String (FilePath, ETag, TarIndex.TarEntryOffset, FilePath))
+    packageTarball   :: PkgInfo -> IO (Either String (FilePath, TarIndex.TarIndex)),
+    packageChangeLog :: PkgInfo -> IO (Either String (FilePath, TarIndex.TarEntryOffset, FilePath))
 }
 
 instance IsHackageFeature PackageContentsFeature where
@@ -100,8 +100,8 @@ packageContentsFeature ServerEnv{serverBlobStore = store}
       case mChangeLog of
         Left err ->
           errNotFound "Changelog not found" [MText err]
-        Right (fp, etag, offset, name) ->
-          liftIO $ serveTarEntry fp offset name etag
+        Right (fp, offset, name) -> do
+          liftIO $ serveTarEntry fp offset name
 
     -- return: not-found error or tarball
     serveContents :: DynamicPath -> ServerPartE Response
@@ -111,22 +111,21 @@ packageContentsFeature ServerEnv{serverBlobStore = store}
       case mTarball of
         Left err ->
           errNotFound "Could not serve package contents" [MText err]
-        Right (fp, etag, index) ->
-          serveTarball ["index.html"] (display (packageId pkg)) fp index etag
+        Right (fp, index) ->
+          serveTarball ["index.html"] (display (packageId pkg)) fp index
 
-    packageTarball :: PkgInfo -> IO (Either String (FilePath, ETag, TarIndex.TarIndex))
+    packageTarball :: PkgInfo -> IO (Either String (FilePath, TarIndex.TarIndex))
     packageTarball PkgInfo{pkgTarball = (pkgTarball, _) : _} = do
       let blobid = pkgTarballNoGz pkgTarball
           fp     = BlobStorage.filepath store blobid
-          etag   = BlobStorage.blobETag blobid
       index <- cachedPackageTarIndex pkgTarball
-      return $ Right (fp, etag, index)
+      return $ Right (fp, index)
     packageTarball _ =
       return $ Left "No tarball found"
 
-    packageChangeLog :: PkgInfo -> IO (Either String (FilePath, ETag, TarIndex.TarEntryOffset, FilePath))
+    packageChangeLog :: PkgInfo -> IO (Either String (FilePath, TarIndex.TarEntryOffset, FilePath))
     packageChangeLog pkgInfo = runErrorT $ do
-      (fp, etag, index) <- ErrorT $ packageTarball pkgInfo
+      (fp, index) <- ErrorT $ packageTarball pkgInfo
       (offset, fname)   <- ErrorT $ return . maybe (Left "No changelog found") Right
                                   $ findChangeLog pkgInfo index
-      return (fp, etag, offset, fname)
+      return (fp, offset, fname)

--- a/Distribution/Server/Util/ServeTarball.hs
+++ b/Distribution/Server/Util/ServeTarball.hs
@@ -23,7 +23,7 @@ import Happstack.Server.Monads
 import Happstack.Server.Routing (method)
 import Happstack.Server.Response
 import Happstack.Server.FileServe as Happstack (mimeTypes)
-import Distribution.Server.Util.Happstack (remainingPath, ETag(..), formatETag)
+import Distribution.Server.Util.Happstack (remainingPath)
 import Distribution.Server.Pages.Template (hackagePage)
 import Distribution.Server.Framework.ResponseContentTypes as Resource
 
@@ -48,9 +48,8 @@ serveTarball :: MonadIO m
              -> FilePath   -- root dir in tar to serve
              -> FilePath   -- the tarball
              -> TarIndex   -- index for tarball
-             -> ETag       -- the etag
              -> ServerPartT m Response
-serveTarball indices tarRoot tarball tarIndex etag = do
+serveTarball indices tarRoot tarball tarIndex = do
     rq <- askRq
     action GET $ remainingPath $ \paths -> do
 
@@ -70,7 +69,7 @@ serveTarball indices tarRoot tarball tarIndex etag = do
              case TarIndex.lookup tarIndex path of
                Just (TarIndex.TarFileEntry off)
                    -> do
-                 tfe <- liftIO $ serveTarEntry tarball off path etag
+                 tfe <- liftIO $ serveTarEntry tarball off path
                  ok (toResponse tfe)
                _ -> mzero
 
@@ -84,8 +83,8 @@ serveTarball indices tarRoot tarball tarIndex etag = do
                  -> seeOther (addTrailingPathSeparator fullPath) (toResponse ())
 
                  | otherwise
-                 -> ok $ setHeader "ETag" (formatETag etag) $
-                         toResponse $ Resource.XHtml $ renderDirIndex fs
+                 -> do
+                      ok $ toResponse $ Resource.XHtml $ renderDirIndex fs
                _ -> mzero
 
 renderDirIndex :: [FilePath] -> XHtml.Html
@@ -94,8 +93,8 @@ renderDirIndex entries = hackagePage "Directory Listing"
       XHtml.+++ XHtml.br
     | e <- entries ]
 
-serveTarEntry :: FilePath -> Int -> FilePath -> ETag -> IO Response
-serveTarEntry tarfile off fname etag = do
+serveTarEntry :: FilePath -> Int -> FilePath -> IO Response
+serveTarEntry tarfile off fname = do
   htar <- openFile tarfile ReadMode
   hSeek htar AbsoluteSeek (fromIntegral (off * 512))
   header <- BS.hGet htar 512
@@ -107,8 +106,7 @@ serveTarEntry tarfile off fname etag = do
                            ext       -> ext
              mimeType = Map.findWithDefault "text/plain" extension mimeTypes'
              response = ((setHeader "Content-Length" (show size)) .
-                         (setHeader "Content-Type" mimeType) .
-                         (setHeader "ETag" (formatETag etag))) $
+                         (setHeader "Content-Type" mimeType)) $
                          resultBS 200 body
          return response
     _ -> fail "oh noes!!"


### PR DESCRIPTION
I spent some time converting some legacy etag code, until I realized that the code was actually bogus. It uses the tarball's ETag for individual files from inside the tarball. This can't be right (and a plain conversion to useETag would have resulted in a bug from overeager cache hits).

According to grep these are the last instances of manual handling of ETags in hackage.
