### PR TITLE
docker: build from source and init hackage-server

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -1,0 +1,12 @@
+build-cache
+mirror-cache
+state
+dist
+tags
+*.swp
+.cabal-sandbox
+cabal.sandbox.config
+TAGS
+datafiles/TUF/*.json
+datafiles/TUF/*.private
+Dockerfile


### PR DESCRIPTION
This updates the Dockerfile so that it builds directly from the source
repository, which allows for easier testing of changes using docker.
The Dockerfile now also sets up everything needed to run hackage-server, so
that the following is enough to get an instance of hackage-server running:

```
$ docker build --tag hackage-server path/to/checkout
$ docker run -it --rm hackage-server
```