### PR TITLE
Add a canonical URL to package pages.

### DIFF
--- a/Distribution/Server/Pages/Package.hs
+++ b/Distribution/Server/Pages/Package.hs
@@ -34,11 +34,14 @@ import Data.Time.Format         (formatTime)
 
 packagePage :: PackageRender -> [Html] -> [Html] -> [(String, Html)] -> [(String, Html)] -> Maybe URL -> Bool -> Html
 packagePage render headLinks top sections bottom docURL isCandidate =
-    hackagePageWith [] docTitle docSubtitle docBody [docFooter]
+    hackagePageWith canonical docTitle docSubtitle docBody [docFooter]
   where
-    pkgid = rendPkgId render
+    pkgid   = rendPkgId render
+    pkgName = packageName pkgid
 
-    docTitle = display (packageName pkgid)
+    canonical = thelink ! [ rel "canonical"
+                          , href "/package/" ++ pkgName ] << noHtml
+    docTitle = display pkgName
             ++ case synopsis (rendOther render) of
                  ""    -> ""
                  short -> ": " ++ short


### PR DESCRIPTION
This is necessary because search engines will needlessly index older versions of
packages unless explicitly pointed to the newer version via a canonical link.