### PR TITLE
fix mirror client build failure

### DIFF
--- a/Distribution/Client/Mirror/Repo/Secure.hs
+++ b/Distribution/Client/Mirror/Repo/Secure.hs
@@ -68,6 +68,12 @@ withSourceRepo verbosity httpLib uri cacheDir threshold keys callback = do
               }
           }
 
+        repoOptions :: Sec.Remote.RepoOpts
+        repoOptions = Sec.Remote.RepoOpts
+           { repoAllowContentCompression = True
+           , repoWantCompressedIndex = True
+           , repoAllowAdditionalMirrors = True
+           }
 
         logger :: Sec.LogMessage -> IO ()
         logger msg = when (verbosity >= verbose) $
@@ -76,8 +82,7 @@ withSourceRepo verbosity httpLib uri cacheDir threshold keys callback = do
     Sec.Remote.withRepository
       httpLib
       [uri]
-      Sec.Remote.AllowContentCompression
-      Sec.Remote.WantCompressedIndex
+      repoOptions
       cache
       Sec.hackageRepoLayout
       logger $ \rep ->

--- a/hackage-server.cabal
+++ b/hackage-server.cabal
@@ -366,7 +366,7 @@ executable hackage-mirror
     SHA,
     parsec,
     process >= 1.2.0,
-    hackage-security,
+    hackage-security >= 0.2,
     hackage-security-HTTP
   default-language:   Haskell2010
   default-extensions: FlexibleContexts


### PR DESCRIPTION
hackage-security changed it's API, which broke the mirror client build. This
PR fixes that.