### PR TITLE
Optimise 'SHA256Digest' representation

### DIFF
--- a/Distribution/Server/Features/Security/SHA256.hs
+++ b/Distribution/Server/Features/Security/SHA256.hs
@@ -1,45 +1,60 @@
+{-# LANGUAGE BangPatterns #-}
+{-# LANGUAGE CPP          #-}
+
 -- | SHA256 digest
 module Distribution.Server.Features.Security.SHA256 (
     SHA256Digest
   , sha256
+
+  , sha256DigestBytes
   ) where
 
 -- stdlibs
-import Control.DeepSeq
-import Control.Monad
-import Data.SafeCopy
-import Data.Serialize
-import qualified Data.ByteString as BS
-import qualified Data.ByteString.Base16 as B16
-import qualified Data.ByteString.Char8 as BS.Char8
-import qualified Data.ByteString.Lazy as BS.Lazy
+import           Control.Applicative
+import           Control.DeepSeq
+import           Control.Monad
+import qualified Data.ByteString                       as BS
+import qualified Data.ByteString.Base16                as B16
+import           Data.SafeCopy
+import           Data.Serialize                        as Ser
+#if MIN_VERSION_binary(0,8,3)
+import           Data.ByteString.Builder.Extra         as BS
+#endif
+import qualified Data.Binary                           as Bin
+import qualified Data.Binary.Put                       as Bin
+import qualified Data.ByteString.Char8                 as BS.Char8
+import qualified Data.ByteString.Lazy                  as BS.Lazy
+import           Data.Word
 
 -- cryptohash
-import qualified Crypto.Hash.SHA256 as SHA256
+import qualified Crypto.Hash.SHA256                    as SHA256
 
 -- hackage
-import Distribution.Server.Framework.MemSize
-import Distribution.Server.Util.ReadDigest
+import           Distribution.Server.Framework.MemSize
+import           Distribution.Server.Util.ReadDigest
 
--- | SHA256 digest.
---
--- Internal invariant: @BS.length . sha256Digest == const 32@
-newtype SHA256Digest = SHA256Digest {
-    -- TODO: currently takes up 9 words on 64bit and uses pinned memory
-    --       could use ShortByteString instead, or
-    --
-    --  data SHA256Digest = SHA256Digest !Word64 !Word64 !Word64 !Word64
-    --
-    -- which would get us unpinned memory, and down to the optimum of
-    -- 5 Words on 64bit
-    sha256Digest :: BS.ByteString
-  }
-  deriving (Eq)
+-- | SHA256 digest
+data SHA256Digest = SHA256Digest {-# UNPACK #-} !Word64 {-# UNPACK #-} !Word64
+                                 {-# UNPACK #-} !Word64 {-# UNPACK #-} !Word64
+                  deriving (Eq)
 
--- | SHA256Digest is a @newtype@ wrapper around a 'BS.Bytestring' holding
--- the raw 32-byte SHA256 digest value; hence WHNF = NF.
 instance NFData SHA256Digest where
-  rnf digest = digest `seq` ()
+  rnf !_ = () -- 'SHA256Digest' has only strict primitive fields, hence WHNF==NF
+
+-- internal convenience helper
+-- fails if input has wrong length; callers must ensure correct length
+sha256digestFromBS :: BS.ByteString -> SHA256Digest
+sha256digestFromBS bs = case runGet getSHA256NoPfx bs of
+    Left  e -> error ("sha256digestFromBS: " ++ e)
+    Right d -> d
+
+-- | 'Data.Serialize.Get' helper to read a raw 32byte SHA256Digest w/o
+-- any length-prefix
+getSHA256NoPfx :: Get SHA256Digest
+getSHA256NoPfx = SHA256Digest <$> getWord64be
+                              <*> getWord64be
+                              <*> getWord64be
+                              <*> getWord64be
 
 -- | The 'Show' instance for 'SHA256Digest' prints the underlying digest
 -- (without showing the newtype wrapper)
@@ -47,7 +62,7 @@ instance NFData SHA256Digest where
 -- For legacy reasons, this instance emits the base16 encoded digest
 -- string without surrounding quotation marks
 instance Show SHA256Digest where
-  show = BS.Char8.unpack . B16.encode . sha256Digest
+  show = BS.Char8.unpack . B16.encode . sha256DigestBytes
 
 instance ReadDigest SHA256Digest where
   -- NOTE: This differs in an important way from the 'Serialize' instance:
@@ -55,24 +70,50 @@ instance ReadDigest SHA256Digest where
   readDigest str =
       case B16.decode (BS.Char8.pack str) of
           (d,rest) | BS.null rest
-                   , BS.length d == 32 -> Right $ SHA256Digest d
+                   , BS.length d == 32 -> Right $! sha256digestFromBS d
                    | otherwise         -> Left $ "Could not decode SHA256 " ++
                                                  show str
 
 -- | Compute SHA256 digest
 sha256 :: BS.Lazy.ByteString -> SHA256Digest
-sha256 = SHA256Digest . SHA256.hashlazy
+sha256 = sha256digestFromBS . SHA256.hashlazy
 
 instance MemSize SHA256Digest where
-  memSize _ = 9 -- memSize (Data.ByteString.replicate 32 0)
+  memSize _ = 5
 
 instance SafeCopy SHA256Digest where
   -- use default Serialize instance
 
--- For legacy reasons this length-prefixes the digest
+-- For legacy reasons this length-prefixes the serialised digest
 instance Serialize SHA256Digest where
-  put = put . sha256Digest
-  get = do bs <- get
-           unless (BS.length bs == 32) $
+  put (SHA256Digest w1 w2 w3 w4) =
+      do put (32 :: Int)
+         putWord64be w1
+         putWord64be w2
+         putWord64be w3
+         putWord64be w4
+
+  get = do lenpfx <- get
+           unless (lenpfx == (32 :: Int)) $
                fail "Bytestring of the wrong length"
-           return (SHA256Digest bs)
+           getSHA256NoPfx
+
+-- | Export 'SHA256Digest' as raw 16-byte 'BS.ByteString' digest-value
+sha256DigestBytes :: SHA256Digest -> BS.ByteString
+sha256DigestBytes =
+    toBs . putSHA256Digest
+  where
+    putSHA256Digest :: SHA256Digest -> Bin.PutM ()
+    putSHA256Digest (SHA256Digest w1 w2 w3 w4)
+        = Bin.putWord64be w1 >> Bin.putWord64be w2 >>
+          Bin.putWord64be w3 >> Bin.putWord64be w4
+
+    toBs :: Bin.Put -> BS.ByteString
+#if MIN_VERSION_binary(0,8,3)
+    -- with later binary versions we can control the buffer size precisely:
+    toBs = BS.Lazy.toStrict
+         . BS.toLazyByteStringWith (BS.untrimmedStrategy 32 0) BS.Lazy.empty
+         . Bin.execPut
+#else
+    toBs = BS.Lazy.toStrict . Bin.runPut
+#endif


### PR DESCRIPTION
This replaces a 32byte 'ByteString' by an unpacked strict product type
made up of four `Word64`s

This addresses the issue of `SHA256Digest` being pinned memory as well
as wasting heap-space.