### PR TITLE
Add "Manual" column to the package flag table

### DIFF
--- a/Distribution/Server/Pages/Package.hs
+++ b/Distribution/Server/Pages/Package.hs
@@ -225,12 +225,14 @@ renderPackageFlags render =
           ,tbody << map flagRow flags]
         flagsHeadings = [th << "Name"
                         ,th << "Description"
-                        ,th << "Default"]
+                        ,th << "Default"
+                        ,th << "Manual"]
         flagRow flag =
           tr << [td ! [theclass "flag-name"]   << code (case flagName flag of FlagName name -> name)
                 ,td ! [theclass "flag-desc"]   << flagDescription flag
                 ,td ! [theclass (if flagDefault flag then "flag-enabled" else "flag-disabled")] <<
-                 if flagDefault flag then "Enabled" else "Disabled"]
+                 if flagDefault flag then "Enabled" else "Disabled"
+                ,td ! [theclass "flag-manual"] << show (flagManual flag)]
         code = (thespan ! [theclass "code"] <<)
 
 moduleSection :: PackageRender -> Maybe TarIndex -> URL -> [Html]

--- a/Distribution/Server/Pages/Package.hs
+++ b/Distribution/Server/Pages/Package.hs
@@ -226,13 +226,14 @@ renderPackageFlags render =
         flagsHeadings = [th << "Name"
                         ,th << "Description"
                         ,th << "Default"
-                        ,th << "Manual"]
+                        ,th << "Type"]
         flagRow flag =
           tr << [td ! [theclass "flag-name"]   << code (case flagName flag of FlagName name -> name)
                 ,td ! [theclass "flag-desc"]   << flagDescription flag
                 ,td ! [theclass (if flagDefault flag then "flag-enabled" else "flag-disabled")] <<
                  if flagDefault flag then "Enabled" else "Disabled"
-                ,td ! [theclass "flag-manual"] << show (flagManual flag)]
+                ,td ! [theclass (if flagManual flag then "flag-manual" else "flag-automatic")] <<
+                 if flagManual flag then "Manual" else "Automatic"]
         code = (thespan ! [theclass "code"] <<)
 
 moduleSection :: PackageRender -> Maybe TarIndex -> URL -> [Html]


### PR DESCRIPTION
Here is a screenshot from aeson:

![aeson](https://cloud.githubusercontent.com/assets/4276753/8785785/f0660578-2ede-11e5-8346-50364c401d60.png)

This column might need an explanation.  Would it be useful to mention manual flags in the section of the Cabal User Guide that "More info" links to?

http://www.haskell.org/cabal/users-guide/installing-packages.html#controlling-flag-assignments

Manual flags are currently only described in the page on developing packages:

https://www.haskell.org/cabal/users-guide/developing-packages.html#configuration-flags