### PR TITLE
Revision and Package feeds have more data

### DIFF
--- a/Distribution/Server/Features/RecentPackages.hs
+++ b/Distribution/Server/Features/RecentPackages.hs
@@ -21,8 +21,6 @@ import Data.Time.Clock (getCurrentTime)
 import Data.List (sortBy)
 import Data.Ord (comparing)
 
-import qualified Data.Vector as Vec
-
 -- the goal is to have the HTML modules import /this/ one, not the other way around
 import qualified Distribution.Server.Pages.Recent as Pages
 
@@ -131,8 +129,8 @@ recentPackagesFeature env
 
             recentRevisions = sortBy (flip $ comparing revisionTime) .
                               filter isRevised $ (PackageIndex.allPackages pkgIndex)
-            revisionTime pkgInfo = fst . snd . Vec.last $ pkgMetadataRevisions pkgInfo
-            isRevised pkgInfo = Vec.length (pkgMetadataRevisions pkgInfo) > 1
+            revisionTime pkgInfo = pkgLatestUploadTime pkgInfo
+            isRevised pkgInfo = pkgNumRevisions pkgInfo > 1
             xmlRevisions = toResponse $ Resource.XHtml $ Pages.revisionsPage users recentRevisions
             rssRevisions = toResponse $ Pages.recentRevisionsFeed users (serverBaseURI env) now recentRevisions
 

--- a/Distribution/Server/Pages/Recent.hs
+++ b/Distribution/Server/Pages/Recent.hs
@@ -125,7 +125,7 @@ recentFeed users hostURI now pkgs = RSS
     desc = "The 20 most recent additions to Hackage (or last 48 hours worth, whichever is greater), the Haskell package database."
     twoDaysAgo = addUTCTime (negate $ 60 * 60 * 48) now
     pkgListTwoDays = takeWhile (\p -> pkgLatestUploadTime p > twoDaysAgo) pkgs
-    pkgList = if (length pkgListTwoDays > 20) then pkgListTwoDays else take 20 pkgList
+    pkgList = if (length pkgListTwoDays > 20) then pkgListTwoDays else take 20 pkgs
 
 
 recentRevisionsFeed :: Users -> URI -> UTCTime -> [PkgInfo] -> RSS
@@ -139,7 +139,7 @@ recentRevisionsFeed users hostURI now pkgs = RSS
     desc = "The 40 most recent revisions to cabal metadata in Hackage (or last 48 hours worth, whichever is greater), the Haskell package database."
     twoDaysAgo = addUTCTime (negate $ 60 * 60 * 48) now
     pkgListTwoDays = takeWhile (\p -> pkgLatestUploadTime p > twoDaysAgo) pkgs
-    pkgList = if (length pkgListTwoDays > 40) then pkgListTwoDays else take 40 pkgList
+    pkgList = if (length pkgListTwoDays > 40) then pkgListTwoDays else take 40 pkgs
 
 channel :: UTCTime -> [RSS.ChannelElem]
 channel now =


### PR DESCRIPTION
As per discussion with @hvr after #344 this will make sure rss feeds for packages and revisions always have the last 48 hours of data, even if that is more than the limit.