### PR TITLE
Apply custom `Content-Type`s correctly

### DIFF
--- a/Distribution/Server/Framework/HappstackUtils.hs
+++ b/Distribution/Server/Framework/HappstackUtils.hs
@@ -70,7 +70,7 @@ mime x =
     Map.findWithDefault thedefault (drop 1 (takeExtension x)) mimeTypes'
   where
     thedefault      = "text/plain; charset=utf-8"
-    mimeTypes'      = mimeTypes `Map.union` customMimeTypes
+    mimeTypes'      = customMimeTypes `Map.union` mimeTypes
     customMimeTypes = Map.fromList
       [ ("xhtml", "application/xhtml+xml; charset=utf-8")
       , ("html" , "text/html; charset=utf-8")


### PR DESCRIPTION
Since `Map.union` is left-biased, the custom entries must be listed first not last.

See https://hackage.haskell.org/package/containers-0.5.6.3/docs/Data-Map-Strict.html#g:9

Closes #441