### PR TITLE
Implement a package ranking feature, accessible via the package page.

### DIFF
--- a/Distribution/Server/Features.hs
+++ b/Distribution/Server/Features.hs
@@ -43,6 +43,7 @@ import Distribution.Server.Features.EditCabalFiles      (initEditCabalFilesFeatu
 import Distribution.Server.Features.AdminFrontend       (initAdminFrontendFeature)
 import Distribution.Server.Features.AdminLog            (initAdminLogFeature)
 import Distribution.Server.Features.HoogleData          (initHoogleDataFeature)
+import Distribution.Server.Features.Ranking             (initRankingFeature)
 #endif
 import Distribution.Server.Features.ServerIntrospect (serverIntrospectFeature)
 
@@ -138,6 +139,8 @@ initHackageFeatures env@ServerEnv{serverVerbosity = verbosity} = do
                                initAdminFrontendFeature env
     mkHoogleDataFeature     <- logStartup "hoogle" $
                                initHoogleDataFeature env
+    mkRankingFeature        <- logStartup "ranking" $
+                               initRankingFeature env
     mkAdminLogFeature       <- logStartup "admin log" $
                                initAdminLogFeature env
 #endif
@@ -162,7 +165,7 @@ initHackageFeatures env@ServerEnv{serverVerbosity = verbosity} = do
                          coreFeature
 
 #ifndef MINIMAL
-    tarIndexCacheFeature <- mkTarIndexCacheFeature 
+    tarIndexCacheFeature <- mkTarIndexCacheFeature
                               usersFeature
 
     packageContentsFeature <- mkPackageContentsFeature
@@ -222,6 +225,10 @@ initHackageFeatures env@ServerEnv{serverVerbosity = verbosity} = do
                          coreFeature
                          usersFeature
 
+    rankingFeature      <- mkRankingFeature
+                           coreFeature
+                           usersFeature
+
     tagsFeature     <- mkTagsFeature
                          coreFeature
                          uploadFeature
@@ -260,6 +267,7 @@ initHackageFeatures env@ServerEnv{serverVerbosity = verbosity} = do
                          -- [reverse index disabled] reverseFeature
                          tagsFeature
                          downloadFeature
+                         rankingFeature
                          listFeature
                          searchFeature
                          mirrorFeature
@@ -324,6 +332,7 @@ initHackageFeatures env@ServerEnv{serverVerbosity = verbosity} = do
          , editCabalFeature
          , adminFrontendFeature
          , getFeatureInterface hoogleDataFeature
+         , getFeatureInterface rankingFeature
          , getFeatureInterface adminLogFeature
 #endif
          , staticFilesFeature

--- a/Distribution/Server/Features/Ranking.hs
+++ b/Distribution/Server/Features/Ranking.hs
@@ -1,0 +1,238 @@
+{-# LANGUAGE RankNTypes, NamedFieldPuns, RecordWildCards, LambdaCase #-}
+
+-- | Implements a ranking system for all packages based on
+-- | stars/upvotes supplied by users.
+module Distribution.Server.Features.Ranking
+  ( RankingFeature(..)
+  , initRankingFeature
+  ) where
+
+import Distribution.Server.Features.Ranking.Types
+  ( Stars(..)
+  , initialStars
+  , getNumberOfStarsFor
+  , enumerate
+  )
+
+import Distribution.Server.Framework as F
+
+import Distribution.Package
+import Distribution.Server.Features.Core
+import Distribution.Server.Features.Users
+import Distribution.Server.Framework.BackupRestore
+import Distribution.Server.Users.Types (UserId(..))
+
+import qualified Distribution.Server.Features.Ranking.State as RState
+import qualified Distribution.Server.Features.Ranking.Types as RTypes
+import qualified Distribution.Server.Features.Ranking.Render as Render
+
+import Data.Aeson
+import Data.List as L
+import Data.Map as Map
+import Data.Set as Set
+import qualified Data.Text as T
+import qualified Data.HashMap.Strict as HashMap
+
+import Control.Arrow (first)
+import qualified Text.XHtml.Strict as X
+
+
+-- | Define the prototype for this feature
+data RankingFeature = RankingFeature {
+    rankingFeatureInterface :: HackageFeature
+  , didUserStar             :: MonadIO m => PackageName -> UserId -> m Bool
+  , pkgNumStars             :: MonadIO m => PackageName -> m Int
+  , renderStarsHtml         :: PackageName -> ServerPartE (String, X.Html)
+}
+
+-- | Implement the isHackageFeature 'interface'
+instance IsHackageFeature RankingFeature where
+  getFeatureInterface = rankingFeatureInterface
+
+-- | Called from Features.hs to initialize this feature
+initRankingFeature :: ServerEnv
+                   -> IO ( CoreFeature
+                      -> UserFeature
+                      -> IO RankingFeature)
+initRankingFeature env@ServerEnv{serverStateDir} = do
+  dbStarsState      <- starsStateComponent serverStateDir
+
+  return $ \coref@CoreFeature{..} userf@UserFeature{..} -> do
+    let feature = rankingFeature env
+                  dbStarsState
+                  coref userf
+    return feature
+
+-- | Define the backing store (i.e. database component)
+starsStateComponent :: FilePath -> IO (StateComponent AcidState Stars)
+starsStateComponent stateDir = do
+  st <- openLocalStateFrom (stateDir </> "db" </> "Stars") initialStars
+  return StateComponent {
+      stateDesc    = "Backing store for Map PackageName -> Users who starred it"
+    , stateHandle  = st
+    , getState     = query st RState.DbGetStars
+    , putState     = F.update st . RState.DbReplaceStars
+    , resetState   = starsStateComponent
+    , backupState  = \_ _ -> []
+    , restoreState = RestoreBackup {
+                         restoreEntry    = error "Unexpected backup entry"
+                       , restoreFinalize = return $ Stars {extractMap = Map.empty}
+                       }
+   }
+
+
+-- | Default constructor for building this feature.
+rankingFeature ::  ServerEnv
+                -> StateComponent AcidState Stars
+                -> CoreFeature                    -- To get site package list
+                -> UserFeature                    -- To authenticate users
+                -> RankingFeature
+
+rankingFeature  ServerEnv{serverBaseURI}
+                starsState
+                CoreFeature {
+                  coreResource = CoreResource { packageInPath
+                                              , guardValidPackageName
+                                              }
+                }
+                UserFeature{..}
+  = RankingFeature{..}
+  where
+    rankingFeatureInterface   = (emptyHackageFeature "Package stars") {
+        featureResources      = [ getEntireMapResource
+                                , addStarResource
+                                , removeStarResource
+                                , allUsersWhoStarredResource
+          ]
+      , featureState          = [abstractAcidStateComponent starsState]
+      }
+
+
+-- | Define resources for this feature's URIs
+
+    getEntireMapResource :: Resource
+    getEntireMapResource =
+      (resourceAt "/package/starstate") {
+        resourceDesc  = [(GET, "Returns the entire database of package stars.")]
+      , resourceGet   = [("json", getPackageStarMap)]
+    }
+
+    addStarResource :: Resource
+    addStarResource  =
+      (resourceAt "/package/star/:package") {
+        resourceDesc  = [ (GET, "Returns the number of stars a package has.")
+                        , (POST, "Adds a star to this package.")
+                        ]
+      , resourceGet   = [("json", getPackageNumStars)]
+      , resourcePost  = [("",     starPackage)]
+    }
+
+    removeStarResource :: Resource
+    removeStarResource =
+      (resourceAt "/package/unstar/:package") {
+        resourceDesc  = [(POST, "Remove a user's star from this package.")]
+      , resourcePost  = [("",     removeStar)]
+    }
+
+    allUsersWhoStarredResource :: Resource
+    allUsersWhoStarredResource =
+      (resourceAt "/package/whostarred/:package") {
+        resourceDesc  = [(GET, "Returns all of the users who have starred a package.")]
+      , resourceGet   = [("",     getAllPackageStars)]
+    }
+
+-- | Implementations of the how the above resources are handled.
+
+    -- Add a star to :packageName (must match name exactly)
+    starPackage :: DynamicPath -> ServerPartE Response
+    starPackage dpath = do
+      uid     <- guardAuthorised [AnyKnownUser]
+      pkgname <- packageInPath dpath
+      guardValidPackageName pkgname
+      alreadyStarred <- didUserStar pkgname uid
+
+      case alreadyStarred of
+        True ->
+          ok . toResponse $ Render.alreadyStarredPage
+            pkgname (show serverBaseURI)
+        False -> do
+          updateState starsState $ RState.DbAddStar pkgname uid
+          ok . toResponse $ Render.starConfirmationPage
+            pkgname (show serverBaseURI) "Package starred successfully"
+
+    -- Removes a user's star from a package. If the user has not
+    -- not starred this package, does nothing.
+    removeStar :: DynamicPath -> ServerPartE Response
+    removeStar dpath = do
+      uid     <- guardAuthorised [AnyKnownUser]
+      pkgname <- packageInPath dpath
+      guardValidPackageName pkgname
+      updateState starsState $ RState.DbRemoveStar pkgname uid
+      ok . toResponse $ Render.starConfirmationPage
+        pkgname (show serverBaseURI) "Package unstarred successfully."
+
+    -- Retrive the entire map (from package names -> # of stars)
+    -- (Must be authenticated as an admin.)
+    getPackageStarMap :: DynamicPath -> ServerPartE Response
+    getPackageStarMap _ = do
+      guardAuthorised [InGroup adminGroup]
+      dbStarsMap <- queryState starsState RState.DbGetStars
+      ok. toResponse $ toJSON $ enumerate dbStarsMap
+
+    -- Get the number of stars a package has. If the package
+    -- has never been starred, returns 0.
+    getPackageNumStars :: DynamicPath -> ServerPartE Response
+    getPackageNumStars dpath = do
+      pkgname <- packageInPath dpath
+      guardValidPackageName pkgname
+      dbStarsMap <- queryState starsState RState.DbGetStars
+
+      let numStars = getNumberOfStarsFor pkgname dbStarsMap
+          arr = objectL
+                  [ ("packageName", string $ unPackageName pkgname)
+                  , ("numStars",    toJSON numStars)
+                  ]
+      ok . toResponse $ toJSON arr
+
+    getAllPackageStars :: DynamicPath -> ServerPartE Response
+    getAllPackageStars dpath = do
+      pkgname <- packageInPath dpath
+      guardValidPackageName pkgname
+      dbStarsMap <- queryState starsState RState.DbGetStars
+
+      let users = RTypes.getUsersWhoStarred pkgname dbStarsMap
+          arr = Set.toList $ users
+
+      ok . toResponse $ toJSON arr
+
+-- | Helper Functions (Used outside of responses, e.g. by other features.)
+
+    -- Returns true if a user has previously starred the
+    -- package in question.
+    didUserStar :: MonadIO m => PackageName -> UserId -> m Bool
+    didUserStar pkgname uid = do
+      dbStarsMap <- queryState starsState RState.DbGetStars
+      return $ RTypes.askUserStarred pkgname uid dbStarsMap
+
+    -- Returns the number of stars a package has.
+    pkgNumStars :: MonadIO m => PackageName -> m Int
+    pkgNumStars pkgname =  do
+      dbStarsMap <- queryState starsState RState.DbGetStars
+      return $ getNumberOfStarsFor pkgname dbStarsMap
+
+    -- Renders the HTML for the "Stars:" section on package pages.
+    renderStarsHtml :: PackageName -> ServerPartE (String, X.Html)
+    renderStarsHtml pkgname = do
+      numStars <- pkgNumStars pkgname
+      return $ Render.renderStarsAnon numStars pkgname
+
+
+-- | Helper functions for constructing JSON responses.
+
+-- Use to construct a list of tuples that can be toJSON'd
+objectL :: [(String, Value)] -> Value
+objectL = Object . HashMap.fromList . L.map (first T.pack)
+
+-- Use inside an objectL to transform strings into json values
+string :: String -> Value
+string = String . T.pack

--- a/Distribution/Server/Features/Ranking/Render.hs
+++ b/Distribution/Server/Features/Ranking/Render.hs
@@ -17,45 +17,46 @@ import Text.XHtml.Strict
 -- to add a star (which prompts for authentication).
 renderStarsAnon :: Int -> PackageName -> (String, Html)
 renderStarsAnon numStars pkgname =
-  ( "Stars:",
-      form  ! [ action $    "star/" ++ unPackageName pkgname
+  ( "Stars",
+      form  ! [ action $ "/package/" ++ unPackageName pkgname ++ "/stars"
               , method      "POST" ]
       << thespan <<
-      (toHtml $ show numStars  ++ " " +++
-        ("[" +++
-        input ! [ thetype     "submit"
-                , value       "Star this package"
-                , theclass    "text-button" ]
-        +++ "]")
-      )
+      [ toHtml $  show numStars ++ " "
+      , toHtml $  ("[" +++
+          hidden  "_method" "PUT" +++
+          input ! [ thetype     "submit"
+                  , value       "Star this package"
+                  , theclass    "text-button" ]
+          +++ "]")
+      ]
   )
 
 -- A page that confirms a package was successfully starred and
 -- provides a link back to the package page.
-starConfirmationPage :: PackageName -> String -> String -> Resource.XHtml
-starConfirmationPage pkgname baseuri message =
+starConfirmationPage :: PackageName -> String -> Resource.XHtml
+starConfirmationPage pkgname message =
   Resource.XHtml $ hackagePage "Star a Package"
   [ h3 << message
   , br
-  , anchor ! [ href $ baseuri ++ "/package/" ++ unPackageName pkgname ] << "Return"
+  , anchor ! [ href $ "/package/" ++ unPackageName pkgname ] << "Return"
   ]
 
 -- Shown when a user has already starred a package.
 -- Gives an option to remove the star, and provides a link
 -- back to the package page.
-alreadyStarredPage :: PackageName -> String -> Resource.XHtml
-alreadyStarredPage pkgname baseuri =
+alreadyStarredPage :: PackageName -> Resource.XHtml
+alreadyStarredPage pkgname =
   Resource.XHtml $ hackagePage "Star a Package"
-  [ h3 << "You have already starred this package."
-  , form  ! [ action $ baseuri ++ "/package/unstar/" ++ unPackageName pkgname
+  [ h3 <<   "You have already starred this package."
+  , form  ! [ action $ "/package/" ++ unPackageName pkgname ++ "/stars"
             , method "POST" ]
       << thespan <<
       ("[" +++
+      hidden  "_method" "DELETE" +++
       input ! [ thetype     "submit"
               , value       "Remove star from this package"
               , theclass    "text-button" ]
       +++ "]")
   , br
-  , anchor ! [ href $ baseuri ++ "/package/" ++ unPackageName pkgname ]
-    << "Return"
+  , anchor ! [ href $ "/package/" ++ unPackageName pkgname ] << "Return"
   ]

--- a/Distribution/Server/Features/Ranking/Render.hs
+++ b/Distribution/Server/Features/Ranking/Render.hs
@@ -1,0 +1,61 @@
+-- | Produces HTML related to the "Stars:" section in the package page.
+-- | Should only be used via the Ranking feature (see renderStarsHtml)
+module Distribution.Server.Features.Ranking.Render
+  ( renderStarsAnon
+  , starConfirmationPage
+  , alreadyStarredPage
+  ) where
+
+import Distribution.Package
+import Distribution.Server.Pages.Template
+import qualified Distribution.Server.Framework.ResponseContentTypes as Resource
+
+import Text.XHtml.Strict
+
+-- When the user is not authenticated/logged in, simply
+-- display the number of stars the package has and a link
+-- to add a star (which prompts for authentication).
+renderStarsAnon :: Int -> PackageName -> (String, Html)
+renderStarsAnon numStars pkgname =
+  ( "Stars:",
+      form  ! [ action $    "star/" ++ unPackageName pkgname
+              , method      "POST" ]
+      << thespan <<
+      (toHtml $ show numStars  ++ " " +++
+        ("[" +++
+        input ! [ thetype     "submit"
+                , value       "Star this package"
+                , theclass    "text-button" ]
+        +++ "]")
+      )
+  )
+
+-- A page that confirms a package was successfully starred and
+-- provides a link back to the package page.
+starConfirmationPage :: PackageName -> String -> String -> Resource.XHtml
+starConfirmationPage pkgname baseuri message =
+  Resource.XHtml $ hackagePage "Star a Package"
+  [ h3 << message
+  , br
+  , anchor ! [ href $ baseuri ++ "/package/" ++ unPackageName pkgname ] << "Return"
+  ]
+
+-- Shown when a user has already starred a package.
+-- Gives an option to remove the star, and provides a link
+-- back to the package page.
+alreadyStarredPage :: PackageName -> String -> Resource.XHtml
+alreadyStarredPage pkgname baseuri =
+  Resource.XHtml $ hackagePage "Star a Package"
+  [ h3 << "You have already starred this package."
+  , form  ! [ action $ baseuri ++ "/package/unstar/" ++ unPackageName pkgname
+            , method "POST" ]
+      << thespan <<
+      ("[" +++
+      input ! [ thetype     "submit"
+              , value       "Remove star from this package"
+              , theclass    "text-button" ]
+      +++ "]")
+  , br
+  , anchor ! [ href $ baseuri ++ "/package/" ++ unPackageName pkgname ]
+    << "Return"
+  ]

--- a/Distribution/Server/Features/Ranking/State.hs
+++ b/Distribution/Server/Features/Ranking/State.hs
@@ -1,0 +1,47 @@
+{-# LANGUAGE DeriveDataTypeable, TypeFamilies, TemplateHaskell, RecordWildCards #-}
+
+module Distribution.Server.Features.Ranking.State where
+
+import Distribution.Package (PackageName)
+
+import Distribution.Server.Features.Ranking.Types
+  ( Stars(..)
+  , addStar
+  , removeStar
+  )
+
+import Distribution.Server.Users.Types (UserId)
+import Distribution.Server.Users.State ()
+
+import Data.Acid     (Query, Update, makeAcidic)
+import Data.SafeCopy (base, deriveSafeCopy)
+
+import qualified Control.Monad.State as State
+import Control.Monad.Reader.Class (ask)
+
+$(deriveSafeCopy 0 'base ''Stars)
+
+dbAddStar :: PackageName -> UserId -> Update Stars ()
+dbAddStar pkgname uid = do
+  state <- State.get
+  State.put $ addStar pkgname uid state
+
+dbRemoveStar :: PackageName -> UserId -> Update Stars ()
+dbRemoveStar pkgName uid = do
+  state <- State.get
+  State.put $ removeStar pkgName uid state
+
+dbGetStars :: Query Stars Stars
+dbGetStars = ask
+
+-- Replace the entire map
+dbReplaceStars :: Stars -> Update Stars ()
+dbReplaceStars = State.put
+
+makeAcidic
+  ''Stars
+  [ 'dbAddStar
+  , 'dbRemoveStar
+  , 'dbGetStars
+  , 'dbReplaceStars
+  ]

--- a/Distribution/Server/Features/Ranking/Types.hs
+++ b/Distribution/Server/Features/Ranking/Types.hs
@@ -1,0 +1,74 @@
+{-# LANGUAGE DeriveDataTypeable #-}
+
+-- | Defines the primary data types and functions that hold/alter
+-- | state relating to package ranking.
+module Distribution.Server.Features.Ranking.Types
+  ( Stars(..)
+  , StarMap
+  , initialStars
+  , addStar
+  , removeStar
+  , getUsersWhoStarred
+  , getNumberOfStarsFor
+  , askUserStarred
+  , enumerate
+  ) where
+
+import Distribution.Package (PackageName(..))
+import Distribution.Server.Users.Types (UserId(..))
+import Distribution.Server.Framework.MemSize
+
+import Data.Typeable
+import Data.Map as Map
+import Data.Set as Set
+import Data.List as L
+
+type StarMap = Map PackageName (Set UserId)
+
+data Stars = Stars {
+  extractMap:: !StarMap
+  } deriving (Show, Eq, Typeable)
+
+instance MemSize Stars where
+    memSize (Stars a) = memSize1 a
+
+
+initialStars :: Stars
+initialStars = Stars Map.empty
+
+addStar :: PackageName -> UserId -> Stars -> Stars
+addStar pkgname uid stars = Stars $
+  adjust (Set.insert uid) pkgname somemap
+    where
+      smap  = extractMap stars
+      somemap = if pkgname `Map.member` smap
+        then smap
+        else Map.insert pkgname Set.empty smap
+
+removeStar :: PackageName -> UserId -> Stars -> Stars
+removeStar pkgname uid vmap = Stars $
+  adjust (Set.delete uid) pkgname (extractMap vmap)
+
+getUsersWhoStarred :: PackageName -> Stars -> Set UserId
+getUsersWhoStarred pkgname stars =
+  case pkgname `Map.member` smap of
+    True -> smap Map.! pkgname
+    False -> Set.empty
+  where
+    smap    = extractMap stars
+
+-- Find out if a particular user starred a package
+askUserStarred :: PackageName -> UserId -> Stars -> Bool
+askUserStarred  pkgname uid stars =
+  case pkgname `Map.member` smap of
+    True -> uid `Set.member` (smap Map.! pkgname)
+    False -> False
+  where
+    smap = extractMap stars
+
+getNumberOfStarsFor :: PackageName -> Stars -> Int
+getNumberOfStarsFor pkgname vmap =
+  Set.size (getUsersWhoStarred pkgname vmap)
+
+enumerate :: Stars -> [(String, Set UserId)]
+enumerate vmap = L.map (\(name, uids) -> (unPackageName name, uids)) $ Map.toList (extractMap vmap)

--- a/Distribution/Server/Pages/Package.hs
+++ b/Distribution/Server/Pages/Package.hs
@@ -342,7 +342,7 @@ renderFields render = [
         Nothing -> strong ! [theclass "warning"] << toHtml "none"
         Just n  -> toHtml n
     sourceRepositoryField sr = sourceRepositoryToHtml sr
-    
+
     rendLicense = case rendLicenseFiles render of
       []            -> toHtml (rendLicenseName render)
       [licenseFile] -> anchor ! [ href (rendPkgUri render </> "src" </> licenseFile) ]

--- a/datafiles/static/hackage.css
+++ b/datafiles/static/hackage.css
@@ -49,14 +49,14 @@ a[href]:hover { text-decoration:underline; }
    For reasons, see:
       http://yui.yahooapis.com/3.1.1/build/cssfonts/fonts.css
  */
- 
+
 body {
 	font:11pt/1.4 sans-serif;
 	*font-size:small; /* for IE */
 	*font:x-small; /* for IE in quirks mode */
 }
 
-h1 { font-size: 146.5%; /* 19pt */ } 
+h1 { font-size: 146.5%; /* 19pt */ }
 h2 { font-size: 131%;   /* 17pt */ }
 h3 { font-size: 116%;   /* 15pt */ }
 h4 { font-size: 100%;   /* 13pt */ }
@@ -99,7 +99,7 @@ pre, code, kbd, samp, .src {
 
 /* @group Common */
 
-.caption, h1, h2, h3, h4, h5, h6 { 
+.caption, h1, h2, h3, h4, h5, h6 {
   font-weight: bold;
   color: rgb(78,98,114);
   margin: 0.8em 0 0.4em;
@@ -123,7 +123,7 @@ ul.links {
 
 ul.links li {
   display: inline;
-  border-left: 1px solid #d5d5d5; 
+  border-left: 1px solid #d5d5d5;
   white-space: nowrap;
   padding: 0;
 }
@@ -288,7 +288,7 @@ ul.links li form {
 ul.links li form input {
 	border:0px;
   padding:1px;
-	width: 8em; 
+	width: 8em;
 	background: rgb(235,235,235); /* url('/static/search.png') no-repeat 3px 4px; */
 }
 
@@ -486,7 +486,7 @@ ul.links li form button:hover {
 }
 
 #mini > * {
-  font-size: 93%; /* 12pt */  
+  font-size: 93%; /* 12pt */
 }
 
 #mini #module-list .caption,
@@ -650,3 +650,16 @@ ul.directory-list {
   list-style: none;
   margin: 0 0 0 2em;
 }
+
+.text-button {
+  font-size: small;
+  background: transparent;
+  border: none;
+  cursor: pointer;
+  color: rgb(196,69,29);
+}
+
+.text-button:hover {
+  text-decoration: underline;
+}
+

--- a/hackage-server.cabal
+++ b/hackage-server.cabal
@@ -214,6 +214,9 @@ executable hackage-server
       Distribution.Server.Features.Search.SearchEngine
       Distribution.Server.Features.Search.SearchIndex
       Distribution.Server.Features.Search.TermBag
+      Distribution.Server.Features.Ranking
+      Distribution.Server.Features.Ranking.State
+      Distribution.Server.Features.Ranking.Render
       Distribution.Server.Features.RecentPackages
       Distribution.Server.Features.PreferredVersions
       Distribution.Server.Features.PreferredVersions.State


### PR DESCRIPTION
Includes the backend feature, as well as an modification of the package page that displays the number of stars a package has (below the number of downloads) and a link to add a star.

![](http://i.gyazo.com/7f47dfa97653a3d86fb8d642181ef761.png)

Demo Instance: http://dzackgarza.com:8080/

---------------------------------
**Sample Test Case**:

`curl -X GET localhost:8080/package/3dmodels/stars`
`{"packageName":"3dmodels","numVotes":0}`

`curl -X PUT localhost:8080/package/3dmodel/stars`
`No Authorization Provided`

`curl -X PUT localhost:8080/package/3dmodels/stars --user admin:admin`
`curl -X GET localhost:8080/package/3dmodels/stars`
`{"packageName":"3dmodels","numVotes":1}`

`curl -X GET localhost:8080/stars --user admin:admin`
`[["3dmodels", [0]]]`

`curl -X PUT localhost:8080/package/3dmodels/stars --user newuser1:pass`
`curl -X GET localhost:8080/package/3dmodels/stars`
`{"packageName":"3dmodels","numVotes":2}`

`curl -X GET localhost:8080/stars --user admin:admin`
`[["3dmodels", [0,1]]]`

`curl -X DELETE localhost:8080/package/3dmodels/stars --user admin:admin`
`curl -X GET localhost:8080/package/3dmodels/stars`
`{"packageName":"3dmodels","numVotes":1}`

----------------------------------------------------------------------------