### PR TITLE
Converted serveTarball to use the useETag helper.

### DIFF
--- a/Distribution/Server/Features/PackageCandidates.hs
+++ b/Distribution/Server/Features/PackageCandidates.hs
@@ -403,8 +403,9 @@ candidatesFeature ServerEnv{serverBlobStore = store}
       case mChangeLog of
         Left err ->
           errNotFound "Changelog not found" [MText err]
-        Right (fp, etag, offset, name) ->
-          liftIO $ serveTarEntry fp offset name etag
+        Right (fp, etag, offset, name) -> do
+          useETag etag
+          liftIO $ serveTarEntry fp offset name
 
     -- return: not-found error or tarball
     serveContents :: DynamicPath -> ServerPartE Response

--- a/Distribution/Server/Features/PackageContents.hs
+++ b/Distribution/Server/Features/PackageContents.hs
@@ -100,8 +100,9 @@ packageContentsFeature ServerEnv{serverBlobStore = store}
       case mChangeLog of
         Left err ->
           errNotFound "Changelog not found" [MText err]
-        Right (fp, etag, offset, name) ->
-          liftIO $ serveTarEntry fp offset name etag
+        Right (fp, etag, offset, name) -> do
+          useETag etag
+          liftIO $ serveTarEntry fp offset name
 
     -- return: not-found error or tarball
     serveContents :: DynamicPath -> ServerPartE Response

--- a/tests/HighLevelTest.hs
+++ b/tests/HighLevelTest.hs
@@ -187,10 +187,7 @@ runPackageTests = do
            _ ->
                die "Bad index contents"
     do info "Getting package index with etag"
-       etag <- getETag "/packages/index.tar.gz"
-       info $ "Got etag: " ++ etag
-       checkETag etag "/packages/index.tar.gz"
-       checkETagMismatch (etag ++ "garbled123") "/packages/index.tar.gz"
+       validateETagHandling "/packages/index.tar.gz"
     do info "Getting testpackage info"
        xs <- validate NoAuth "/package/testpackage"
        unless ("The testpackage package" `isInfixOf` xs) $
@@ -211,6 +208,8 @@ runPackageTests = do
        hsFile <- getUrl NoAuth ("/package/testpackage/src" </> testpackageHaskellFilename)
        unless (hsFile == testpackageHaskellFileContent) $
            die "Bad Haskell file"
+    do info "Getting testpackage source with etag"
+       validateETagHandling ("/package/testpackage/src" </> testpackageHaskellFilename)
     do info "Getting testpackage maintainer info"
        xs <- getGroup "/package/testpackage/maintainers/.json"
        unless (map userName (groupMembers xs) == ["HackageTestUser1"]) $


### PR DESCRIPTION
ServeTarball deals with serving individual files from a package's tar file.

The previous code handled ETags by hand, and would include them
in the response but ignore any ETags in the request header.
