### PR TITLE
Cache new documentation for short periods

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -5,5 +5,6 @@ dist
 tags
 *.swp
 .cabal-sandbox
+.stack-work
 cabal.sandbox.config
 TAGS


### PR DESCRIPTION
Previously, the cache time for all documentation was set to
one day. Cache it, instead, for as long as it's been since it
was last modified, but no less than ten minutes and no more than
a day. This takes into account the fact that documentation is
particularly likely to be modified soon after it was uploaded.