### PR TITLE
Remove libicu48 from Ubuntu instructions

### DIFF
--- a/README.md
+++ b/README.md
@@ -16,7 +16,7 @@ You'll need to do the following to get hackage-server's dependency `text-icu` to
 ### Ubuntu/Debian
 
     sudo apt-get update
-    sudo apt-get install unzip libicu48 libicu-dev
+    sudo apt-get install unzip libicu-dev
 
 ## Running
 


### PR DESCRIPTION
This package isn't available on all Ubuntu versions. For example, on 14.04, libicu52 is available. However, depending on libicu-dev should always install the runtime library necessary, so simply having libicu-dev in the install line should be sufficient.