### PR TITLE
Use cryptohash-sha256 for SHA256

### DIFF
--- a/Distribution/Server/Features/Security/SHA256.hs
+++ b/Distribution/Server/Features/Security/SHA256.hs
@@ -6,54 +6,73 @@ module Distribution.Server.Features.Security.SHA256 (
 
 -- stdlibs
 import Control.DeepSeq
+import Control.Monad
 import Data.SafeCopy
 import Data.Serialize
+import qualified Data.ByteString as BS
+import qualified Data.ByteString.Base16 as B16
+import qualified Data.ByteString.Char8 as BS.Char8
 import qualified Data.ByteString.Lazy as BS.Lazy
 
 -- cryptohash
-import Data.Byteable (toBytes)
-import qualified Crypto.Hash as Crypto
+import qualified Crypto.Hash.SHA256 as SHA256
 
 -- hackage
 import Distribution.Server.Framework.MemSize
 import Distribution.Server.Util.ReadDigest
 
--- | SHA256 digest
+-- | SHA256 digest.
+--
+-- Internal invariant: @BS.length . sha256Digest == const 32@
 newtype SHA256Digest = SHA256Digest {
-    sha256Digest :: Crypto.Digest Crypto.SHA256
+    -- TODO: currently takes up 9 words on 64bit and uses pinned memory
+    --       could use ShortByteString instead, or
+    --
+    --  data SHA256Digest = SHA256Digest !Word64 !Word64 !Word64 !Word64
+    --
+    -- which would get us unpinned memory, and down to the optimum of
+    -- 5 Words on 64bit
+    sha256Digest :: BS.ByteString
   }
   deriving (Eq)
 
--- | SHA256Digest is a newtype wrapper around 'Crypto.Digest', which in turn
--- is a newtype wrapper around a string bytestring; hence WHNF = NF.
+-- | SHA256Digest is a @newtype@ wrapper around a 'BS.Bytestring' holding
+-- the raw 32-byte SHA256 digest value; hence WHNF = NF.
 instance NFData SHA256Digest where
   rnf digest = digest `seq` ()
 
 -- | The 'Show' instance for 'SHA256Digest' prints the underlying digest
 -- (without showing the newtype wrapper)
+--
+-- For legacy reasons, this instance emits the base16 encoded digest
+-- string without surrounding quotation marks
 instance Show SHA256Digest where
-  show = show . sha256Digest
+  show = BS.Char8.unpack . B16.encode . sha256Digest
 
 instance ReadDigest SHA256Digest where
   -- NOTE: This differs in an important way from the 'Serialize' instance:
   -- the base16-encoded digest doesn't have a length prefix
-  readDigest str = case Crypto.digestFromByteString (readBase16 str) of
-                     Nothing -> Left  $ "Could not decode SHA256 " ++ show str
-                     Just d  -> Right $ SHA256Digest d
+  readDigest str =
+      case B16.decode (BS.Char8.pack str) of
+          (d,rest) | BS.null rest
+                   , BS.length d == 32 -> Right $ SHA256Digest d
+                   | otherwise         -> Left $ "Could not decode SHA256 " ++
+                                                 show str
 
+-- | Compute SHA256 digest
 sha256 :: BS.Lazy.ByteString -> SHA256Digest
-sha256 = SHA256Digest . Crypto.hashlazy
+sha256 = SHA256Digest . SHA256.hashlazy
 
 instance MemSize SHA256Digest where
-  memSize _ = 8 -- 8 words @ 32 bits = 256 bits
+  memSize _ = 9 -- memSize (Data.ByteString.replicate 32 0)
 
 instance SafeCopy SHA256Digest where
   -- use default Serialize instance
 
 -- For legacy reasons this length-prefixes the digest
 instance Serialize SHA256Digest where
-  put = put . toBytes . sha256Digest
+  put = put . sha256Digest
   get = do bs <- get
-           case Crypto.digestFromByteString bs of
-             Nothing -> fail "Bytestring of the wrong length"
-             Just d  -> return $ SHA256Digest d
+           unless (BS.length bs == 32) $
+               fail "Bytestring of the wrong length"
+           return (SHA256Digest bs)

--- a/hackage-server.cabal
+++ b/hackage-server.cabal
@@ -323,8 +323,7 @@ executable hackage-server
     xmlgen     >= 0.6,
     hackage-security >= 0.5.2 && < 0.6,
     ed25519,
-    byteable,
-    cryptohash,
+    cryptohash-sha256 == 0.11.*,
     binary
 
   if ! flag(minimal)
@@ -384,8 +383,7 @@ executable hackage-mirror
     Cabal,
     safecopy, cereal, binary, mtl,
     unix, aeson,
-    byteable,
-    cryptohash,
+    cryptohash-sha256,
     parsec,
     process >= 1.2.0,
     hackage-security >= 0.5.1 && < 0.6,
@@ -430,8 +428,7 @@ executable hackage-build
     aeson >= 0.6.1.0,
     random,
     unix,
-    byteable,
-    cryptohash,
+    cryptohash-sha256,
     -- Runtime dependency only:
     hscolour >= 1.8
   default-language: Haskell2010
@@ -581,12 +578,11 @@ Test-Suite HashTests
                     base,
                     base16-bytestring,
                     binary,
-                    byteable,
                     bytestring,
                     cereal,
                     containers,
                     crypto-api,
-                    cryptohash,
+                    cryptohash-sha256,
                     deepseq,
                     pureMD5,
                     safecopy,


### PR DESCRIPTION
This avoids the hard to constrain cryptohash/cryptonite/byteable/memory
dependency which is a bit of a moving target and uses the simpler and
focused `cryptohash-sha256` package instead. This is also what
hackage-security and therefore cabal-install uses.