### PR TITLE
Fix preferred versions colors

### DIFF
--- a/Distribution/Server/Pages/Package.hs
+++ b/Distribution/Server/Pages/Package.hs
@@ -279,7 +279,7 @@ renderVersion (PackageIdentifier pname pversion) allVersions info =
                                ++ map versionedLink laterVersions
         versionedLink (v, s) = anchor ! (status s ++ [href $ packageURL $ PackageIdentifier pname v]) << display v
         status st = case st of
-            NormalVersion -> []
+            NormalVersion -> [theclass "normal"]
             DeprecatedVersion  -> [theclass "deprecated"]
             UnpreferredVersion -> [theclass "unpreferred"]
         infoHtml = case info of Nothing -> noHtml; Just str -> " (" +++ (anchor ! [href str] << "info") +++ ")"

--- a/datafiles/static/hackage.css
+++ b/datafiles/static/hackage.css
@@ -41,6 +41,15 @@ a[href]:link { color: rgb(196,69,29); }
 a[href]:visited { color: rgb(171,105,84); }
 a[href]:hover { text-decoration:underline; }
 
+a.normal[href]:link { color: rgb(29,69,196); }
+a.normal[href]:visited { color: rgb(84,105,171); }
+
+a.unpreferred[href]:link { color: rgb(69,196,29); }
+a.unpreferred[href]:visited { color: rgb(105,171,84); }
+
+a.deprecated[href]:link { color: rgb(196,196,196); }
+a.deprecated[href]:visited { color: rgb(171,171,171); }
+
 /* @end */
 
 /* @group Fonts & Sizes */


### PR DESCRIPTION
Colors of version links at /package/:package/preferred should follow the rule:

> Blue versions are normal versions. Green are those out of any preferred version ranges. Gray are deprecated.