### PR TITLE
set a maximum width for the synopsis, closes #422

### DIFF
--- a/datafiles/static/hackage.css
+++ b/datafiles/static/hackage.css
@@ -345,6 +345,7 @@ ul.links li form button:hover {
   height: 80%;
   top: 10%;
   padding: 0;
+  max-width: 90%;
 }
 
 #synopsis .caption {


### PR DESCRIPTION
this fixes the issue, at least on my Chrome 45