### PR TITLE
Replace non-breaking-space with space

### DIFF
--- a/Distribution/Server/Framework/BackupRestore.hs
+++ b/Distribution/Server/Framework/BackupRestore.hs
@@ -5,7 +5,7 @@
 {-# LANGUAGE MultiParamTypeClasses      #-}
 {-# LANGUAGE RankNTypes                 #-}
 {-# LANGUAGE RecordWildCards            #-}
-{-# LANGUAGE ScopedTypeVariables        #-}
+{-# LANGUAGE ScopedTypeVariables        #-}
 {-# OPTIONS_GHC -fno-warn-orphans #-}
 
 module Distribution.Server.Framework.BackupRestore (


### PR DESCRIPTION
This one drove me crazy.. we got a compile error when building hackage on the hackage server, but I could not reproduce it on my box nor could @dcoutts on his; turns out the code contained a non-breaking space (unicode 0xC2A0) instead of a normal space before "`LANGUAGE ScopedTypeVariables`", and this was confusing `ghc` (but apparently only under certain circumstances?).

Only found this after retyping the code in desperation ("maybe if I do it again it'll be work this time".. :-o), being very surprised it suddenly worked, and then hexdumping the git diff..
