### PR TITLE
Replace description with README if present

### DIFF
--- a/Distribution/Server/Features.hs
+++ b/Distribution/Server/Features.hs
@@ -165,11 +165,11 @@ initHackageFeatures env@ServerEnv{serverVerbosity = verbosity} = do
     packageContentsFeature <- mkPackageContentsFeature
                                 coreFeature
                                 tarIndexCacheFeature
+                                usersFeature
 
     packagesFeature <- mkRecentPackagesFeature
                          usersFeature
                          coreFeature
-                         packageContentsFeature
 
     userDetailsFeature <- mkUserDetailsFeature
                             usersFeature
@@ -250,7 +250,7 @@ initHackageFeatures env@ServerEnv{serverVerbosity = verbosity} = do
     htmlFeature     <- mkHtmlFeature
                          usersFeature
                          coreFeature
-                         packagesFeature
+                         packageContentsFeature
                          uploadFeature
                          candidatesFeature
                          versionsFeature

--- a/Distribution/Server/Features/Html.hs
+++ b/Distribution/Server/Features/Html.hs
@@ -9,7 +9,6 @@ import qualified Distribution.Server.Framework.ResponseContentTypes as Resource
 import Distribution.Server.Framework.Templating
 
 import Distribution.Server.Features.Core
-import Distribution.Server.Features.RecentPackages
 import Distribution.Server.Features.Upload
 import Distribution.Server.Features.BuildReports
 import Distribution.Server.Features.BuildReports.Render
@@ -20,6 +19,7 @@ import Distribution.Server.Features.Search
 import Distribution.Server.Features.Search as Search
 import Distribution.Server.Features.PreferredVersions
 -- [reverse index disabled] import Distribution.Server.Features.ReverseDependencies
+import Distribution.Server.Features.PackageContents (PackageContentsFeature(..))
 import Distribution.Server.Features.PackageList
 import Distribution.Server.Features.Tags
 import Distribution.Server.Features.Mirror
@@ -96,7 +96,7 @@ instance IsHackageFeature HtmlFeature where
 initHtmlFeature :: ServerEnv
                 -> IO (UserFeature
                     -> CoreFeature
-                    -> RecentPackagesFeature
+                    -> PackageContentsFeature
                     -> UploadFeature -> PackageCandidatesFeature
                     -> VersionsFeature
                     -- [reverse index disabled] -> ReverseFeature
@@ -172,7 +172,7 @@ initHtmlFeature ServerEnv{serverTemplatesDir, serverTemplatesMode,
 
 htmlFeature :: UserFeature
             -> CoreFeature
-            -> RecentPackagesFeature
+            -> PackageContentsFeature
             -> UploadFeature
             -> PackageCandidatesFeature
             -> VersionsFeature
@@ -194,7 +194,7 @@ htmlFeature :: UserFeature
 
 htmlFeature user
             core@CoreFeature{queryGetPackageIndex}
-            recent upload
+            packages upload
             candidates versions
             -- [reverse index disabled] ReverseFeature{..}
             tags download
@@ -236,7 +236,7 @@ htmlFeature user
                                       reportsCore
                                       download
                                       distros
-                                      recent
+                                      packages
                                       htmlTags
                                       htmlPreferred
                                       cachePackagesPage
@@ -423,7 +423,7 @@ mkHtmlCore :: HtmlUtilities
            -> ReportsFeature
            -> DownloadFeature
            -> DistroFeature
-           -> RecentPackagesFeature
+           -> PackageContentsFeature
            -> HtmlTags
            -> HtmlPreferred
            -> AsyncCache Response
@@ -444,7 +444,7 @@ mkHtmlCore HtmlUtilities{..}
            reportsFeature
            DownloadFeature{recentPackageDownloads,totalPackageDownloads}
            DistroFeature{queryPackageStatus}
-           RecentPackagesFeature{packageRender}
+           PackageContentsFeature{packageRender}
            HtmlTags{..}
            HtmlPreferred{..}
            cachePackagesPage

--- a/Distribution/Server/Features/PackageCandidates.hs
+++ b/Distribution/Server/Features/PackageCandidates.hs
@@ -155,7 +155,7 @@ candidatesFeature ServerEnv{serverBlobStore = store}
                              , updateAddPackage
                              }
                   UploadFeature{..}
-                  TarIndexCacheFeature{packageTarball, packageChangeLog}
+                  TarIndexCacheFeature{packageTarball, findToplevelFile}
                   candidatesState
   = PackageCandidatesFeature{..}
   where
@@ -368,9 +368,9 @@ candidatesFeature ServerEnv{serverBlobStore = store}
     candidateRender cand = do
            users  <- queryGetUserDb
            index  <- queryGetPackageIndex
-           mChangeLog <- packageChangeLog (candPkgInfo cand)
+           mChangeLog <- findToplevelFile (candPkgInfo cand) isChangeLogFile
            let changeLog = case mChangeLog of Right (_,_,_,fname,contents) -> Just (fname, contents) 
-                                              _                    -> Nothing
+                                              _                           -> Nothing
                render = doPackageRender users (candPkgInfo cand)
            return $ CandidateRender {
              candPackageRender = render { rendPkgUri = rendPkgUri render ++ "/candidate"
@@ -412,7 +412,7 @@ candidatesFeature ServerEnv{serverBlobStore = store}
     serveChangeLog :: DynamicPath -> ServerPartE Response
     serveChangeLog dpath = do
       pkg        <- packageInPath dpath >>= lookupCandidateId
-      mChangeLog <- liftIO $ packageChangeLog (candPkgInfo pkg)
+      mChangeLog <- liftIO $ findToplevelFile (candPkgInfo pkg) isChangeLogFile
       case mChangeLog of
         Left err ->
           errNotFound "Changelog not found" [MText err]

--- a/Distribution/Server/Features/PackageContents.hs
+++ b/Distribution/Server/Features/PackageContents.hs
@@ -6,20 +6,18 @@ module Distribution.Server.Features.PackageContents (
   ) where
 
 import Distribution.Server.Framework
-import qualified Distribution.Server.Framework.BlobStorage as BlobStorage
 
 import Distribution.Server.Features.Core
 import Distribution.Server.Features.TarIndexCache
 
-import Distribution.Server.Packages.Types
 import Distribution.Server.Packages.ChangeLog
+import Distribution.Server.Packages.Types
 import Distribution.Server.Util.ServeTarball (serveTarEntry, serveTarball)
 import qualified Data.TarIndex as TarIndex
 
 import Distribution.Text
 import Distribution.Package
 
-import Control.Monad.Error (ErrorT(..))
 
 data PackageContentsFeature = PackageContentsFeature {
     packageFeatureInterface :: HackageFeature,
@@ -60,7 +58,7 @@ packageContentsFeature ServerEnv{serverBlobStore = store}
                                     , lookupPackageId
                                     }
                                   }
-                       TarIndexCacheFeature{cachedPackageTarIndex}
+                       TarIndexCacheFeature{packageTarball, packageChangeLog}
   = PackageContentsFeature{..}
   where
     packageFeatureInterface = (emptyHackageFeature "package-contents") {
@@ -111,20 +109,3 @@ packageContentsFeature ServerEnv{serverBlobStore = store}
         Right (fp, etag, index) ->
           serveTarball ["index.html"] (display (packageId pkg)) fp index
                        [Public, maxAgeDays 30] etag
-
-    packageTarball :: PkgInfo -> IO (Either String (FilePath, ETag, TarIndex.TarIndex))
-    packageTarball pkginfo
-      | Just (pkgTarball, _uploadinfo) <- pkgLatestTarball pkginfo = do
-          let blobid = pkgTarballNoGz pkgTarball
-              fp     = BlobStorage.filepath store blobid
-              etag   = BlobStorage.blobETag blobid
-          index <- cachedPackageTarIndex pkgTarball
-          return $ Right (fp, etag, index)
-      | otherwise = return $ Left "No tarball found"
-
-    packageChangeLog :: PkgInfo -> IO (Either String (FilePath, ETag, TarIndex.TarEntryOffset, FilePath))
-    packageChangeLog pkgInfo = runErrorT $ do
-      (fp, etag, index) <- ErrorT $ packageTarball pkgInfo
-      (offset, fname)   <- ErrorT $ return . maybe (Left "No changelog found") Right
-                                  $ findChangeLog pkgInfo index
-      return (fp, etag, offset, fname)

--- a/Distribution/Server/Features/PackageContents.hs
+++ b/Distribution/Server/Features/PackageContents.hs
@@ -45,7 +45,7 @@ initPackageContentsFeature :: ServerEnv
                                -> TarIndexCacheFeature
                                -> UserFeature
                                -> IO PackageContentsFeature)
-initPackageContentsFeature = do
+initPackageContentsFeature _ = do
     return $ \core tarIndexCache user -> do
       let feature = packageContentsFeature core tarIndexCache user
 

--- a/Distribution/Server/Features/RecentPackages.hs
+++ b/Distribution/Server/Features/RecentPackages.hs
@@ -107,9 +107,11 @@ recentPackagesFeature env
 
     packageRender pkg = do
       users <- queryGetUserDb
-      changeLog <- packageChangeLog pkg
-      let showChangeLogLink = case changeLog of Right _ -> True ; _ -> False
-      doPackageRender users pkg showChangeLogLink
+      mChangeLog <- packageChangeLog pkg
+      let changeLog = case mChangeLog of Right (_,_,_,fname,contents) -> Just (fname, contents) 
+                                         _                            -> Nothing
+          render = doPackageRender users pkg
+      return $ render { rendChangeLog = changeLog }
 
     updateRecentCache = do
         -- TODO: move the html version to the HTML feature

--- a/Distribution/Server/Features/RecentPackages.hs
+++ b/Distribution/Server/Features/RecentPackages.hs
@@ -11,6 +11,7 @@ import Distribution.Server.Features.Core
 import Distribution.Server.Features.Users
 import Distribution.Server.Features.PackageContents (PackageContentsFeature(..))
 
+import Distribution.Server.Packages.ChangeLog
 import Distribution.Server.Packages.Types
 import Distribution.Server.Packages.Render
 
@@ -80,7 +81,7 @@ recentPackagesFeature :: ServerEnv
 recentPackagesFeature env
                       UserFeature{..}
                       CoreFeature{..}
-                      PackageContentsFeature{packageChangeLog}
+                      PackageContentsFeature{findToplevelFile}
                       cacheRecent
   = (RecentPackagesFeature{..}, updateRecentCache)
   where
@@ -107,7 +108,7 @@ recentPackagesFeature env
 
     packageRender pkg = do
       users <- queryGetUserDb
-      mChangeLog <- packageChangeLog pkg
+      mChangeLog <- findToplevelFile pkg isChangeLogFile
       let changeLog = case mChangeLog of Right (_,_,_,fname,contents) -> Just (fname, contents) 
                                          _                            -> Nothing
           render = doPackageRender users pkg

--- a/Distribution/Server/Features/RecentPackages.hs
+++ b/Distribution/Server/Features/RecentPackages.hs
@@ -9,11 +9,8 @@ import Distribution.Server.Framework
 
 import Distribution.Server.Features.Core
 import Distribution.Server.Features.Users
-import Distribution.Server.Features.PackageContents (PackageContentsFeature(..))
 
-import Distribution.Server.Packages.ChangeLog
 import Distribution.Server.Packages.Types
-import Distribution.Server.Packages.Render
 
 import qualified Distribution.Server.Packages.PackageIndex as PackageIndex
 import qualified Distribution.Server.Framework.ResponseContentTypes as Resource
@@ -28,10 +25,8 @@ import qualified Distribution.Server.Pages.Recent as Pages
 
 data RecentPackagesFeature = RecentPackagesFeature {
     recentPackagesFeatureInterface :: HackageFeature,
-    recentPackagesResource :: RecentPackagesResource,
+    recentPackagesResource :: RecentPackagesResource
 
-    -- necessary information for the representation of a package resource
-    packageRender :: PkgInfo -> IO PackageRender
     -- other informational hooks: perhaps a simplified CondTree so a browser script can dynamically change the package page based on flags
 }
 
@@ -46,15 +41,14 @@ data RecentPackagesResource = RecentPackagesResource {
 initRecentPackagesFeature :: ServerEnv
                           -> IO (UserFeature
                               -> CoreFeature
-                              -> PackageContentsFeature
                               -> IO RecentPackagesFeature)
 initRecentPackagesFeature env@ServerEnv{serverCacheDelay, serverVerbosity = verbosity} = do
-    return $ \user core@CoreFeature{packageChangeHook} packageContents -> do
+    return $ \user core@CoreFeature{packageChangeHook} -> do
 
       -- recent caches. in lieu of an ActionLog
       -- TODO: perhaps a hook, recentUpdated :: HookList ([PkgInfo] -> IO ())
       rec let (feature, updateRecentCache) =
-                recentPackagesFeature env user core packageContents
+                recentPackagesFeature env user core
                                       cacheRecent
 
           cacheRecent <- newAsyncCacheNF updateRecentCache
@@ -74,14 +68,12 @@ initRecentPackagesFeature env@ServerEnv{serverCacheDelay, serverVerbosity = verb
 recentPackagesFeature :: ServerEnv
                       -> UserFeature
                       -> CoreFeature
-                      -> PackageContentsFeature
                       -> AsyncCache (Response, Response)
                       -> (RecentPackagesFeature, IO (Response, Response))
 
 recentPackagesFeature env
                       UserFeature{..}
                       CoreFeature{..}
-                      PackageContentsFeature{findToplevelFile}
                       cacheRecent
   = (RecentPackagesFeature{..}, updateRecentCache)
   where
@@ -105,14 +97,6 @@ recentPackagesFeature env
               ]
           }
       }
-
-    packageRender pkg = do
-      users <- queryGetUserDb
-      mChangeLog <- findToplevelFile pkg isChangeLogFile
-      let changeLog = case mChangeLog of Right (_,_,_,fname,contents) -> Just (fname, contents) 
-                                         _                            -> Nothing
-          render = doPackageRender users pkg
-      return $ render { rendChangeLog = changeLog }
 
     updateRecentCache = do
         -- TODO: move the html version to the HTML feature

--- a/Distribution/Server/Features/TarIndexCache.hs
+++ b/Distribution/Server/Features/TarIndexCache.hs
@@ -8,7 +8,6 @@ module Distribution.Server.Features.TarIndexCache (
 
 import Control.Exception (throwIO)
 import Control.Monad.Error (ErrorT(..))
-import qualified Codec.Archive.Tar.Entry as Tar
 
 import qualified Data.ByteString.Lazy as BS
 import Data.Serialize (runGetLazy, runPutLazy)

--- a/Distribution/Server/Features/TarIndexCache.hs
+++ b/Distribution/Server/Features/TarIndexCache.hs
@@ -7,15 +7,24 @@ module Distribution.Server.Features.TarIndexCache (
   ) where
 
 import Control.Exception (throwIO)
+import Control.Monad.Error (ErrorT(..))
+import qualified Codec.Archive.Tar as Tar
+import qualified Codec.Archive.Tar.Entry as Tar
+
+import qualified Data.ByteString.Lazy as BS
 import Data.Serialize (runGetLazy, runPutLazy)
 import Data.SafeCopy (safeGet, safePut)
 
+import System.IO
+
 import Distribution.Server.Framework
 import Distribution.Server.Framework.BlobStorage
+import qualified Distribution.Server.Framework.BlobStorage as BlobStorage
 import Distribution.Server.Framework.BackupRestore
 import Distribution.Server.Features.TarIndexCache.State
 import Distribution.Server.Features.Users
-import Distribution.Server.Packages.Types (PkgTarball(..))
+import Distribution.Server.Packages.ChangeLog
+import Distribution.Server.Packages.Types (PkgTarball(..), PkgInfo(..), pkgLatestTarball)
 import Data.TarIndex
 import Distribution.Server.Util.ServeTarball (constructTarIndex)
 
@@ -26,6 +35,8 @@ data TarIndexCacheFeature = TarIndexCacheFeature {
     tarIndexCacheFeatureInterface :: HackageFeature
   , cachedTarIndex        :: BlobId -> IO TarIndex
   , cachedPackageTarIndex :: PkgTarball -> IO TarIndex
+  , packageTarball :: PkgInfo -> IO (Either String (FilePath, ETag, TarIndex))
+  , packageChangeLog :: PkgInfo -> IO (Either String (FilePath, ETag, TarEntryOffset, FilePath))
   }
 
 instance IsHackageFeature TarIndexCacheFeature where
@@ -123,3 +134,23 @@ tarIndexCacheFeature ServerEnv{serverBlobStore = store}
       -- remove any blobs
       liftIO $ putState tarIndexCache initialTarIndexCache
       ok $ toResponse "Ok!"
+
+    -- Functions to access specific files in a tarball
+
+    packageTarball :: PkgInfo -> IO (Either String (FilePath, ETag, TarIndex))
+    packageTarball pkginfo
+      | Just (pkgTarball, _uploadinfo) <- pkgLatestTarball pkginfo = do
+        let blobid = pkgTarballNoGz pkgTarball
+            fp     = BlobStorage.filepath store blobid
+            etag   = BlobStorage.blobETag blobid
+        index <- cachedPackageTarIndex pkgTarball
+        return $ Right (fp, etag, index)
+      | otherwise =
+        return $ Left "No tarball found"
+
+    packageChangeLog :: PkgInfo -> IO (Either String (FilePath, ETag, TarEntryOffset, FilePath))
+    packageChangeLog pkgInfo = runErrorT $ do
+      (fp, etag, index) <- ErrorT $ packageTarball pkgInfo
+      (offset, fname)   <- ErrorT $ return . maybe (Left "No changelog found") Right
+                                  $ findChangeLog pkgInfo index
+      return (fp, etag, offset, fname)

--- a/Distribution/Server/Packages/ChangeLog.hs
+++ b/Distribution/Server/Packages/ChangeLog.hs
@@ -1,35 +1,15 @@
-{-# LANGUAGE NamedFieldPuns #-}
 module Distribution.Server.Packages.ChangeLog (
-    findChangeLog
+    isChangeLogFile
   ) where
 
-import Data.TarIndex (TarIndex, TarEntryOffset)
-import qualified Data.TarIndex as TarIndex
-import Distribution.Server.Packages.Types (PkgInfo)
-import Distribution.Package (packageId)
-import Distribution.Text (display)
 
-import System.FilePath ((</>), splitExtension)
+import System.FilePath (splitExtension)
 import Data.Char as Char
-import Data.Maybe
 
-
-findChangeLog :: PkgInfo -> TarIndex -> Maybe (TarEntryOffset, String)
-findChangeLog pkg index = do
-    let topdir = display (packageId pkg)
-    TarIndex.TarDir fnames <- TarIndex.lookup index topdir
-    listToMaybe
-      [ (offset, fname')
-      | fname <- fnames
-      , isChangelogFile fname
-      , let fname' = topdir </> fname
-      , Just (TarIndex.TarFileEntry offset) <- [TarIndex.lookup index fname'] ]
+isChangeLogFile :: FilePath -> Bool
+isChangeLogFile fname = map Char.toLower base `elem` basenames
+                        && ext `elem` extensions
   where
-    isChangelogFile fname = 
-      let (base, ext) = splitExtension fname
-       in map Char.toLower base `elem` basenames
-       && ext `elem` extensions
-
+    (base, ext) = splitExtension fname
     basenames  = ["changelog", "change_log", "changes"]
     extensions = ["", ".txt", ".md", ".markdown"]
-

--- a/Distribution/Server/Packages/Readme.hs
+++ b/Distribution/Server/Packages/Readme.hs
@@ -1,0 +1,14 @@
+module Distribution.Server.Packages.Readme (
+    isReadmeFile
+  ) where
+
+import System.FilePath (splitExtension)
+import Data.Char as Char
+
+isReadmeFile :: FilePath -> Bool
+isReadmeFile fname = map Char.toLower base `elem` basenames
+                        && ext `elem` extensions
+  where
+    (base, ext) = splitExtension fname
+    basenames  = ["readme"]
+    extensions = ["", ".txt", ".html", ".md", ".markdown"]

--- a/Distribution/Server/Packages/Render.hs
+++ b/Distribution/Server/Packages/Render.hs
@@ -19,7 +19,6 @@ import qualified Data.Vector as Vec
 import Data.Ord (comparing)
 import Data.List (sortBy)
 import Data.Time.Clock (UTCTime)
-import System.IO (FilePath)
 
 -- Cabal
 import Distribution.PackageDescription
@@ -48,6 +47,7 @@ data PackageRender = PackageRender {
     rendModules      :: Maybe ModuleForest,
     rendHasTarball   :: Bool,
     rendChangeLog    :: Maybe (FilePath, BS.ByteString),
+    rendReadme       :: Maybe (FilePath, BS.ByteString),
     rendUploadInfo   :: (UTCTime, Maybe UserInfo),
     rendUpdateInfo   :: Maybe (Int, UTCTime, Maybe UserInfo),
     rendPkgUri       :: String,
@@ -76,7 +76,8 @@ doPackageRender users info = PackageRender
     , rendRepoHeads    = catMaybes (map rendRepo $ sourceRepos desc)
     , rendModules      = fmap (moduleForest . exposedModules) (library flatDesc)
     , rendHasTarball   = not . Vec.null $ pkgTarballRevisions info
-    , rendHasChangeLog = hasChangeLog
+    , rendChangeLog    = Nothing -- populated later
+    , rendReadme       = Nothing -- populated later
     , rendUploadInfo   = let (utime, uid) = pkgOriginalUploadInfo info
                          in (utime, Users.lookupUserId uid users)
     , rendUpdateInfo   = let maxrevision  = Vec.length (pkgMetadataRevisions info) - 1

--- a/Distribution/Server/Pages/Package.hs
+++ b/Distribution/Server/Pages/Package.hs
@@ -85,9 +85,9 @@ descriptionSection PackageRender{..} =
  ++ [ hr
     , ulist << li << changelogLink]
   where
-    changelogLink
-      | rendHasChangeLog = anchor ! [href changeLogURL] << "Changelog"
-      | otherwise        = toHtml << "No changelog available"
+    changelogLink = case rendChangeLog of
+      Just _ -> anchor ! [href changeLogURL] << "Changelog"
+      _      -> toHtml << "No changelog available"
     changeLogURL  = rendPkgUri </> "changelog"
 
 prologue :: String -> [Html]

--- a/Distribution/Server/Util/ServeTarball.hs
+++ b/Distribution/Server/Util/ServeTarball.hs
@@ -99,7 +99,7 @@ renderDirIndex entries = hackagePage "Directory Listing"
       XHtml.+++ XHtml.br
     | e <- entries ]
 
-loadTarEntry :: FilePath -> Int -> IO (Either String (Tar.FileSize, BS.ByteString))
+loadTarEntry :: FilePath -> TarIndex.TarEntryOffset -> IO (Either String (Tar.FileSize, BS.ByteString))
 loadTarEntry tarfile off = do
   htar <- openFile tarfile ReadMode
   hSeek htar AbsoluteSeek (fromIntegral $ off * 512)
@@ -110,7 +110,7 @@ loadTarEntry tarfile off = do
          return $ Right (size, body)
     _ -> fail "oops"
 
-serveTarEntry :: FilePath -> Int -> FilePath -> IO Response
+serveTarEntry :: FilePath -> TarIndex.TarEntryOffset -> FilePath -> IO Response
 serveTarEntry tarfile off fname = do
     Right (size, body) <- loadTarEntry tarfile off
     return . ((setHeader "Content-Length" (show size)) .

--- a/Distribution/Server/Util/ServeTarball.hs
+++ b/Distribution/Server/Util/ServeTarball.hs
@@ -14,6 +14,7 @@
 module Distribution.Server.Util.ServeTarball
     ( serveTarball
     , serveTarEntry
+    , loadTarEntry
     , constructTarIndexFromFile
     , constructTarIndex
     ) where
@@ -98,24 +99,28 @@ renderDirIndex entries = hackagePage "Directory Listing"
       XHtml.+++ XHtml.br
     | e <- entries ]
 
-serveTarEntry :: FilePath -> Int -> FilePath -> IO Response
-serveTarEntry tarfile off fname = do
+loadTarEntry :: FilePath -> Int -> IO (Either String (Tar.FileSize, BS.ByteString))
+loadTarEntry tarfile off = do
   htar <- openFile tarfile ReadMode
-  hSeek htar AbsoluteSeek (fromIntegral (off * 512))
+  hSeek htar AbsoluteSeek (fromIntegral $ off * 512)
   header <- BS.hGet htar 512
   case Tar.read header of
     (Tar.Next Tar.Entry{Tar.entryContent = Tar.NormalFile _ size} _) -> do
          body <- BS.hGet htar (fromIntegral size)
-         let extension = case takeExtension fname of
+         return $ Right (size, body)
+    _ -> fail "oops"
+
+serveTarEntry :: FilePath -> Int -> FilePath -> IO Response
+serveTarEntry tarfile off fname = do
+    Right (size, body) <- loadTarEntry tarfile off
+    return . ((setHeader "Content-Length" (show size)) .
+              (setHeader "Content-Type" mimeType)) $
+              resultBS 200 body
+  where extension = case takeExtension fname of
                            ('.':ext) -> ext
                            ext       -> ext
-             mimeType = Map.findWithDefault "text/plain" extension mimeTypes'
-             response = ((setHeader "Content-Length" (show size)) .
-                         (setHeader "Content-Type" mimeType)) $
-                         resultBS 200 body
-         return response
-    _ -> fail "oh noes!!"
-
+        mimeType = Map.findWithDefault "text/plain" extension mimeTypes'
+        
 -- | Extended mapping from file extension to mime type
 mimeTypes' :: Map.Map String String
 mimeTypes' = Happstack.mimeTypes `Map.union` Map.fromList

--- a/hackage-server.cabal
+++ b/hackage-server.cabal
@@ -44,8 +44,8 @@ data-files:
   static/*.png
 
 source-repository head
-  type: git 
-  location: https://github.com/haskell/hackage-server 
+  type: git
+  location: https://github.com/haskell/hackage-server
 
 flag minimal
   default: False
@@ -257,14 +257,14 @@ executable hackage-server
     async      == 2.0.*,
     cereal     >= 0.4,
     safecopy   >= 0.6 && < 0.9,
-    crypto-api >= 0.12 && < 0.13, 
+    crypto-api >= 0.12 && < 0.13,
     pureMD5    >= 0.2,
     xhtml      >= 3000.1,
-    -- The instances created by deriveJSON in later versions of Aeson are 
+    -- The instances created by deriveJSON in later versions of Aeson are
     -- different from the instances created by this version; this would be ok
     -- if we only used the Aeson-created instance, but we also hand-create
     -- JSON in various places (for instance, in 'putUserDetails' in the import
-    -- client). 
+    -- client).
     aeson      == 0.6.1.*,
     unordered-containers >= 0.2.3.0,
     rss        >= 3000.2.0.3,
@@ -343,7 +343,7 @@ executable hackage-build
     Cabal,
     safecopy, cereal, binary, mtl,
     -- See comment above why we insist on this version of Aeson
-    aeson == 0.6.1.*, 
+    aeson == 0.6.1.*,
     random,
     unix,
     -- Runtime dependency only:

--- a/hackage-server.cabal
+++ b/hackage-server.cabal
@@ -119,6 +119,7 @@ executable hackage-server
     Distribution.Server.Packages.Unpack
     Distribution.Server.Packages.Render
     Distribution.Server.Packages.ChangeLog
+    Distribution.Server.Packages.Readme
 
     Distribution.Server.Pages.Distributions
     Distribution.Server.Pages.Group

--- a/hackage-server.cabal
+++ b/hackage-server.cabal
@@ -279,7 +279,9 @@ executable hackage-server
     HStringTemplate ==0.7.*,
     lifted-base >= 0.2.1 && < 0.3,
     QuickCheck >= 2.5,
-    friendly-time >= 0.3 && < 0.4
+    friendly-time >= 0.3 && < 0.4,
+    cheapskate >= 0.1,
+    blaze-html >= 0.7
 
   if ! flag(minimal)
     build-depends:


### PR DESCRIPTION
This completes the work that @conklech started. I think there are still at least two problems.

1. If the readme is very long then it takes up far too much of the page.
2. If the readme is formatted in a different dialect of markdown then it also looks bad. (One example of this is `pandoc` which uses it's own dialect). 



