### PR TITLE
Fix build status to always use the full package ID

### DIFF
--- a/Distribution/Server/Features/Html.hs
+++ b/Distribution/Server/Features/Html.hs
@@ -487,7 +487,7 @@ mkHtmlCore HtmlUtilities{..}
             pkgname = packageName realpkg
             middleHtml = Pages.renderFields render
         -- render the build status line
-        buildStatus <- renderBuildStatus documentationFeature reportsFeature pkgid
+        buildStatus <- renderBuildStatus documentationFeature reportsFeature realpkg
         let buildStatusHtml = [("Status", buildStatus)]
         -- get additional information from other features
         prefInfo <- queryGetPreferredInfo pkgname


### PR DESCRIPTION
If the user requests a package page without giving an explicit version (e.g. `/package/hello`), the indicator would try to look up the status of a non-existent package.

This patch fixes the indicator to use the latest version instead.
