### PR TITLE
Add test-suite and benchmark tags

### DIFF
--- a/Distribution/Server/Features/Html.hs
+++ b/Distribution/Server/Features/Html.hs
@@ -1614,7 +1614,7 @@ mkHtmlSearch HtmlUtilities{..}
             renderSearchResult :: PackageItem -> Html
             renderSearchResult item = li ! classes <<
               [ packageNameLink pkgname
-              , toHtml $ " " ++ ptype (itemHasLibrary item) (itemNumExecutables item)
+              , toHtml $ " " ++ ptype
               , br
               , toHtml (itemDesc item)
               , br
@@ -1629,9 +1629,8 @@ mkHtmlSearch HtmlUtilities{..}
                           $ PackageIndex.lookupPackageName pkgIndex pkgname
                 -- takes current time as argument so it can say how many $X ago something was
                 humanTime = HumanTime.humanReadableTime' currentTime timestamp
-                ptype _ 0 = "library"
-                ptype lib num = (if lib then "library and " else "")
-                                ++ (case num of 1 -> "program"; _ -> "programs")
+                ptype = packageType (itemHasLibrary item) (itemNumExecutables item)
+                                    (itemNumTests item) (itemNumBenchmarks item)
                 classes = case classList of [] -> []; _ -> [theclass $ unwords classList]
                 classList = (case itemDeprecated item of Nothing -> []; _ -> ["deprecated"])
 

--- a/Distribution/Server/Features/Html/HtmlUtilities.hs
+++ b/Distribution/Server/Features/Html/HtmlUtilities.hs
@@ -34,14 +34,13 @@ htmlUtilities CoreFeature{coreResource}
     renderItem :: PackageItem -> Html
     renderItem item = li ! classes <<
           [ packageNameLink pkgname
-          , toHtml $ " " ++ ptype (itemHasLibrary item) (itemNumExecutables item)
+          , toHtml $ " " ++ ptype
                          ++ ": " ++ itemDesc item
           , " (" +++ renderTags (itemTags item) +++ ")"
           ]
       where pkgname = itemName item
-            ptype _ 0 = "library"
-            ptype lib num = (if lib then "library and " else "")
-                         ++ (case num of 1 -> "program"; _ -> "programs")
+            ptype = packageType (itemHasLibrary item) (itemNumExecutables item)
+                                (itemNumTests item) (itemNumBenchmarks item)
             classes = case classList of [] -> []; _ -> [theclass $ unwords classList]
             classList = (case itemDeprecated item of Nothing -> []; _ -> ["deprecated"])
 

--- a/Distribution/Server/Features/PackageList.hs
+++ b/Distribution/Server/Features/PackageList.hs
@@ -66,7 +66,11 @@ data PackageItem = PackageItem {
     -- Whether there's a library here.
     itemHasLibrary :: !Bool,
     -- How many executables (>=0) this package has.
-    itemNumExecutables :: !Int
+    itemNumExecutables :: !Int,
+    -- How many test suites (>=0) this package has.
+    itemNumTests :: !Int,
+    -- How many benchmarks (>=0) this package has.
+    itemNumBenchmarks :: !Int
     -- Hotness: a more heuristic way to sort packages. presently non-existent.
   --itemHotness :: Int
 }
@@ -231,7 +235,9 @@ updateDescriptionItem genDesc item =
         -- desc is flattened, we might miss some flags. Perhaps use the
         -- CondTree instead.
         itemHasLibrary = hasLibs desc,
-        itemNumExecutables = length . filter (buildable . buildInfo) $ executables desc
+        itemNumExecutables = length . filter (buildable . buildInfo) $ executables desc,
+        itemNumTests = length . filter (buildable . testBuildInfo) $ testSuites desc,
+        itemNumBenchmarks = length . filter (buildable . benchmarkBuildInfo) $ benchmarks desc
     }
 
 updateTagItem :: Set Tag -> PackageItem -> PackageItem

--- a/Distribution/Server/Features/Tags.hs
+++ b/Distribution/Server/Features/Tags.hs
@@ -242,9 +242,13 @@ constructImmutableTags genDesc =
         !l = license desc
         !hl = hasLibs desc
         !he = hasExes desc
+        !ht = hasTests desc
+        !hb = hasBenchmarks desc
     in licenseToTag l
     ++ (if hl then [Tag "library"] else [])
     ++ (if he then [Tag "program"] else [])
+    ++ (if ht then [Tag "test"] else [])
+    ++ (if hb then [Tag "benchmark"] else [])
   where
     licenseToTag :: License -> [Tag]
     licenseToTag l = case l of

--- a/Distribution/Server/Pages/Index.hs
+++ b/Distribution/Server/Pages/Index.hs
@@ -3,6 +3,7 @@
 module Distribution.Server.Pages.Index (packageIndex) where
 
 import Distribution.Server.Pages.Template       ( hackagePage )
+import Distribution.Server.Pages.Util           ( packageType )
 
 import Distribution.Package
 import Distribution.PackageDescription
@@ -34,6 +35,8 @@ data PackageIndexInfo = PackageIndexInfo {
                             pii_categories :: ![Category],
                             pii_hasLibrary :: !Bool,
                             pii_numExecutables :: !Int,
+                            pii_numTests :: !Int,
+                            pii_numBenchmarks :: !Int,
                             pii_synopsis :: !String
                         }
 
@@ -43,6 +46,8 @@ mkPackageIndexInfo pd = PackageIndexInfo {
                             pii_categories = categories pd,
                             pii_hasLibrary = hasLibs pd,
                             pii_numExecutables = length (executables pd),
+                            pii_numTests = length (testSuites pd),
+                            pii_numBenchmarks = length (benchmarks pd),
                             pii_synopsis = synopsis pd
                         }
 
@@ -92,13 +97,8 @@ formatPkg pkg = li << (pkgLink : toHtml (" " ++ ptype) : defn)
         defn
           | null (pii_synopsis pkg) = []
           | otherwise = [toHtml (": " ++ trim (pii_synopsis pkg))]
-        ptype
-          | pii_numExecutables pkg == 0 = "library"
-          | pii_hasLibrary pkg = "library and " ++ programs
-          | otherwise = programs
-          where programs
-                  | pii_numExecutables pkg > 1 = "programs"
-                  | otherwise = "program"
+        ptype = packageType (pii_hasLibrary pkg) (pii_numExecutables pkg)
+                            (pii_numTests pkg) (pii_numBenchmarks pkg)
         trim s
           | length s < 90 = s
           | otherwise = reverse (dropWhile (/= ',') (reverse (take 76 s))) ++ " ..."

--- a/Distribution/Server/Pages/Util.hs
+++ b/Distribution/Server/Pages/Util.hs
@@ -5,7 +5,11 @@ module Distribution.Server.Pages.Util
 
     , makeInput
     , makeCheckbox
+
+    , packageType
     ) where
+
+import Data.List (intercalate)
 
 import Distribution.Server.Pages.Template (hackagePage)
 
@@ -28,3 +32,33 @@ makeCheckbox isChecked fname fvalue labelName = [input ! ([thetype "checkbox", n
                                                  ++ if isChecked then [checked] else []),
                                         toHtml " ",
                                         label ! [thefor fname] << labelName]
+
+packageType :: Bool
+            -> Int
+            -> Int
+            -> Int
+            -> String
+packageType hasLibrary numExes numTests numBenches =
+    commaSeparate $ map format components
+  where
+    components = (if hasLibrary     then [Library]               else [])
+              ++ (if numExes    > 0 then [Programs numExes]      else [])
+              ++ (if numTests   > 0 then [Tests numTests]        else [])
+              ++ (if numBenches > 0 then [Benchmarks numBenches] else [])
+
+    format Library        = "library"
+    format (Programs n)   = "program"   ++ suffix n
+    format (Tests n)      = "test"      ++ suffix n
+    format (Benchmarks n) = "benchmark" ++ suffix n
+
+    suffix n = if n > 1 then "s" else ""
+
+    commaSeparate []  = []
+    commaSeparate [x] = x
+    commaSeparate xs  = let (init', [last']) = splitAt (length xs - 1) xs
+                        in intercalate ", " init' ++ " and " ++ last'
+
+data Component = Library
+               | Programs   !Int
+               | Tests      !Int
+               | Benchmarks !Int


### PR DESCRIPTION
Implementing this mostly involves plumbing. The logic for determining whether to print "library", "library and program", "library, programs, tests and benchmarks", etc. became more complicated, so I factored it out into `Distribution.Server.Pages.Util`.

Fixes #498.