### PR TITLE
Admin Log Features

### DIFF
--- a/Distribution/Server/Features.hs
+++ b/Distribution/Server/Features.hs
@@ -288,7 +288,7 @@ initHackageFeatures env@ServerEnv{serverVerbosity = verbosity} = do
 
     adminLogFeature <- mkAdminLogFeature
                          usersFeature
-                         coreFeature
+
 #endif
 
     -- The order of initialization above should be the same as

--- a/Distribution/Server/Features.hs
+++ b/Distribution/Server/Features.hs
@@ -41,6 +41,7 @@ import Distribution.Server.Features.UserSignup          (initUserSignupFeature)
 import Distribution.Server.Features.LegacyPasswds       (initLegacyPasswdsFeature)
 import Distribution.Server.Features.EditCabalFiles      (initEditCabalFilesFeature)
 import Distribution.Server.Features.AdminFrontend       (initAdminFrontendFeature)
+import Distribution.Server.Features.AdminLog            (initAdminLogFeature)
 import Distribution.Server.Features.HoogleData          (initHoogleDataFeature)
 #endif
 import Distribution.Server.Features.ServerIntrospect (serverIntrospectFeature)
@@ -137,6 +138,8 @@ initHackageFeatures env@ServerEnv{serverVerbosity = verbosity} = do
                                initAdminFrontendFeature env
     mkHoogleDataFeature     <- logStartup "hoogle" $
                                initHoogleDataFeature env
+    mkAdminLogFeature       <- logStartup "admin log" $
+                               initAdminLogFeature env
 #endif
 
     loginfo verbosity "Initialising features, part 2"
@@ -282,6 +285,10 @@ initHackageFeatures env@ServerEnv{serverVerbosity = verbosity} = do
                            coreFeature
                            documentationCoreFeature
                            tarIndexCacheFeature
+
+    adminLogFeature <- mkAdminLogFeature
+                         usersFeature
+                         coreFeature
 #endif
 
     -- The order of initialization above should be the same as
@@ -317,6 +324,7 @@ initHackageFeatures env@ServerEnv{serverVerbosity = verbosity} = do
          , editCabalFeature
          , adminFrontendFeature
          , getFeatureInterface hoogleDataFeature
+         , getFeatureInterface adminLogFeature
 #endif
          , staticFilesFeature
          , serverIntrospectFeature allFeatures

--- a/Distribution/Server/Features/AdminLog.hs
+++ b/Distribution/Server/Features/AdminLog.hs
@@ -1,0 +1,144 @@
+{-# LANGUAGE DeriveDataTypeable, TypeFamilies, TemplateHaskell, BangPatterns, GeneralizedNewtypeDeriving, NamedFieldPuns, PatternGuards #-}
+
+module Distribution.Server.Features.AdminLog where
+
+import Distribution.Package
+import Distribution.Server.Users.Types (UserId)
+import Distribution.Server.Users.Group
+import Distribution.Server.Framework
+import Distribution.Server.Framework.BackupRestore
+
+import Distribution.Server.Features.Core
+import Distribution.Server.Features.Users
+
+import Data.SafeCopy (base, deriveSafeCopy)
+import Data.Typeable
+import Data.Maybe(catMaybes)
+import Control.Monad.Reader
+import qualified Control.Monad.State as State
+import Data.Time (UTCTime)
+import Data.Time.Clock (getCurrentTime)
+import qualified Data.ByteString.Lazy.Char8 as BS
+import Text.Read (readMaybe)
+import Distribution.Server.Util.Parse
+
+data GroupDesc = MaintainerGroup PackageName | AdminGroup | TrusteeGroup | OtherGroup String deriving (Eq, Ord, Read, Show)
+
+deriveSafeCopy 0 'base ''GroupDesc
+
+instance MemSize GroupDesc where
+    memSize (MaintainerGroup x) = memSize x
+    memSize _ = 0
+
+data AdminAction = Admin_GroupAddUser UserId GroupDesc | Admin_GroupDelUser UserId GroupDesc deriving (Eq, Ord, Read, Show)
+
+instance MemSize AdminAction where
+    memSize (Admin_GroupAddUser x y) = memSize2 x y
+    memSize (Admin_GroupDelUser x y) = memSize2 x y
+
+deriveSafeCopy 0 'base ''AdminAction
+
+mkAdminAction :: GroupDescription -> Bool -> UserId -> AdminAction
+mkAdminAction gd isAdd uid = (if isAdd then Admin_GroupAddUser else Admin_GroupDelUser) uid groupdesc
+    where groupdesc | groupTitle gd == "Hackage admins" = AdminGroup
+                    | groupTitle gd == "Package trustees" = TrusteeGroup
+                    | Just (pn,_) <- groupEntity gd, groupTitle gd == "Maintainers" = MaintainerGroup (PackageName pn)
+                    | otherwise = OtherGroup (groupTitle gd ++ maybe "" ((' ':) . fst) (groupEntity gd))
+
+newtype AdminLog = AdminLog {
+      adminLog :: [(UTCTime,UserId,AdminAction)]
+} deriving (Typeable, Show, MemSize)
+
+deriveSafeCopy 0 'base ''AdminLog
+
+initialAdminLog :: AdminLog
+initialAdminLog = AdminLog []
+
+getAdminLog :: Query AdminLog AdminLog
+getAdminLog = ask
+
+addAdminLog :: (UTCTime, UserId, AdminAction) -> Update AdminLog ()
+addAdminLog x = State.modify (\(AdminLog xs) -> AdminLog (x : xs))
+
+instance Eq AdminLog where
+    (AdminLog (x:_)) == (AdminLog (y:_)) = x == y
+    (AdminLog []) == (AdminLog []) = True
+    _ == _ = False
+
+replaceAdminLog :: AdminLog -> Update AdminLog ()
+replaceAdminLog = State.put
+
+makeAcidic ''AdminLog ['getAdminLog
+                      ,'replaceAdminLog
+                      ,'addAdminLog]
+
+data AdminLogFeature = AdminLogFeature {
+      adminLogFeatureInterface :: HackageFeature
+}
+
+instance IsHackageFeature AdminLogFeature where
+    getFeatureInterface = adminLogFeatureInterface
+
+initAdminLogFeature :: ServerEnv -> IO (UserFeature -> CoreFeature -> IO AdminLogFeature)
+initAdminLogFeature ServerEnv{serverStateDir} = do
+  adminLogState <- adminLogStateComponent serverStateDir
+  return $ \UserFeature{groupChangedHook} CoreFeature{coreResource} -> do
+    registerHook groupChangedHook $ \(gd,addOrDel,actorUid,targetUid) -> do
+        now <- getCurrentTime
+        updateState adminLogState $ AddAdminLog
+            (now, actorUid, mkAdminAction gd addOrDel targetUid)
+
+    return $ AdminLogFeature {
+       adminLogFeatureInterface =
+           (emptyHackageFeature "Admin Actions Log") {
+               featureDesc = "Log of additions and removals of users from groups.",
+               featureResources = [adminLogResource coreResource adminLogState],
+               featureState = [abstractAcidStateComponent adminLogState]
+       }
+    }
+
+adminLogResource :: CoreResource -> StateComponent AcidState AdminLog -> Resource
+adminLogResource coreResource logState = (extendResourcePath "/admin-log.:format" (corePackagesPage coreResource)) {
+               resourceGet = [
+                  ("html", \ _ -> do
+                     adminLog <- queryState logState GetAdminLog
+                     return . toResponse $ show adminLog)
+                , ("rss", \ _ -> do
+                     adminLog <- queryState logState GetAdminLog
+                     return . toResponse $ show adminLog)
+               ]
+             }
+
+adminLogStateComponent :: FilePath -> IO (StateComponent AcidState AdminLog)
+adminLogStateComponent stateDir = do
+  st <- openLocalStateFrom (stateDir </> "db" </> "AdminLog") initialAdminLog
+  return StateComponent {
+      stateDesc    = "AdminLog"
+    , stateHandle  = st
+    , getState     = query st GetAdminLog
+    , putState     = update st . ReplaceAdminLog
+    , backupState  = \_ (AdminLog xs) -> [BackupByteString ["adminLog.txt"] . backupLogEntries $ xs]
+    , restoreState = restoreAdminLogBackup
+    , resetState   = adminLogStateComponent
+    }
+
+restoreAdminLogBackup :: RestoreBackup AdminLog
+restoreAdminLogBackup = go (AdminLog [])
+    where go logs =
+              RestoreBackup {
+                   restoreEntry = \entry ->
+                                  case entry of
+                                    BackupByteString ["adminLog.txt"] bs ->
+                                        return . go $ importLogs logs bs
+                                    _ -> return (go logs)
+                 , restoreFinalize = return logs
+                 }
+
+importLogs :: AdminLog -> BS.ByteString -> AdminLog
+importLogs (AdminLog ls) = AdminLog . (++ls) . catMaybes . map fromRecord . lines . unpackUTF8
+    where
+      fromRecord :: String -> Maybe (UTCTime,UserId,AdminAction)
+      fromRecord = readMaybe
+
+backupLogEntries :: [(UTCTime,UserId,AdminAction)] -> BS.ByteString
+backupLogEntries = packUTF8 . unlines . map show

--- a/Distribution/Server/Features/Users.hs
+++ b/Distribution/Server/Features/Users.hs
@@ -52,6 +52,8 @@ data UserFeature = UserFeature {
     -- modification thereof.
     adminGroup :: UserGroup,
 
+    groupChangedHook :: Hook (GroupDescription, Bool, UserId, UserId) (),
+
     -- Authorisation
     -- | Require any of a set of privileges.
     guardAuthorised_   :: [PrivilegeCondition] -> ServerPartE (),
@@ -62,7 +64,6 @@ data UserFeature = UserFeature {
     -- | A hook to override the default authentication error in particular
     -- circumstances.
     authFailHook       :: Hook Auth.AuthError (Maybe ErrorResponse),
-
     -- | Retrieves the entire user base.
     queryGetUserDb    :: forall m. MonadIO m => m Users.Users,
 
@@ -204,6 +205,7 @@ initUserFeature ServerEnv{serverStateDir} = do
   -- Extension hooks
   userAdded     <- newHook
   authFailHook  <- newHook
+  groupChangedHook <- newHook
 
   return $ do
     -- Slightly tricky: we have an almost recursive knot between the group
@@ -216,7 +218,7 @@ initUserFeature ServerEnv{serverStateDir} = do
               = userFeature usersState
                             adminsState
                             groupIndex
-                            userAdded authFailHook
+                            userAdded authFailHook groupChangedHook
                             adminG adminR
 
         (adminG, adminR) <- groupResourceAt "/users/admins/" adminGroupDesc
@@ -255,11 +257,12 @@ userFeature :: StateComponent AcidState Users.Users
             -> MemState GroupIndex
             -> Hook () ()
             -> Hook Auth.AuthError (Maybe ErrorResponse)
+            -> Hook (GroupDescription, Bool, UserId, UserId) ()
             -> UserGroup
             -> GroupResource
             -> (UserFeature, UserGroup)
 userFeature  usersState adminsState
-             groupIndex userAdded authFailHook
+             groupIndex userAdded authFailHook groupChangedHook
              adminGroup adminResource
   = (UserFeature {..}, adminGroupDesc)
   where
@@ -554,29 +557,32 @@ userFeature  usersState adminsState
     adminGroupDesc = UserGroup {
           groupDesc      = nullDescription { groupTitle = "Hackage admins" },
           queryUserList  = queryState adminsState GetAdminList,
-          addUserList    = updateState adminsState . AddHackageAdmin,
-          removeUserList = updateState adminsState . RemoveHackageAdmin,
+          addUserList    =  updateState adminsState . AddHackageAdmin,
+          removeUserList =  updateState adminsState . RemoveHackageAdmin,
           canAddGroup    = [adminGroupDesc],
           canRemoveGroup = [adminGroupDesc]
         }
 
     groupAddUser :: UserGroup -> DynamicPath -> ServerPartE ()
     groupAddUser group _ = do
-        guardAuthorised_ (map InGroup (canAddGroup group))
+        actorUid <- guardAuthorised (map InGroup (canAddGroup group))
         users <- queryState usersState GetUserDb
         muser <- optional $ look "user"
         case muser of
             Nothing -> addError "Bad request (could not find 'user' argument)"
             Just ustr -> case simpleParse ustr >>= \uname -> Users.lookupUserName uname users of
                 Nothing      -> addError $ "No user with name " ++ show ustr ++ " found"
-                Just (uid,_) -> liftIO $ addUserList group uid
+                Just (uid,_) -> do
+                             liftIO $ addUserList group uid
+                             runHook_ groupChangedHook (groupDesc group, True,actorUid,uid)
        where addError = errBadRequest "Failed to add user" . return . MText
 
     groupDeleteUser :: UserGroup -> DynamicPath -> ServerPartE ()
     groupDeleteUser group dpath = do
-      guardAuthorised_ (map InGroup (canRemoveGroup group))
+      actorUid <- guardAuthorised (map InGroup (canRemoveGroup group))
       uid <- lookupUserName =<< userNameInPath dpath
       liftIO $ removeUserList group uid
+      runHook_ groupChangedHook (groupDesc group, False,actorUid,uid)
 
     lookupGroupEditAuth :: UserGroup -> ServerPartE (Bool, Bool)
     lookupGroupEditAuth group = do
@@ -696,16 +702,18 @@ userFeature  usersState adminsState
     --      and then remove groupAddUser & groupDeleteUser
     serveUserGroupUserPut groupr dpath = do
       group <- getGroup groupr dpath
-      guardAuthorised_ (map InGroup (canAddGroup group))
+      actorUid <- guardAuthorised (map InGroup (canAddGroup group))
       uid <- lookupUserName =<< userNameInPath dpath
       liftIO $ addUserList group uid
+      runHook_ groupChangedHook (groupDesc group, True,actorUid,uid)
       goToList groupr dpath
 
     serveUserGroupUserDelete groupr dpath = do
       group <- getGroup groupr dpath
-      guardAuthorised_ (map InGroup (canRemoveGroup group))
+      actorUid <- guardAuthorised (map InGroup (canRemoveGroup group))
       uid <- lookupUserName =<< userNameInPath dpath
       liftIO $ removeUserList group uid
+      runHook_ groupChangedHook (groupDesc group, False,actorUid,uid)
       goToList groupr dpath
 
     goToList group dpath = seeOther (renderResource' (groupResource group) dpath)

--- a/Distribution/Server/Pages/AdminLog.hs
+++ b/Distribution/Server/Pages/AdminLog.hs
@@ -23,18 +23,19 @@ import Data.Time.Format
 import Data.Time.Locale.Compat
          ( defaultTimeLocale )
 
-adminLogPage :: Users -> [(UTCTime, UserId, String, UserId, String)] -> Html
+adminLogPage :: Users -> [(UTCTime, UserId, String, UserId, String, String)] -> Html
 adminLogPage users entries = hackagePage "adminstrator actions log" docBody
      where
         docBody = [XHtml.h2 << "Administrator actions",
                    XHtml.table ! [XHtml.align "center"] << (header : map makeRow entries)]
-        makeRow (time, actorId, action, targetId, group) = XHtml.tr << map fmtCell
+        makeRow (time, actorId, action, targetId, group, reason) = XHtml.tr << map fmtCell
              [showTime time,
               display $ Users.userIdToName users actorId,
               action,
               display $ Users.userIdToName users targetId,
-              group]
+              group,
+              reason]
         nbsp = XHtml.primHtmlChar "nbsp"
         showTime = formatTime defaultTimeLocale "%c"
-        header = XHtml.tr << map (XHtml.th <<) ["Time ","User ","Action ","Target ","Group "]
+        header = XHtml.tr << map (XHtml.th <<) ["Time ","User ","Action ","Target ","Group ","Reason "]
         fmtCell x = XHtml.td ! [XHtml.align "left"] << [XHtml.toHtml x, nbsp, nbsp]

--- a/Distribution/Server/Pages/AdminLog.hs
+++ b/Distribution/Server/Pages/AdminLog.hs
@@ -1,0 +1,40 @@
+-- Takes a reversed log file on the standard input and outputs web page.
+
+module Distribution.Server.Pages.AdminLog (
+    adminLogPage
+  ) where
+
+import qualified Distribution.Server.Users.Users as Users
+import Distribution.Server.Users.Users (Users)
+import Distribution.Server.Users.Types (UserId)
+import Distribution.Server.Pages.Template
+         ( hackagePage)
+
+import Distribution.Text
+         ( display )
+
+import qualified Text.XHtml.Strict as XHtml
+import Text.XHtml
+         ( Html, (<<), (!) )
+import Data.Time.Clock
+         ( UTCTime )
+import Data.Time.Format
+         ( formatTime )
+import Data.Time.Locale.Compat
+         ( defaultTimeLocale )
+
+adminLogPage :: Users -> [(UTCTime, UserId, String, UserId, String)] -> Html
+adminLogPage users entries = hackagePage "adminstrator actions log" docBody
+     where
+        docBody = [XHtml.h2 << "Administrator actions",
+                   XHtml.table ! [XHtml.align "center"] << (header : map makeRow entries)]
+        makeRow (time, actorId, action, targetId, group) = XHtml.tr << map fmtCell
+             [showTime time,
+              display $ Users.userIdToName users actorId,
+              action,
+              display $ Users.userIdToName users targetId,
+              group]
+        nbsp = XHtml.primHtmlChar "nbsp"
+        showTime = formatTime defaultTimeLocale "%c"
+        header = XHtml.tr << map (XHtml.th <<) ["Time ","User ","Action ","Target ","Group "]
+        fmtCell x = XHtml.td ! [XHtml.align "left"] << [XHtml.toHtml x, nbsp, nbsp]

--- a/Distribution/Server/Pages/Group.hs
+++ b/Distribution/Server/Pages/Group.hs
@@ -48,17 +48,19 @@ addUser uri =
     [ h3 << "Add user"
     , gui uri ! [theclass "box"] <<
         [ p << [stringToHtml "User: ", textfield "user"]
+        , p << [stringToHtml "Reason: ", textfield "reason"]
         , submit "submit" "Add member"
         ]
     ]
 
 removeUser :: Users.UserName -> String -> [Html]
 removeUser uname uri =
-    [ toHtml " ",
-      gui (uri </> "user" </> display uname) <<
-       [ hidden "_method" "DELETE"
-       , submit "submit" "Remove"
-       ]
+    [ toHtml " "
+    , gui (uri </> "user" </> display uname) <<
+        [ p << [stringToHtml "Reason: ", textfield "reason"]
+        , hidden "_method" "DELETE"
+        , submit "submit" "Remove"
+        ]
     ]
 
 listGroup :: [Users.UserName] -> Maybe String -> Html
@@ -66,4 +68,3 @@ listGroup [] _ = p << "No member exist presently"
 listGroup users muri = unordList (map displayName users)
   where displayName uname = (anchor ! [href $ "/user/" ++ display uname] << display uname) +++
                             fromMaybe [] (fmap (removeUser uname) muri)
-

--- a/Distribution/Server/Users/Types.hs
+++ b/Distribution/Server/Users/Types.hs
@@ -21,10 +21,10 @@ import Data.Typeable (Typeable)
 
 
 newtype UserId = UserId Int
-  deriving (Eq, Ord, Show, Typeable, MemSize, ToJSON, FromJSON)
+  deriving (Eq, Ord, Read, Show, Typeable, MemSize, ToJSON, FromJSON)
 
 newtype UserName  = UserName String
-  deriving (Eq, Ord, Show, Typeable, MemSize, ToJSON, FromJSON)
+  deriving (Eq, Ord, Read, Show, Typeable, MemSize, ToJSON, FromJSON)
 
 data UserInfo = UserInfo {
                   userName   :: !UserName,

--- a/hackage-server.cabal
+++ b/hackage-server.cabal
@@ -163,6 +163,7 @@ executable hackage-server
     Distribution.Server.Features.Upload.State
     Distribution.Server.Features.Upload.Backup
     Distribution.Server.Features.Users
+    Distribution.Server.Features.AdminLog
 
 
   if flag(minimal)

--- a/hackage-server.cabal
+++ b/hackage-server.cabal
@@ -44,8 +44,8 @@ data-files:
   static/*.png
 
 source-repository head
-  type: git 
-  location: https://github.com/haskell/hackage-server 
+  type: git
+  location: https://github.com/haskell/hackage-server
 
 flag minimal
   default: False
@@ -133,6 +133,7 @@ executable hackage-server
     Distribution.Server.Pages.Package.HaddockParse
     Distribution.Server.Pages.Package.HaddockTypes
     Distribution.Server.Pages.Recent
+    Distribution.Server.Pages.AdminLog
     -- [reverse index disabled] Distribution.Server.Pages.Reverse
     Distribution.Server.Pages.Template
     Distribution.Server.Pages.Util
@@ -163,8 +164,6 @@ executable hackage-server
     Distribution.Server.Features.Upload.State
     Distribution.Server.Features.Upload.Backup
     Distribution.Server.Features.Users
-    Distribution.Server.Features.AdminLog
-
 
   if flag(minimal)
     cpp-options: -DMINIMAL
@@ -176,6 +175,7 @@ executable hackage-server
       Distribution.Server.Features.LegacyPasswds
       Distribution.Server.Features.LegacyPasswds.Auth
       Distribution.Server.Features.PackageContents
+      Distribution.Server.Features.AdminLog
       Distribution.Server.Features.BuildReports
       Distribution.Server.Features.BuildReports.BuildReport
       Distribution.Server.Features.BuildReports.BuildReports
@@ -262,7 +262,7 @@ executable hackage-server
     async      == 2.0.*,
     cereal     >= 0.4,
     safecopy   >= 0.6 && < 0.9,
-    crypto-api >= 0.12 && < 0.13, 
+    crypto-api >= 0.12 && < 0.13,
     pureMD5    >= 0.2,
     xhtml      >= 3000.1,
     aeson      >= 0.6.2,
@@ -462,4 +462,3 @@ Test-Suite CreateUserTest
     build-depends: network-uri >= 2.6, network >= 2.6
   else
     build-depends: network-uri < 2.6, network < 2.6
-


### PR DESCRIPTION
This pull request adds an admin log feature to hackage. Any time a user is added or deleted from a group, it will record who took the action. Furthermore, when this is done through the frontend, an optional "reason" may be added. The display is just a flat html table at the moment -- since the main purpose seems to me to be auditing, this seems fine to me. Based on what people want, we could of course add whatever other display options they'd like, including limiting display to specific groups, etc.