### PR TITLE
Install postfix and update APT cache as part of the Docker image build

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -4,7 +4,6 @@ env HOME /home/haskell
 
 # dependencies
 run sudo apt-get update && sudo apt-get install -yy unzip libicu48 libicu-dev postfix
-
 run cabal update
 run curl -LO https://github.com/haskell/hackage-server/archive/master.zip
 


### PR DESCRIPTION
Seems to fix #275. However, the new behavior seems to be that mails silently fail if they can't be sent properly which isn't optimal either. Any ideas for better behavior when a mail proxy is required?
