### PR TITLE
Replace pureMD5 by cryptohash-md5

### DIFF
--- a/Distribution/Server/Features/Security/Cache.hs
+++ b/Distribution/Server/Features/Security/Cache.hs
@@ -19,7 +19,6 @@ import System.IO (IOMode(..))
 import System.Posix.Files
 import System.Posix.IO
 import System.Posix.Types (EpochTime)
-import qualified Crypto.Classes             as Crypto
 import qualified Data.ByteString.Lazy.Char8 as BS.Lazy
 
 -- Hackage

--- a/Distribution/Server/Features/Security/MD5.hs
+++ b/Distribution/Server/Features/Security/MD5.hs
@@ -1,77 +1,92 @@
 {-# LANGUAGE BangPatterns #-}
+{-# LANGUAGE CPP          #-}
 
 -- | MD5 digest
 module Distribution.Server.Features.Security.MD5 (
     MD5Digest
   , md5
 
+  , md5DigestBytes
+
   , lazyMD5
   , ByteStringWithMd5(..)
   ) where
 
 -- stdlibs
-import Control.DeepSeq
-import Data.SafeCopy
-import qualified Data.ByteString as BS
-import qualified Data.ByteString.Lazy as BS.Lazy
+import           Control.Applicative
+import           Control.DeepSeq
+import qualified Data.Binary                           as Bin
+import qualified Data.Binary.Put                       as Bin
+import qualified Data.ByteString                       as BS
+import qualified Data.ByteString.Base16                as B16
+#if MIN_VERSION_binary(0,8,3)
+import           Data.ByteString.Builder.Extra         as BS
+#endif
+import qualified Data.ByteString.Char8                 as BS.Char8
+import qualified Data.ByteString.Lazy                  as BS.Lazy
+import           Data.SafeCopy
+import qualified Data.Serialize                        as Ser
+import           Data.Word
 
--- pureMD5
-import Data.Digest.Pure.MD5 (MD5Digest, MD5Context, md5)
-import Crypto.Classes (initialCtx, updateCtx, finalize, blockLength)
-import Crypto.Types (ByteLength)
-import qualified Crypto.Util (for)
-
--- cryptohash-md5
--- TODO: import qualified Crypto.Hash.MD5 as MD5
+-- cryptohash
+import qualified Crypto.Hash.MD5                       as MD5
 
 -- hackage
-import Distribution.Server.Framework.MemSize
-import Distribution.Server.Util.ReadDigest
+import           Distribution.Server.Framework.MemSize
+import           Distribution.Server.Util.ReadDigest
 
--- Orphans!
---
--- Every module which gets access to the MD5Digest type imports this
--- module, so we can place orphan instances here rather than in
--- Distribution.Server.Features.Security.Orphans
---
--- NB: This is only a temporary measure until pureMD5 is replaced with
--- cryptohash-md5, which will only require rewriting *this* module.
-
-instance ReadDigest MD5Digest
+-- | MD5 digest
+data MD5Digest = MD5Digest {-# UNPACK #-} !Word64 {-# UNPACK #-} !Word64
+               deriving (Eq,Ord)
 
 instance NFData MD5Digest where
-    rnf = rnf . show  --TODO: MD5Digest should be a newtype wrapper and an instance of NFData
+    rnf !_ = () -- 'MD5Digest' has only strict primitive fields, hence WHNF==NF
+
+-- internal convenience helper
+-- fails if input has wrong length; callers must ensure correct length
+md5digestFromBS :: BS.ByteString -> MD5Digest
+md5digestFromBS bs = case Ser.runGet (Ser.get :: Ser.Get MD5Digest) bs of
+    Left  e -> error ("md5digestFromBS: " ++ e)
+    Right d -> d
+
+-- | The 'Show' instance for 'MD5Digest' prints the underlying digest
+-- (without showing the newtype wrapper)
+--
+-- For legacy reasons, this instance emits the base16 encoded digest
+-- string without surrounding quotation marks
+instance Show MD5Digest where
+  show = BS.Char8.unpack . B16.encode . md5DigestBytes
+
+instance ReadDigest MD5Digest where
+  readDigest str =
+      case B16.decode (BS.Char8.pack str) of
+          (d,rest) | BS.null rest
+                   , BS.length d == 16 -> Right $! md5digestFromBS d
+                   | otherwise         -> Left $ "Could not decode MD5 " ++
+                                                 show str
+
+-- | Compute MD5 digest
+md5 :: BS.Lazy.ByteString -> MD5Digest
+md5 = md5digestFromBS . MD5.hashlazy
 
 instance MemSize MD5Digest where
-    memSize _ = 7 --TODO: pureMD5 package wastes 5 words!
+    memSize _ = 3
 
 instance SafeCopy MD5Digest where
- -- use default Serialize instance (provided by the pureMD5 package)
+    -- use default Serialize instance
 
-{------------------------------------------------------------------------------
-  Lazy MD5 computation
-------------------------------------------------------------------------------}
+instance Ser.Serialize MD5Digest where
+    put (MD5Digest w1 w2) = Ser.putWord64be w1 >> Ser.putWord64be w2
+    get = MD5Digest <$> Ser.getWord64be <*> Ser.getWord64be
 
--- | Adapted from crypto-api
+
+-- We don't need a 'Binary' instance currently (previously, it was
+-- needed for md5DigestBytes), and SHA256Digest doesn't have one either
 --
--- This function is defined in crypto-api but not exported, and moreover
--- not lazy enough.
---
--- Guaranteed not to return an empty list
-makeBlocks :: ByteLength -> BS.Lazy.ByteString -> [BS.ByteString]
-makeBlocks len = go . BS.Lazy.toChunks
-  where
-    go :: [BS.ByteString] -> [BS.ByteString]
-    go [] = [BS.empty]
-    go (bs:bss)
-      | BS.length bs >= len =
-          let l = BS.length bs - BS.length bs `rem` len
-              (blocks, leftover) = BS.splitAt l bs
-          in blocks : go (leftover : bss)
-      | otherwise =
-          case bss of
-            []           -> [bs]
-            (bs' : bss') -> go (BS.append bs bs' : bss')
+-- instance Bin.Binary MD5Digest where
+--     put (MD5Digest w1 w2) = Bin.putWord64be w1 >> Bin.putWord64be w2
+--     get = MD5Digest <$> Bin.getWord64be <*> Bin.getWord64be
+
 
 -- | Compute the MD5 checksum of a lazy bytestring without reading the entire
 -- thing into memory
@@ -94,19 +109,32 @@ makeBlocks len = go . BS.Lazy.toChunks
 -- will run in constant memory.
 --
 lazyMD5 :: BS.Lazy.ByteString -> ByteStringWithMd5
-lazyMD5 = go initialCtx . makeBlocks blockLen
+lazyMD5 = go MD5.init . BS.Lazy.toChunks
   where
-    blockLen = (blockLength `Crypto.Util.for` (undefined :: MD5Digest)) `div` 8
-
-    go :: MD5Context
-       -> [BS.ByteString]
-       -> ByteStringWithMd5
-    go !md5ctx [lastBlock] =
-      BsChunk lastBlock $! (BsEndMd5 (finalize md5ctx lastBlock))
+    go :: MD5.Ctx -> [BS.ByteString] -> ByteStringWithMd5
+    go !md5ctx [] =
+      BsEndMd5 (md5digestFromBS (MD5.finalize md5ctx))
     go !md5ctx (block : blocks') =
-      BsChunk block (go (updateCtx md5ctx block) blocks')
-    go _ [] = error "impossible"
+      BsChunk block (go (MD5.update md5ctx block) blocks')
 
+-- | See 'lazyMD5'
 data ByteStringWithMd5 = BsChunk  !BS.ByteString ByteStringWithMd5
                        | BsEndMd5 !MD5Digest
 
+-- | Export 'MD5Digest' as raw 16-byte 'BS.ByteString' digest-value
+md5DigestBytes :: MD5Digest -> BS.ByteString
+md5DigestBytes =
+    toBs . putMD5Digest
+  where
+    putMD5Digest :: MD5Digest -> Bin.PutM ()
+    putMD5Digest (MD5Digest w1 w2) = Bin.putWord64be w1 >> Bin.putWord64be w2
+
+    toBs :: Bin.Put -> BS.ByteString
+#if MIN_VERSION_binary(0,8,3)
+    -- with later binary versions we can control the buffer size precisely:
+    toBs = BS.Lazy.toStrict
+         . BS.toLazyByteStringWith (BS.untrimmedStrategy 16 0) BS.Lazy.empty
+         . Bin.execPut
+#else
+    toBs = BS.Lazy.toStrict . Bin.runPut
+#endif

--- a/Distribution/Server/Features/Security/State.hs
+++ b/Distribution/Server/Features/Security/State.hs
@@ -13,7 +13,6 @@ import Data.SafeCopy
 import Data.Time
 import Data.Typeable
 import qualified Control.Monad.State  as State
-import qualified Crypto.Classes       as Crypto
 import qualified Data.ByteString.Lazy as BS.Lazy
 
 -- hackage

--- a/Distribution/Server/Framework/ResponseContentTypes.hs
+++ b/Distribution/Server/Framework/ResponseContentTypes.hs
@@ -1,4 +1,3 @@
-{-# LANGUAGE CPP                        #-}
 {-# LANGUAGE DeriveDataTypeable         #-}
 {-# LANGUAGE GeneralizedNewtypeDeriving #-}
 {-# LANGUAGE OverloadedStrings          #-}
@@ -32,15 +31,9 @@ import Happstack.Server
          ( ToMessage(..), Response(..), RsFlags(..), Length(NoContentLength), nullRsFlags, mkHeaders
          , noContentLength )
 
-import qualified Data.ByteString       as BS
 import qualified Data.ByteString.Lazy  as BS.Lazy
 import qualified Data.ByteString.Char8 as BS.Char8
-import qualified Data.Binary     as Binary
-import qualified Data.Binary.Put as Binary
 import qualified Data.ByteString.Base64 as Base64
-#if MIN_VERSION_binary(0,8,3)
-import Data.ByteString.Builder.Extra as BS
-#endif
 import Text.RSS (RSS)
 import qualified Text.RSS as RSS (rssToXML, showXML)
 import qualified Text.XHtml.Strict as XHtml (Html, showHtml)
@@ -157,20 +150,6 @@ instance ToMessage DocTarball where
 -- | Format an 'MD5Digest' in Base64 as required for the \"Content-MD5\" header.
 formatMD5Digest :: MD5Digest -> String
 formatMD5Digest = BS.Char8.unpack . Base64.encode . md5DigestBytes
-
-md5DigestBytes :: MD5Digest -> BS.ByteString
-md5DigestBytes =
-    toBs . Binary.put
-  where
-    toBs :: Binary.Put -> BS.ByteString
-#if MIN_VERSION_binary(0,8,3)
-    -- with later binary versions we can control the buffer size precisely:
-    toBs = BS.Lazy.toStrict
-         . BS.toLazyByteStringWith (BS.untrimmedStrategy 16 0) BS.Lazy.empty
-         . Binary.execPut
-#else
-    toBs = BS.Lazy.toStrict . Binary.runPut
-#endif
 
 formatLastModifiedTime :: UTCTime -> String
 formatLastModifiedTime = Time.formatTime defaultTimeLocale rfc822DateFormat

--- a/hackage-server.cabal
+++ b/hackage-server.cabal
@@ -301,8 +301,6 @@ executable hackage-server
     async      == 2.1.*,
     cereal     >= 0.4,
     safecopy   >= 0.8.3 && < 0.9,
-    crypto-api >= 0.12 && < 0.14,
-    pureMD5    >= 0.2,
     xhtml      >= 3000.1,
     aeson      >= 0.6.2,
     unordered-containers >= 0.2.3.0,
@@ -323,6 +321,7 @@ executable hackage-server
     xmlgen     >= 0.6,
     hackage-security >= 0.5.2 && < 0.6,
     ed25519,
+    cryptohash-md5    == 0.11.*,
     cryptohash-sha256 == 0.11.*,
     binary
 
@@ -581,10 +580,9 @@ Test-Suite HashTests
                     bytestring,
                     cereal,
                     containers,
-                    crypto-api,
+                    cryptohash-md5,
                     cryptohash-sha256,
                     deepseq,
-                    pureMD5,
                     safecopy,
                     text,
                     time,

--- a/tests/HashTestMain.hs
+++ b/tests/HashTestMain.hs
@@ -11,10 +11,6 @@ import qualified Data.ByteString.Lazy as BL
 import qualified Data.ByteString.Char8 as BC8
 import Data.Bits
 
-import qualified  Data.Binary      as Bin
-import qualified  Data.Binary.Get  as Bin
-import qualified  Data.Binary.Put  as Bin
-
 import qualified Data.Serialize as Ser
 
 import Distribution.Server.Util.ReadDigest
@@ -70,8 +66,9 @@ sha256tests = testGroup "Distribution.Server.Features.Security.SHA256"
 md5tests = testGroup "Distribution.Server.Features.Security.MD5"
     [ testGroup l
       [ testCase "Show"          $ show digest @?= hexref -- NB: w/o quotation marks
-      , testCase "Binary.put"    $ Bin.runPut (Bin.put digest) @?= hex2bs hexref
-      , testCase "Binary.get"    $ Bin.runGet (Bin.get :: Bin.Get MD5Digest) (hex2bs hexref) @?= digest
+      -- MD5Digest has no Binary instances anymore
+      -- , testCase "Binary.put"    $ Bin.runPut (Bin.put digest) @?= hex2bs hexref
+      -- , testCase "Binary.get"    $ Bin.runGet (Bin.get :: Bin.Get MD5Digest) (hex2bs hexref) @?= digest
       , testCase "Serialize.put" $ Ser.runPutLazy (Ser.put digest) @?= hex2bs hexref
       , testCase "Serialize.get" $ Ser.runGetLazy (Ser.get :: Ser.Get MD5Digest) (hex2bs hexref) @?= Right digest
       , testCase "readDigest"    $ readDigest hexref @?= Right digest


### PR DESCRIPTION
Most notably, this uses an space-optimal representation of MD5Digests:

  data MD5Digest = MD5Digest !Word64 !Word64

(`pureMD5` was only optimal for 32bit archs)