### PR TITLE
Add a dynamically generated sitemap.xml for crawlers.

### DIFF
--- a/Distribution/Server/Features.hs
+++ b/Distribution/Server/Features.hs
@@ -43,6 +43,7 @@ import Distribution.Server.Features.EditCabalFiles      (initEditCabalFilesFeatu
 import Distribution.Server.Features.AdminFrontend       (initAdminFrontendFeature)
 import Distribution.Server.Features.AdminLog            (initAdminLogFeature)
 import Distribution.Server.Features.HoogleData          (initHoogleDataFeature)
+import Distribution.Server.Features.Sitemap             (initSitemapFeature)
 #endif
 import Distribution.Server.Features.ServerIntrospect (serverIntrospectFeature)
 
@@ -140,6 +141,8 @@ initHackageFeatures env@ServerEnv{serverVerbosity = verbosity} = do
                                initHoogleDataFeature env
     mkAdminLogFeature       <- logStartup "admin log" $
                                initAdminLogFeature env
+    mkSitemapFeature        <- logStartup "sitemap" $
+                               initSitemapFeature env
 #endif
 
     loginfo verbosity "Initialising features, part 2"
@@ -162,7 +165,7 @@ initHackageFeatures env@ServerEnv{serverVerbosity = verbosity} = do
                          coreFeature
 
 #ifndef MINIMAL
-    tarIndexCacheFeature <- mkTarIndexCacheFeature 
+    tarIndexCacheFeature <- mkTarIndexCacheFeature
                               usersFeature
 
     packageContentsFeature <- mkPackageContentsFeature
@@ -289,6 +292,10 @@ initHackageFeatures env@ServerEnv{serverVerbosity = verbosity} = do
     adminLogFeature <- mkAdminLogFeature
                          usersFeature
 
+    siteMapFeature <- mkSitemapFeature
+                        coreFeature
+                        documentationCoreFeature
+
 #endif
 
     -- The order of initialization above should be the same as
@@ -325,6 +332,7 @@ initHackageFeatures env@ServerEnv{serverVerbosity = verbosity} = do
          , adminFrontendFeature
          , getFeatureInterface hoogleDataFeature
          , getFeatureInterface adminLogFeature
+         , getFeatureInterface siteMapFeature
 #endif
          , staticFilesFeature
          , serverIntrospectFeature allFeatures

--- a/Distribution/Server/Features.hs
+++ b/Distribution/Server/Features.hs
@@ -295,6 +295,7 @@ initHackageFeatures env@ServerEnv{serverVerbosity = verbosity} = do
     siteMapFeature <- mkSitemapFeature
                         coreFeature
                         documentationCoreFeature
+                        tagsFeature
 
 #endif
 

--- a/Distribution/Server/Features/Sitemap.hs
+++ b/Distribution/Server/Features/Sitemap.hs
@@ -1,0 +1,96 @@
+{-# LANGUAGE RecordWildCards #-}
+
+
+module Distribution.Server.Features.Sitemap (
+  SitemapFeature(..)
+, initSitemapFeature
+  ) where
+
+import Distribution.Server.Framework
+
+import Distribution.Server.Features.Core
+import Distribution.Server.Features.Documentation
+
+import Distribution.Package
+import Distribution.Text (display)
+import Distribution.Server.Packages.Types
+
+import qualified Distribution.Server.Features.Sitemap.Functions as SM
+import qualified Distribution.Server.Packages.PackageIndex as PackageIndex
+import qualified Data.List as L
+
+data SitemapFeature = SitemapFeature {
+  sitemapFeatureInterface :: HackageFeature
+}
+
+instance IsHackageFeature SitemapFeature where
+  getFeatureInterface = sitemapFeatureInterface
+
+initSitemapFeature :: ServerEnv
+                   -> IO ( CoreFeature
+                      -> DocumentationFeature
+                      -> IO SitemapFeature)
+initSitemapFeature env@ServerEnv{..} = do
+  return $ \coref@CoreFeature{..} docsCore@DocumentationFeature{..} -> do
+    let feature = sitemapFeature env
+                  coref docsCore
+    return feature
+
+sitemapFeature  :: ServerEnv
+                -> CoreFeature
+                -> DocumentationFeature
+                -> SitemapFeature
+sitemapFeature  ServerEnv{..}
+                CoreFeature{..}
+                DocumentationFeature{..}
+  = SitemapFeature{..} where
+
+    sitemapFeatureInterface = (emptyHackageFeature "XML sitemap generation") {
+      featureResources = [ xmlSitemapResource ]
+    }
+
+    xmlSitemapResource :: Resource
+    xmlSitemapResource = (resourceAt "/sitemap.xml") {
+      resourceDesc = [(GET, "Returns a dynamically generated sitemap in XML form.")]
+    , resourceGet = [("json", generateSitemap)]
+    }
+
+    generateSitemap :: DynamicPath -> ServerPartE Response
+    generateSitemap _ = do
+
+      pkgIndex <- queryGetPackageIndex
+      let pkgs = PackageIndex.allPackagesByName pkgIndex
+
+      -- Unversioned package pages - always redirect to latest version.
+          names = [display . pkgName . pkgInfoId $ pkg
+            | pkg <- L.map L.head pkgs]
+          nameNodes= SM.makeURLNodes names serverBaseURI "1.0"
+
+      -- Versioned package pages
+          nameVers = [(display . pkgName . pkgInfoId $ pkg) ++ "-" ++
+            (display . pkgVersion . pkgInfoId $ pkg) | pkg <- concat pkgs]
+          nameVersNodes = SM.makeURLNodes nameVers serverBaseURI "0.25"
+
+      -- Unversioned doc pages (for packages with valid documentation)
+      basePkgNamesWithDocs <- mapParaM (queryHasDocumentation . pkgInfoId)
+        (L.map L.head pkgs)
+      let baseDocs = [(display . pkgName . pkgInfoId . fst $ pkg) ++ "/docs"
+            | pkg <- filter ((== True) . snd) basePkgNamesWithDocs]
+          baseDocNodes = SM.makeURLNodes baseDocs serverBaseURI "1.0"
+
+      -- Versioned doc pages
+      docsAllVersions <- mapParaM (queryHasDocumentation . pkgInfoId)
+        (concat pkgs)
+      let versionedDocs = [(display . pkgName . pkgInfoId . fst $ pkg) ++ "-" ++
+            (display . pkgVersion . pkgInfoId . fst $ pkg) ++ "/docs"
+            | pkg <- filter ((== True) . snd) docsAllVersions]
+          versionedDocNodes = SM.makeURLNodes versionedDocs serverBaseURI "0.25"
+
+      -- Combine and build sitemap
+          allNodes = nameNodes ++ nameVersNodes ++ baseDocNodes ++ versionedDocNodes
+          sitemapXML = XMLResponse $ SM.nodesToSiteMap allNodes
+
+      return $ toResponse sitemapXML
+
+    mapParaM :: Monad m => (a -> m b) -> [a] -> m [(a, b)]
+    mapParaM f = mapM (\x -> (,) x `liftM` f x)

--- a/Distribution/Server/Features/Sitemap.hs
+++ b/Distribution/Server/Features/Sitemap.hs
@@ -87,7 +87,7 @@ sitemapFeature  ServerEnv{..}
           miscNodes = SM.makeURLNodes miscPages serverBaseURI "1.0"
 
       alltags <- queryGetTagList
-      let tagURLs = map (("/packages/tag/" ++) . show . fst) alltags
+      let tagURLs = map (("/packages/tag/" ++) . display . fst) alltags
           tagNodes = SM.makeURLNodes tagURLs serverBaseURI "0.5"
 
       pkgIndex <- queryGetPackageIndex

--- a/Distribution/Server/Features/Sitemap.hs
+++ b/Distribution/Server/Features/Sitemap.hs
@@ -51,6 +51,8 @@ sitemapFeature  ServerEnv{..}
 
     sitemapFeatureInterface = (emptyHackageFeature "XML sitemap generation") {
       featureResources = [ xmlSitemapResource ]
+      , featureState = []
+      , featureDesc = "Dynamically generates a sitemap.xml."
     }
 
     xmlSitemapResource :: Resource

--- a/Distribution/Server/Features/Sitemap.hs
+++ b/Distribution/Server/Features/Sitemap.hs
@@ -94,26 +94,26 @@ sitemapFeature  ServerEnv{..}
       let pkgs = PackageIndex.allPackagesByName pkgIndex
 
       -- Unversioned package pages - always redirect to latest version.
-          names = [display . pkgName . pkgInfoId $ pkg
+          names = [("/package/" ++) . display . pkgName . pkgInfoId $ pkg
             | pkg <- L.map L.head pkgs]
           nameNodes= SM.makeURLNodes names serverBaseURI "1.0"
 
       -- Versioned package pages
-          nameVers = [(display . pkgName . pkgInfoId $ pkg) ++ "-" ++
+          nameVers = [(("/package/" ++) . display . pkgName . pkgInfoId $ pkg) ++ "-" ++
             (display . pkgVersion . pkgInfoId $ pkg) | pkg <- concat pkgs]
           nameVersNodes = SM.makeURLNodes nameVers serverBaseURI "0.25"
 
       -- Unversioned doc pages (for packages with valid documentation)
       basePkgNamesWithDocs <- mapParaM (queryHasDocumentation . pkgInfoId)
         (L.map L.head pkgs)
-      let baseDocs = [(display . pkgName . pkgInfoId . fst $ pkg) ++ "/docs"
+      let baseDocs = [(("/package/" ++) . display . pkgName . pkgInfoId . fst $ pkg) ++ "/docs"
             | pkg <- filter ((== True) . snd) basePkgNamesWithDocs]
           baseDocNodes = SM.makeURLNodes baseDocs serverBaseURI "1.0"
 
       -- Versioned doc pages
       docsAllVersions <- mapParaM (queryHasDocumentation . pkgInfoId)
         (concat pkgs)
-      let versionedDocs = [(display . pkgName . pkgInfoId . fst $ pkg) ++ "-" ++
+      let versionedDocs = [(("/package/" ++) . display . pkgName . pkgInfoId . fst $ pkg) ++ "-" ++
             (display . pkgVersion . pkgInfoId . fst $ pkg) ++ "/docs"
             | pkg <- filter ((== True) . snd) docsAllVersions]
           versionedDocNodes = SM.makeURLNodes versionedDocs serverBaseURI "0.25"

--- a/Distribution/Server/Features/Sitemap.hs
+++ b/Distribution/Server/Features/Sitemap.hs
@@ -103,13 +103,12 @@ sitemapFeature  ServerEnv{..}
             , "/packages/preferred"
             , "/packages/deprecated"
             , "/packages/candidates"
-            , "/packages/uploads"
+            , "/packages/uploaders"
             , "/users"
             , "/users/register-request"
             , "/users/password-reset"
             , "/upload"
             , "/api"
-            , "/new-features"
             ]
           miscNodes = SM.urlsToNodes miscPages
             pageBuildDate "weekly" "0.75"

--- a/Distribution/Server/Features/Sitemap/Functions.hs
+++ b/Distribution/Server/Features/Sitemap/Functions.hs
@@ -28,7 +28,7 @@ schemaAttr = Map.fromList [ (makeName "xmlns", pack "http://www.sitemaps.org/sch
 
 packageToNode :: URI.URI -> String -> String -> Node
 packageToNode baseuri priority pkgname =
-  makeNodeURL (show baseuri ++ "/package/" ++ pkgname) "2012-04-30" "monthly" priority
+  makeNodeURL (show baseuri ++ pkgname) "2012-04-30" "monthly" priority
 
 
 makeNodeURL :: String -> String -> String -> String -> Node

--- a/Distribution/Server/Features/Sitemap/Functions.hs
+++ b/Distribution/Server/Features/Sitemap/Functions.hs
@@ -1,0 +1,54 @@
+
+module Distribution.Server.Features.Sitemap.Functions
+  ( nodesToSiteMap
+  , makeURLNodes
+  ) where
+
+import qualified Data.Map as Map
+import Prelude hiding (writeFile)
+import Data.Text
+import Text.XML
+import qualified Data.ByteString.Lazy as L
+import qualified Network.URI as URI
+
+
+nodesToSiteMap :: [Node] -> L.ByteString
+nodesToSiteMap nodes = renderLBS def (Document (Prologue [] Nothing []) root [])
+  where
+    root = Element (makeName "urlset") schemaAttr nodes
+
+makeURLNodes :: [String] -> URI.URI -> String -> [Node]
+makeURLNodes xs baseuri priority = Prelude.map (packageToNode baseuri priority) xs
+
+noAttr :: Map.Map Name Text
+noAttr = Map.empty
+
+schemaAttr :: Map.Map Name Text
+schemaAttr = Map.fromList [ (makeName "xmlns", pack "http://www.sitemaps.org/schemas/sitemap/0.9")]
+
+packageToNode :: URI.URI -> String -> String -> Node
+packageToNode baseuri priority pkgname =
+  makeNodeURL (show baseuri ++ "/package/" ++ pkgname) "2012-04-30" "monthly" priority
+
+
+makeNodeURL :: String -> String -> String -> String -> Node
+makeNodeURL loc lastmod changefreq priority =
+          NodeElement $ Element (makeName "url") noAttr
+            [ NodeElement $ Element (makeName "loc") noAttr
+                (makeNodeValue loc)
+            , NodeElement $ Element (makeName "lastmod") noAttr
+                (makeNodeValue lastmod)
+            , NodeElement $ Element (makeName "changefreq") noAttr
+                (makeNodeValue changefreq)
+            , NodeElement $ Element (makeName "priority") noAttr
+                (makeNodeValue priority)
+            ]
+
+makeNodeValue :: String -> [Node]
+makeNodeValue val = [NodeContent (pack val)]
+
+makeName :: String -> Name
+makeName s = Name
+  { nameLocalName = pack s
+  , nameNamespace = Nothing
+  , namePrefix = Nothing }

--- a/Distribution/Server/Features/Sitemap/Functions.hs
+++ b/Distribution/Server/Features/Sitemap/Functions.hs
@@ -1,8 +1,29 @@
+-- | Provides several ways to construct an XML Sitemap.
+--
+-- | Generally speaking, it is the user's responsibility to
+-- | construct a list of Nodes (i.e., [Node]) and to call
+-- | 'nodesToSiteMap' on that list.
+--
+-- | This can be done by manually populating a list using
+-- | the URLNode data type, transforming them into Nodes
+-- | with 'urlNodeToXMLElement', and passing them to 'nodesToSiteMap'.
+--
+-- | If you have a variety of paths with common values for last modification,
+-- | change frequency, and priority, apply 'urlsToNodes' to a list of
+-- | fully qualified URLs.
+-- | (e.g., ["http://yourhackage.com/package/blah", ...]
+-- |        :: [String] )
+--
+-- | If you have paths with differing dates for the last modification,
+-- | apply "pathsAndDatesToNodes" to a list of tuples consisting of
+-- | fully qualified paths and UTCTimes.
+-- | (e.g., [("http://yourhackage.com/foo", "2012-04-30 20:31:07.123485 UTC"), ...]
+-- |        :: [(String, UTCTime)] )
 
 module Distribution.Server.Features.Sitemap.Functions
   ( nodesToSiteMap
-  , makeURLNodes
-  , makeURLNodes'
+  , urlsToNodes
+  , pathsAndDatesToNodes
   ) where
 
 import qualified Data.Map as Map
@@ -21,49 +42,51 @@ data URLNode = URLNode {
 , priority :: String
 }
 
-
+-- | Primary function - generates the XML file from a list of Nodes.
 nodesToSiteMap :: [Node] -> L.ByteString
 nodesToSiteMap nodes = renderLBS def (Document (Prologue [] Nothing []) root [])
   where
     root = Element (makeName "urlset") schemaAttr nodes
 
-makeURLNodes :: [String] -> String -> [Node]
-makeURLNodes urls priorityForAll =
-  Prelude.map (packageToNode priorityForAll) urls
+-- | Make nodes with differing paths, but common lastmod/changefreq/priority values.
+urlsToNodes :: [String] -> String -> String -> String -> [Node]
+urlsToNodes urls lastModAll changeFreqAll priorityAll =
+  Prelude.map (createURLNode lastModAll changeFreqAll priorityAll) urls
 
-makeURLNodes' :: [(String, UTCTime)] -> String -> [Node]
-makeURLNodes' urls priorityForAll = Prelude.map (packageToNode' priorityForAll) urls
-
-noAttr :: Map.Map Name Text
-noAttr = Map.empty
-
-schemaAttr :: Map.Map Name Text
-schemaAttr = Map.fromList [ (makeName "xmlns", pack "http://www.sitemaps.org/schemas/sitemap/0.9")]
-
-packageToNode :: String -> String -> Node
-packageToNode priorityForPkg pkgPath =
+-- Take url/location as last argument to facilitate mapping over lists.
+createURLNode :: String -> String -> String -> String -> Node
+createURLNode l cf p url =
   let node = URLNode {
-        location = pkgPath
-      , lastmod = "2012-04-30"
-      , changefreq = "monthly"
-      , priority = priorityForPkg
+        location = url
+      , lastmod = l
+      , changefreq = cf
+      , priority = p
       } in
-  makeNodeURL node
+  urlNodeToXMLElement node
 
-packageToNode' :: String -> (String, UTCTime) -> Node
-packageToNode' priorityForPkg nameAndDate =
+-- | Make nodes with differeing paths and modification times, but common
+-- | change frequencies and priorities.
+pathsAndDatesToNodes :: [(String, UTCTime)] -> String -> String -> [Node]
+pathsAndDatesToNodes urls changeFreqAll priorityAll =
+  Prelude.map (packageToNode' changeFreqAll priorityAll) urls
+
+-- Take url and lastmod time as last argument to facilitate mapping.
+packageToNode' :: String -> String -> (String, UTCTime) -> Node
+packageToNode' cf p nameAndDate =
   let node = URLNode {
         location = fst nameAndDate
-      {-, lastmod = show . toModifiedJulianDay . utctDay . snd . nameAndDate-}
       , lastmod = showGregorian . utctDay . snd $ nameAndDate
-      , changefreq = "monthly"
-      , priority = priorityForPkg
+      , changefreq = cf
+      , priority = p
       } in
-      makeNodeURL node
+      urlNodeToXMLElement node
 
 
-makeNodeURL :: URLNode -> Node
-makeNodeURL node =
+-- | Local Functions
+
+-- Unwraps a URLNode and creates a NodeElement (from xml-conduit)
+urlNodeToXMLElement :: URLNode -> Node
+urlNodeToXMLElement node =
           NodeElement $ Element (makeName "url") noAttr
             [ NodeElement $ Element (makeName "loc") noAttr
                 (makeNodeValue $ location node)
@@ -75,9 +98,29 @@ makeNodeURL node =
                 (makeNodeValue $ priority node)
             ]
 
+
+-- | Helper Functions
+
+-- Empty set of attributes for an XML Element
+noAttr :: Map.Map Name Text
+noAttr = Map.empty
+
+-- Attributes needed for an XML Sitemap
+schemaAttr :: Map.Map Name Text
+schemaAttr = Map.fromList [
+  ( makeName "xmlns"
+  , pack "http://www.sitemaps.org/schemas/sitemap/0.9"
+  )]
+
+-- xml-conduit expects the actual value of a given element
+-- (i.e., what goes between the element's tags) to be typed as
+-- 'NodeContent Text', so this function abstracts that into a String.
 makeNodeValue :: String -> [Node]
 makeNodeValue val = [NodeContent (pack val)]
 
+-- xml-conduit allows for fully-qualified namespaces of type 'Name'.
+-- For a simple sitemap, we only need local names, so this function
+-- abstracts the global namespace and prefix away.
 makeName :: String -> Name
 makeName s = Name
   { nameLocalName = pack s

--- a/Distribution/Server/Features/Sitemap/Functions.hs
+++ b/Distribution/Server/Features/Sitemap/Functions.hs
@@ -26,14 +26,16 @@ module Distribution.Server.Features.Sitemap.Functions
   , pathsAndDatesToNodes
   ) where
 
+import Text.XML
+import Data.Text
+
 import qualified Data.Map as Map
 import Prelude hiding (writeFile)
-import Data.Text
-import Text.XML
-import qualified Data.ByteString.Lazy as L
-import qualified Network.URI as URI
+
 import Data.Time.Clock (UTCTime(..))
-import Data.Time.Calendar (Day(..), showGregorian)
+import Data.Time.Calendar (showGregorian)
+
+import qualified Data.ByteString.Lazy as L
 
 data URLNode = URLNode {
   location :: String
@@ -68,14 +70,14 @@ createURLNode l cf p url =
 -- | change frequencies and priorities.
 pathsAndDatesToNodes :: [(String, UTCTime)] -> String -> String -> [Node]
 pathsAndDatesToNodes urls changeFreqAll priorityAll =
-  Prelude.map (packageToNode' changeFreqAll priorityAll) urls
+  Prelude.map (createURLNode' changeFreqAll priorityAll) urls
 
--- Take url and lastmod time as last argument to facilitate mapping.
-packageToNode' :: String -> String -> (String, UTCTime) -> Node
-packageToNode' cf p nameAndDate =
+-- Take url and lastmod time tuple as last argument to facilitate mapping.
+createURLNode' :: String -> String -> (String, UTCTime) -> Node
+createURLNode' cf p urlAndDate =
   let node = URLNode {
-        location = fst nameAndDate
-      , lastmod = showGregorian . utctDay . snd $ nameAndDate
+        location = fst urlAndDate
+      , lastmod = showGregorian . utctDay . snd $ urlAndDate
       , changefreq = cf
       , priority = p
       } in

--- a/Distribution/Server/Features/Sitemap/Functions.hs
+++ b/Distribution/Server/Features/Sitemap/Functions.hs
@@ -2,6 +2,7 @@
 module Distribution.Server.Features.Sitemap.Functions
   ( nodesToSiteMap
   , makeURLNodes
+  , makeURLNodes'
   ) where
 
 import qualified Data.Map as Map
@@ -10,6 +11,15 @@ import Data.Text
 import Text.XML
 import qualified Data.ByteString.Lazy as L
 import qualified Network.URI as URI
+import Data.Time.Clock (UTCTime(..))
+import Data.Time.Calendar (Day(..), showGregorian)
+
+data URLNode = URLNode {
+  location :: String
+, lastmod :: String
+, changefreq :: String
+, priority :: String
+}
 
 
 nodesToSiteMap :: [Node] -> L.ByteString
@@ -17,8 +27,12 @@ nodesToSiteMap nodes = renderLBS def (Document (Prologue [] Nothing []) root [])
   where
     root = Element (makeName "urlset") schemaAttr nodes
 
-makeURLNodes :: [String] -> URI.URI -> String -> [Node]
-makeURLNodes xs baseuri priority = Prelude.map (packageToNode baseuri priority) xs
+makeURLNodes :: [String] -> String -> [Node]
+makeURLNodes urls priorityForAll =
+  Prelude.map (packageToNode priorityForAll) urls
+
+makeURLNodes' :: [(String, UTCTime)] -> String -> [Node]
+makeURLNodes' urls priorityForAll = Prelude.map (packageToNode' priorityForAll) urls
 
 noAttr :: Map.Map Name Text
 noAttr = Map.empty
@@ -26,22 +40,39 @@ noAttr = Map.empty
 schemaAttr :: Map.Map Name Text
 schemaAttr = Map.fromList [ (makeName "xmlns", pack "http://www.sitemaps.org/schemas/sitemap/0.9")]
 
-packageToNode :: URI.URI -> String -> String -> Node
-packageToNode baseuri priority pkgname =
-  makeNodeURL (show baseuri ++ pkgname) "2012-04-30" "monthly" priority
+packageToNode :: String -> String -> Node
+packageToNode priorityForPkg pkgPath =
+  let node = URLNode {
+        location = pkgPath
+      , lastmod = "2012-04-30"
+      , changefreq = "monthly"
+      , priority = priorityForPkg
+      } in
+  makeNodeURL node
+
+packageToNode' :: String -> (String, UTCTime) -> Node
+packageToNode' priorityForPkg nameAndDate =
+  let node = URLNode {
+        location = fst nameAndDate
+      {-, lastmod = show . toModifiedJulianDay . utctDay . snd . nameAndDate-}
+      , lastmod = showGregorian . utctDay . snd $ nameAndDate
+      , changefreq = "monthly"
+      , priority = priorityForPkg
+      } in
+      makeNodeURL node
 
 
-makeNodeURL :: String -> String -> String -> String -> Node
-makeNodeURL loc lastmod changefreq priority =
+makeNodeURL :: URLNode -> Node
+makeNodeURL node =
           NodeElement $ Element (makeName "url") noAttr
             [ NodeElement $ Element (makeName "loc") noAttr
-                (makeNodeValue loc)
+                (makeNodeValue $ location node)
             , NodeElement $ Element (makeName "lastmod") noAttr
-                (makeNodeValue lastmod)
+                (makeNodeValue $ lastmod node)
             , NodeElement $ Element (makeName "changefreq") noAttr
-                (makeNodeValue changefreq)
+                (makeNodeValue $ changefreq node)
             , NodeElement $ Element (makeName "priority") noAttr
-                (makeNodeValue priority)
+                (makeNodeValue $ priority node)
             ]
 
 makeNodeValue :: String -> [Node]

--- a/Distribution/Server/Framework/ResponseContentTypes.hs
+++ b/Distribution/Server/Framework/ResponseContentTypes.hs
@@ -136,6 +136,12 @@ instance ToMessage CSVFile where
     toContentType _ = "text/csv"
     toMessage (CSVFile csv) = packUTF8 (printCSV csv)
 
+newtype XMLResponse = XMLResponse BS.Lazy.ByteString
+
+instance ToMessage XMLResponse where
+  toContentType _ = "application/xml"
+  toMessage (XMLResponse bs) = bs
+
 mkResponse :: BS.Lazy.ByteString -> [(String, String)] -> Response
 mkResponse bs headers = Response {
     rsCode    = 200,

--- a/hackage-server.cabal
+++ b/hackage-server.cabal
@@ -227,6 +227,7 @@ executable hackage-server
       Distribution.Server.Features.UserSignup
       Distribution.Server.Features.StaticFiles
       Distribution.Server.Features.ServerIntrospect
+      Distribution.Server.Features.Sitemap
 
   if flag(debug)
     cpp-options: -DDEBUG
@@ -282,7 +283,8 @@ executable hackage-server
     QuickCheck >= 2.5,
     friendly-time >= 0.4 && < 0.5,
     cheapskate >= 0.1,
-    blaze-html >= 0.7
+    blaze-html >= 0.7,
+    xml-conduit
 
   if ! flag(minimal)
     build-depends:


### PR DESCRIPTION
This is a rough draft of a feature that will hopefully help further address the issue of Google results linking to versioned package/doc pages. Essentially, it prioritizes unversioned pages over their versioned counterparts. 

Parameters are fairly straightforward to tweak, so changes, feedback, and/or improvements welcome!

Here's a quick overview of the pages contained in the sitemap, and their relevant attributes. 

For each URL, there are three variables to consider:
* Date of Last Modification
* Change/Update Frequency
* Priority (in the range [0,1.0], defaults to 0.5)

And as of now, there are 6 primary categories of URLs contained in the sitemap:

* Miscellaneous base/root pages (e.g. "/index", "/packages")
  * **Last Mod**: Static, time recorded in-memory when feature is initialized (presumably corresponds to server startup date)
  * **Change Freq**: Weekly
  * **Priority**: 0.75

* Individual tag pages ("packages/tag/library", "packages/tag/bsd3")
  * **Last Mod**: Same as misc pages (date of feature initialization)
  * **Change Freq**: Daily
  * **Priority**: 0.5

* Unversioned Package Pages ("/package/aeson", "/package/text")
  * **Last Mod**: Date of last package metadata revision 

    (see Dist/Server/Packages/Types->PkgInfo->pkgMetadataRevisions->UploadInfo)
  * **Change Freq**: Daily
  * **Priority**: 1.0

* Versioned Package Pages ("/package/aeson-0.9.0.1", "/package/text-1.2.1.1")
  * **Last Mod**: Same as misc pages (Feature initialization date)
  * **Change Freq**: Monthly
  * **Priority**: 0.25

* Unversioned Document Pages ("/package/aeson/docs/", "/package/text/docs/")
  * **Last Mod**: Same as misc pages (Feature initialization date)
  * **Change Freq**: Daily
  * **Priority**: 1.0

* Versioned Document Pages ("/package/aeson-0.9.0.1/docs/", "/package/text-1.2.1.1/docs/")
  * **Last Mod**: Same as misc pages (Feature initialization date)
  * **Change Freq**: Monthly
  * **Priority**: 0.25