### PR TITLE
Added stack.yaml files freezing the dependencies

### DIFF
--- a/stack-7.10.yaml
+++ b/stack-7.10.yaml
@@ -1,0 +1,152 @@
+# For more information, see: https://github.com/commercialhaskell/stack/blob/release/doc/yaml_configuration.md
+
+# Specifies the GHC version and set of packages available (e.g., lts-3.5, nightly-2015-09-21, ghc-7.10.2)
+resolver: ghc-7.10.2
+
+# Local packages, usually specified by relative directory name
+packages:
+- '.'
+
+# Packages to be pulled from upstream that are not in the resolver (e.g., acme-missiles-0.3)
+extra-deps:
+- HStringTemplate-0.8.3
+- HTTP-4000.2.20
+- HUnit-1.3.0.0
+- HaXml-1.25.3
+- QuickCheck-2.8.1
+- SHA-1.6.4.2
+- acid-state-0.13.0
+- aeson-0.10.0.0
+- ansi-terminal-0.6.2.3
+- ansi-wl-pprint-0.6.7.3
+- appar-0.1.4
+- async-2.0.2
+- attoparsec-0.13.0.1
+- auto-update-0.1.2.2
+- base16-bytestring-0.1.1.6
+- base64-bytestring-1.0.0.1
+- blaze-builder-0.4.0.1
+- blaze-html-0.8.1.1
+- blaze-markup-0.7.0.3
+- byteable-0.1.1
+- byteorder-1.0.4
+- bytestring-builder-0.10.6.0.0
+- case-insensitive-1.2.0.5
+- cereal-0.4.1.1
+- cheapskate-0.1.0.4
+- cookie-0.4.1.6
+- crypto-api-0.13.2
+- cryptohash-0.11.6
+- css-text-0.1.2.1
+- csv-0.1.2
+- data-default-0.5.3
+- data-default-class-0.0.1
+- data-default-instances-base-0.0.1
+- data-default-instances-containers-0.0.1
+- data-default-instances-dlist-0.0.1
+- data-default-instances-old-locale-0.0.1
+- dlist-0.7.1.2
+- easy-file-0.2.1
+- ed25519-0.0.4.0
+- entropy-0.3.7
+- exceptions-0.8.0.2
+- extensible-exceptions-0.1.1.4
+- fast-logger-2.4.1
+- friendly-time-0.4
+- hackage-security-0.3.0.0
+- hackage-security-HTTP-0.1.0.2
+- happstack-server-7.4.4
+- hashable-1.2.3.3
+- hostname-1.0
+- hscolour-1.23
+- hslogger-1.2.9
+- html-1.0.1.2
+- http-types-0.9
+- iproute-1.7.0
+- lifted-base-0.2.3.6
+- mime-mail-0.4.11
+- mmorph-1.0.4
+- monad-control-1.0.0.4
+- mtl-2.2.1
+- nats-1
+- network-2.6.2.1
+- network-uri-2.6.0.3
+- old-locale-1.0.0.7
+- old-time-1.1.0.3
+- parsec-3.1.9
+- polyparse-1.11
+- primitive-0.6.1.0
+- pureMD5-2.1.2.1
+- random-1.1
+- regex-base-0.93.2
+- regex-posix-0.95.2
+- resourcet-1.1.6
+- rss-3000.2.0.5
+- safecopy-0.8.5
+- scientific-0.3.4.2
+- semigroups-0.17.0.1
+- sendfile-0.7.9
+- snowball-1.0.0.1
+- split-0.2.2
+- stm-2.4.4
+- streaming-commons-0.1.14.2
+- stringsearch-0.3.6.6
+- syb-0.6
+- system-filepath-0.4.13.4
+- tagged-0.8.1
+- tagsoup-0.13.3
+- tar-0.4.2.1
+- test-framework-0.8.1.1
+- test-framework-hunit-0.3.0.2
+- text-1.2.1.3
+- text-icu-0.7.0.1
+- tf-random-0.5
+- threads-0.5.1.3
+- time-compat-0.1.0.3
+- time-locale-compat-0.1.1.0
+- tokenize-0.3.0
+- transformers-base-0.4.4
+- transformers-compat-0.4.0.4
+- uniplate-1.6.12
+- unix-compat-0.4.1.4
+- unix-time-0.3.5
+- unordered-containers-0.2.5.1
+- utf8-string-1.0.1.1
+- vault-0.3.0.4
+- vector-0.10.12.3
+- void-0.7.1
+- wai-3.0.4.0
+- wai-extra-3.0.11.1
+- wai-logger-2.2.4.1
+- word8-0.1.2
+- xml-1.3.14
+- xmlgen-0.6.2.1
+- xss-sanitize-0.3.5.6
+- zlib-0.5.4.2
+
+# Override default flag values for local packages and extra-deps
+flags:
+  text:
+    integer-simple: false
+  tar:
+    old-time: false
+  time-locale-compat:
+    old-locale: false
+
+# Extra package databases containing global packages
+extra-package-dbs: []
+
+# Control whether we use the GHC we find on the path
+# system-ghc: true
+
+# Require a specific version of stack, using version ranges
+# require-stack-version: -any # Default
+# require-stack-version: >= 0.1.4.0
+
+# Override the architecture used by stack, especially useful on Windows
+# arch: i386
+# arch: x86_64
+
+# Extra directories used by stack for building
+# extra-include-dirs: [/path/to/dir]
+# extra-lib-dirs: [/path/to/dir]

--- a/stack-7.8.yaml
+++ b/stack-7.8.yaml
@@ -1,0 +1,163 @@
+# For more information, see: https://github.com/commercialhaskell/stack/blob/release/doc/yaml_configuration.md
+
+# Specifies the GHC version and set of packages available (e.g., lts-3.5, nightly-2015-09-21, ghc-7.10.2)
+resolver: ghc-7.8.3
+
+# Local packages, usually specified by relative directory name
+packages:
+- '.'
+
+# Packages to be pulled from upstream that are not in the resolver (e.g., acme-missiles-0.3)
+extra-deps:
+- Cabal-1.22.4.0
+- HStringTemplate-0.8.3
+- HTTP-4000.2.20
+- HUnit-1.3.0.0
+- HaXml-1.25.3
+- QuickCheck-2.8.1
+- SHA-1.6.4.2
+- acid-state-0.13.0
+- aeson-0.10.0.0
+- ansi-terminal-0.6.2.3
+- ansi-wl-pprint-0.6.7.3
+- appar-0.1.4
+- async-2.0.2
+- attoparsec-0.13.0.1
+- auto-update-0.1.2.2
+- base16-bytestring-0.1.1.6
+- base64-bytestring-1.0.0.1
+- binary-0.7.6.1
+- blaze-builder-0.4.0.1
+- blaze-html-0.8.1.1
+- blaze-markup-0.7.0.3
+- byteable-0.1.1
+- byteorder-1.0.4
+- bytestring-0.10.6.0
+- bytestring-builder-0.10.6.0.0
+- case-insensitive-1.2.0.5
+- cereal-0.4.1.1
+- cheapskate-0.1.0.4
+- cookie-0.4.1.6
+- crypto-api-0.13.2
+- cryptohash-0.11.6
+- css-text-0.1.2.1
+- csv-0.1.2
+- data-default-0.5.3
+- data-default-class-0.0.1
+- data-default-instances-base-0.0.1
+- data-default-instances-containers-0.0.1
+- data-default-instances-dlist-0.0.1
+- data-default-instances-old-locale-0.0.1
+- directory-1.2.4.0
+- dlist-0.7.1.2
+- easy-file-0.2.1
+- ed25519-0.0.4.0
+- entropy-0.3.7
+- exceptions-0.8.0.2
+- extensible-exceptions-0.1.1.4
+- fast-logger-2.4.1
+- friendly-time-0.4
+- hackage-security-0.3.0.0
+- hackage-security-HTTP-0.1.0.2
+- happstack-server-7.4.4
+- hashable-1.2.3.3
+- hostname-1.0
+- hscolour-1.23
+- hslogger-1.2.9
+- html-1.0.1.2
+- http-types-0.9
+- iproute-1.7.0
+- lifted-base-0.2.3.6
+- mime-mail-0.4.11
+- mmorph-1.0.4
+- monad-control-1.0.0.4
+- mtl-2.2.1
+- nats-1
+- network-2.6.2.1
+- network-uri-2.6.0.3
+- parsec-3.1.9
+- polyparse-1.11
+- primitive-0.6.1.0
+- process-1.2.3.0
+- pureMD5-2.1.2.1
+- random-1.1
+- regex-base-0.93.2
+- regex-posix-0.95.2
+- resourcet-1.1.6
+- rss-3000.2.0.5
+- safecopy-0.8.5
+- scientific-0.3.4.2
+- semigroups-0.17.0.1
+- sendfile-0.7.9
+- snowball-1.0.0.1
+- split-0.2.2
+- stm-2.4.4
+- streaming-commons-0.1.14.2
+- stringsearch-0.3.6.6
+- syb-0.6
+- system-filepath-0.4.13.4
+- tagged-0.8.1
+- tagsoup-0.13.3
+- tar-0.4.2.1
+- test-framework-0.8.1.1
+- test-framework-hunit-0.3.0.2
+- text-1.2.1.3
+- text-icu-0.7.0.1
+- tf-random-0.5
+- threads-0.5.1.3
+- time-compat-0.1.0.3
+- time-locale-compat-0.1.1.0
+- tokenize-0.3.0
+- transformers-0.4.3.0
+- transformers-base-0.4.4
+- transformers-compat-0.4.0.4
+- uniplate-1.6.12
+- unix-2.7.1.0
+- unix-compat-0.4.1.4
+- unix-time-0.3.5
+- unordered-containers-0.2.5.1
+- utf8-string-1.0.1.1
+- vault-0.3.0.4
+- vector-0.10.12.3
+- void-0.7.1
+- wai-3.0.4.0
+- wai-extra-3.0.11.1
+- wai-logger-2.2.4.1
+- word8-0.1.2
+- xml-1.3.14
+- xmlgen-0.6.2.1
+- xss-sanitize-0.3.5.6
+- zlib-0.5.4.2
+
+# Override default flag values for local packages and extra-deps
+flags:
+  rss:
+    old-locale: true
+  text:
+    integer-simple: false
+  hackage-security:
+    base48: false
+  tar:
+    old-time: false
+  QuickCheck:
+    base4point8: false
+  aeson:
+    old-locale: true
+
+# Extra package databases containing global packages
+extra-package-dbs: []
+
+# Control whether we use the GHC we find on the path
+# system-ghc: true
+
+# Require a specific version of stack, using version ranges
+# require-stack-version: -any # Default
+# require-stack-version: >= 0.1.4.0
+
+# Override the architecture used by stack, especially useful on Windows
+# arch: i386
+# arch: x86_64
+
+# Extra directories used by stack for building
+# extra-include-dirs: [/path/to/dir]
+# extra-lib-dirs: [/path/to/dir]

--- a/stack.yaml
+++ b/stack.yaml
@@ -1,0 +1,1 @@
+stack-7.8.yaml


### PR DESCRIPTION
one for GHC 7.8, symlinked as the default and one for GHC 7.10

Maybe this is useful to others as well?

Upon suggestion from Duncan, I also prepared a cabal.config that contains the list of frozen dependencies, but... well, I created 2:

- [one from plain `cabal freeze`](https://gist.github.com/berdario/eaaf96f69accbb15d34e)
- [this one](https://gist.github.com/berdario/e3053e90877c2c99efa2) from `stack list-dependencies`, and by manually adding the versions for packages that come with ghc (is that a good idea?) The end result is that a version is different (ed25519's), rts ==1.0 is missing, and a bunch of dependencies needed for testing have been added

Not sure which of the 2 would be the desired one.