### PR TITLE
Prevent package README images from overflowing

### DIFF
--- a/datafiles/static/hackage.css
+++ b/datafiles/static/hackage.css
@@ -614,6 +614,10 @@ p.tip {
 */
 }
 
+.embedded-author-content img {
+  max-width: 100%;
+}
+
 /* Misc admin forms */
 
 form.box {


### PR DESCRIPTION
This limits package README `img` tags to 100% width, which prevents them
from overflowing. A screenshot:

![](http://i.imgur.com/hkv0Bqs.png)