### PR TITLE
Add network-uri dependency to hackage-server.cabal.

### DIFF
--- a/hackage-server.cabal
+++ b/hackage-server.cabal
@@ -253,7 +253,6 @@ executable hackage-server
     transformers >= 0.3,
     mtl        >= 2.0,
     parsec     == 3.1.*,
-    network    >= 2.1,
     unix       >= 2.6,
     zlib       >= 0.5.3 && < 0.6,
     tar        == 0.4.* && >= 0.4.0.1,

--- a/hackage-server.cabal
+++ b/hackage-server.cabal
@@ -250,6 +250,7 @@ executable hackage-server
     mtl        >= 2.0,
     parsec     == 3.1.*,
     network    >= 2.1,
+    network-uri >= 2.6,
     unix       >= 2.6,
     zlib       >= 0.5.3 && < 0.6,
     tar        == 0.4.* && >= 0.4.0.1,
@@ -317,6 +318,7 @@ executable hackage-mirror
     time,     old-locale, random,
     tar,      zlib,
     network,  HTTP >= 4000.2.11,
+    network-uri,
     Cabal,
     safecopy, cereal, binary, mtl,
     unix, aeson
@@ -339,6 +341,7 @@ executable hackage-build
     time,     old-locale,
     tar,      zlib,
     network,  HTTP,
+    network-uri,
     Cabal,
     safecopy, cereal, binary, mtl,
     -- See comment above why we insist on this version of Aeson

--- a/hackage-server.cabal
+++ b/hackage-server.cabal
@@ -78,6 +78,10 @@ flag test-create-user
   default: False
   manual: True
 
+flag network-uri
+  description: Get Network.URI from the network-uri package
+  default: True
+
 executable hackage-server
   if ! flag(build-hackage-server)
     buildable: False
@@ -250,7 +254,6 @@ executable hackage-server
     mtl        >= 2.0,
     parsec     == 3.1.*,
     network    >= 2.1,
-    network-uri >= 2.6,
     unix       >= 2.6,
     zlib       >= 0.5.3 && < 0.6,
     tar        == 0.4.* && >= 0.4.0.1,
@@ -280,6 +283,11 @@ executable hackage-server
     lifted-base >= 0.2.1 && < 0.3,
     QuickCheck >= 2.5,
     friendly-time >= 0.3 && < 0.4
+
+  if flag(network-uri)
+    build-depends: network-uri >= 2.6, network >= 2.6
+  else
+    build-depends: network-uri < 2.6, network < 2.6
 
   if ! flag(minimal)
     build-depends:
@@ -396,6 +404,7 @@ Test-Suite HighLevelTest
                     filepath,
                     HTTP,
                     network,
+                    network-uri,
                     process,
                     tar,
                     unix,
@@ -423,6 +432,7 @@ Test-Suite CreateUserTest
                     filepath,
                     HTTP,
                     network,
+                    network-uri,
                     process,
                     tar,
                     unix,


### PR DESCRIPTION
When trying to build from the git repository, cabal complained about a missing network-uri reference. This adds that dependency to the cabal file.