### PR TITLE
Upgrade to safecopy-0.9.1 & Add support for GHC 8.0

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -35,6 +35,9 @@ matrix:
     - env: CABALVER=1.24 GHCVER=7.10.3
       compiler: ": #GHC 7.10.3"
       addons: {apt: {packages: [cabal-install-1.24,ghc-7.10.3,alex-3.1.7,happy-1.19.5], sources: [hvr-ghc]}}
+    - env: CABALVER=1.24 GHCVER=8.0.1
+      compiler: ": #GHC 8.0.1"
+      addons: {apt: {packages: [cabal-install-1.24,ghc-8.0.1,alex-3.1.7,happy-1.19.5], sources: [hvr-ghc]}}
 
 before_install:
  - unset CC

--- a/hackage-server.cabal
+++ b/hackage-server.cabal
@@ -26,7 +26,7 @@ license-file: LICENSE
 
 build-type: Simple
 cabal-version: >=1.10
-tested-with: GHC==7.10.3, GHC==7.8.4, GHC==7.6.3
+tested-with: GHC==8.0.1, GHC==7.10.3, GHC==7.8.4, GHC==7.6.3
 
 data-dir: datafiles
 data-files:
@@ -300,7 +300,7 @@ executable hackage-server
     tar        >= 0.4.5 && < 0.6,
     async      == 2.1.*,
     cereal     >= 0.4,
-    safecopy   >= 0.8.3 && < 0.9,
+    safecopy   >= 0.9.1 && < 0.10,
     crypto-api >= 0.12 && < 0.14,
     pureMD5    >= 0.2,
     xhtml      >= 3000.1,


### PR DESCRIPTION
This also extends the build-matrix to build/test with GHC 8.0

GHC 8.0 requires safecopy-0.9 or later

However, safecopy-0.9 also causes us to upgrade cereal from 0.4 to
version 0.5, which appears to have changed how some primitive types are
serialised. This requires further careful examination.