### PR TITLE
add some context as to what ICU is

### DIFF
--- a/README.md
+++ b/README.md
@@ -7,7 +7,7 @@ This is the `hackage-server` code. This is what powers <http://hackage.haskell.o
 ## Installing ICU
 
 ICU stands for "International Components for Unicode". The `icu4c` is a set
-of libraries that provide Uncicode and Globalization support.
+of libraries that provide Unicode and Globalization support.
 The [text-icu](https://hackage.haskell.org/package/text-icu) Haskell package
 uses the [icu4c](http://icu-project.org/apiref/icu4c/) library to build.
 

--- a/README.md
+++ b/README.md
@@ -6,6 +6,11 @@ This is the `hackage-server` code. This is what powers <http://hackage.haskell.o
 
 ## Installing ICU
 
+ICU stands for "International Components for Unicode". The `icu4c` is a set
+of libraries that provide Uncicode and Globalization support.
+The [text-icu](https://hackage.haskell.org/package/text-icu) Haskell package
+uses the [icu4c](http://icu-project.org/apiref/icu4c/) library to build.
+
 You'll need to do the following to get hackage-server's dependency `text-icu` to build:
 
 ### Mac OS X


### PR DESCRIPTION
I didn't know what `ICU` was, so I spent a minute updating the docs so they explain what the library install does and why `text-icu` needs them