### PR TITLE
Perform full 'cabal check' on uploaded packages.

### DIFF
--- a/Distribution/Server/Packages/Unpack.hs
+++ b/Distribution/Server/Packages/Unpack.hs
@@ -27,7 +27,8 @@ import Distribution.PackageDescription.Parse
 import Distribution.PackageDescription.Configuration
          ( flattenPackageDescription )
 import Distribution.PackageDescription.Check
-         ( PackageCheck(..), checkPackage )
+         ( PackageCheck(..), checkPackage, CheckPackageContentOps(..)
+         , checkPackageContent )
 import Distribution.ParseUtils
          ( ParseResult(..), locatedErrorMsg, showPWarning )
 import Distribution.Text
@@ -53,10 +54,13 @@ import Data.Bits
 import Data.ByteString.Lazy
          ( ByteString )
 import qualified Data.ByteString.Lazy as LBS
+import qualified Data.ByteString.Lazy.Char8
 import Data.List
-         ( nub, (\\), partition, intercalate )
+         ( nub, (\\), partition, intercalate, isPrefixOf )
 import Data.Maybe
          ( isJust )
+import qualified Data.Map.Strict as Map
+         ( fromList, lookup )
 import Data.Time
          ( UTCTime(..), fromGregorian, addUTCTime )
 import Data.Time.Clock.POSIX
@@ -66,6 +70,9 @@ import System.FilePath
          ( (</>), (<.>), splitDirectories, splitExtension, normalise )
 import qualified System.FilePath.Windows
          ( takeFileName )
+import qualified System.FilePath.Posix
+         ( takeFileName, takeDirectory, addTrailingPathSeparator
+         , dropTrailingPathSeparator )
 import Text.Printf
          ( printf )
 
@@ -81,9 +88,10 @@ unpackPackage :: UTCTime -> FilePath -> ByteString
                         ((GenericPackageDescription, ByteString), [String])
 unpackPackage now tarGzFile contents =
   runUploadMonad $ do
-    (pkgDesc, warnings, cabalEntry) <- basicChecks False now tarGzFile contents
+    (pkgId, tarIndex) <- tarPackageChecks False now tarGzFile contents
+    (pkgDesc, warnings, cabalEntry) <- basicChecks pkgId tarIndex
     mapM_ throwError warnings
-    extraChecks pkgDesc
+    extraChecks pkgDesc pkgId tarIndex
     return (pkgDesc, cabalEntry)
 
 unpackPackageRaw :: FilePath -> ByteString
@@ -91,14 +99,15 @@ unpackPackageRaw :: FilePath -> ByteString
                            ((GenericPackageDescription, ByteString), [String])
 unpackPackageRaw tarGzFile contents =
   runUploadMonad $ do
-    (pkgDesc, _warnings, cabalEntry) <- basicChecks True noTime tarGzFile contents
+    (pkgId, tarIndex) <- tarPackageChecks True noTime tarGzFile contents
+    (pkgDesc, _warnings, cabalEntry) <- basicChecks pkgId tarIndex
     return (pkgDesc, cabalEntry)
   where
     noTime = UTCTime (fromGregorian 1970 1 1) 0
 
-basicChecks :: Bool -> UTCTime -> FilePath -> ByteString
-            -> UploadMonad (GenericPackageDescription, [String], ByteString)
-basicChecks lax now tarGzFile contents = do
+tarPackageChecks :: Bool -> UTCTime -> FilePath -> ByteString
+                 -> UploadMonad (PackageIdentifier, TarIndex)
+tarPackageChecks lax now tarGzFile contents = do
   let (pkgidStr, ext) = (base, tar ++ gz)
         where (tarFile, gz) = splitExtension (portableTakeFileName tarGzFile)
               (base,   tar) = splitExtension tarFile
@@ -125,14 +134,27 @@ basicChecks lax now tarGzFile contents = do
               $ Tar.read (GZip.decompressNamed tarGzFile contents)
       expectedDir = display pkgid
 
+      selectEntry entry = case Tar.entryContent entry of
+        Tar.NormalFile bs _         -> Just (normalise (Tar.entryPath entry), NormalFile bs)
+        Tar.Directory               -> Just (normalise (Tar.entryPath entry), Directory)
+        Tar.SymbolicLink linkTarget -> Just (normalise (Tar.entryPath entry), Link (Tar.fromLinkTarget linkTarget))
+        Tar.HardLink     linkTarget -> Just (normalise (Tar.entryPath entry), Link (Tar.fromLinkTarget linkTarget))
+        _                           -> Nothing
+  files <- selectEntries explainTarError selectEntry entries
+  return (pkgid, files)
+
+type TarIndex = [(FilePath, File)]
+data File = Directory | NormalFile ByteString | Link FilePath deriving Show
+
+basicChecks :: PackageIdentifier
+            -> TarIndex
+            -> UploadMonad (GenericPackageDescription, [String], ByteString)
+basicChecks pkgid tarIndex = do
   -- Extract the .cabal file from the tarball
-  let selectEntry entry = case Tar.entryContent entry of
-        Tar.NormalFile bs _ | cabalFileName == normalise (Tar.entryPath entry)
-                           -> Just bs
-        _                  -> Nothing
+  let cabalEntries = [ content | (fp, NormalFile content) <- tarIndex
+                               , fp == cabalFileName ]
       PackageName name  = packageName pkgid
       cabalFileName     = display pkgid </> name <.> "cabal"
-  cabalEntries <- selectEntries explainTarError selectEntry entries
   cabalEntry   <- case cabalEntries of
     -- NB: tar files *can* contain more than one entry for the same filename.
     -- (This was observed in practice with the package CoreErlang-0.0.1).
@@ -178,25 +200,72 @@ basicChecks lax now tarGzFile contents = do
 portableTakeFileName :: FilePath -> String
 portableTakeFileName = System.FilePath.Windows.takeFileName
 
--- Miscellaneous checks on package description
-extraChecks :: GenericPackageDescription -> UploadMonad ()
-extraChecks genPkgDesc = do
-  let pkgDesc = flattenPackageDescription genPkgDesc
-  -- various checks
+tarOps :: PackageIdentifier -> TarIndex -> CheckPackageContentOps UploadMonad
+tarOps pkgId tarIndex = CheckPackageContentOps {
+  doesFileExist        = fileExist    . relative,
+  doesDirectoryExist   = dirExist . relative . System.FilePath.Posix.addTrailingPathSeparator,
+  getDirectoryContents = dirContents . System.FilePath.Posix.dropTrailingPathSeparator . relative,
+  getFileContents      = fileContents . relative
+}
+  where
+    -- The tar index has names like <pkgid>/foo.cabal, but the
+    -- CheckPackageContentOps requests files without specifying the pkgid
+    -- root. We convert the requested file paths into the tar index format.
+    relative = normalise . (display pkgId </>)
+    -- Build the map. In case of multiple intries for a file, we want the
+    -- first entry in the tar file to win. Since the tarIndex is the reversed
+    -- tar file, we need to reverse it back.
+    fileMap = Map.fromList (reverse tarIndex)
 
-  --FIXME: do the content checks. The dev version of Cabal generalises
-  -- checkPackageContent to work in any monad, we just need to provide
-  -- a record of ops that will do checks inside the tarball. We should
-  -- gather a map of files and dirs and have these just to map lookups:
-  --
-  -- > checkTarballContents = CheckPackageContentOps {
-  -- >   doesFileExist      = Set.member fileMap,
-  -- >   doesDirectoryExist = Set.member dirsMap
-  -- > }
-  -- > fileChecks <- checkPackageContent checkTarballContents pkgDesc
+    resolvePath :: Int -> FilePath -> Either String (Maybe File)
+    resolvePath 0 path =
+      Left ("Too many links redirects when looking for file " ++ quote path)
+    resolvePath n path =
+      case Map.lookup path fileMap of
+        Just (Link fp) -> resolvePath (n-1) fp
+        Just entry -> Right (Just entry)
+        Nothing -> Right Nothing
+
+    fileExist path =
+      case resolvePath 10 path of
+        Left err -> throwError err
+        Right (Just NormalFile{}) -> return True
+        Right _ -> return False
+    dirExist path =
+      case resolvePath 10 path of
+        Left err -> throwError err
+        Right (Just Directory) -> return True
+        -- Some .tar files miss some directory entries, though it has files in
+        -- those directories. That's enough for the directory to be created,
+        -- thus we should consider it to exist.
+        _ -> return (any ((path `isPrefixOf`) . fst) tarIndex)
+    -- O(n). Only used once to find all .cabal files in the package root. Some
+    -- .tar files have duplicate entries for the same .cabal file, so we use
+    -- nub.
+    dirContents dir =
+      return (nub [ fileName
+                  | (fp, _) <- tarIndex
+                  , System.FilePath.Posix.takeDirectory fp == dir
+                  , let fileName = System.FilePath.Posix.takeFileName fp
+                  , fileName /= "" ])
+    fileContents path =
+      case Map.lookup path fileMap of
+        Just (NormalFile contents) ->
+          return (Data.ByteString.Lazy.Char8.unpack contents)
+        Just (Link fp) -> fileContents fp
+        _ -> throwError ("getFileContents: file does not exist: " ++ path)
+
+-- Miscellaneous checks on package description
+extraChecks :: GenericPackageDescription
+            -> PackageIdentifier
+            -> TarIndex
+            -> UploadMonad ()
+extraChecks genPkgDesc pkgId tarIndex = do
+  let pkgDesc = flattenPackageDescription genPkgDesc
+  fileChecks <- checkPackageContent (tarOps pkgId tarIndex) pkgDesc
 
   let pureChecks = checkPackage genPkgDesc (Just pkgDesc)
-      checks = pureChecks -- ++ fileChecks
+      checks = pureChecks ++ fileChecks
       isDistError (PackageDistSuspicious     {}) = False -- just a warning
       isDistError (PackageDistSuspiciousWarn {}) = False -- just a warning
       isDistError _                              = True

--- a/hackage-server.cabal
+++ b/hackage-server.cabal
@@ -53,6 +53,14 @@ data-files:
 
 extra-source-files:
   tests/permissions-tarballs/*.tar.gz
+  tests/unpack-checks/correct-package-0.1.0.0/LICENSE
+  tests/unpack-checks/correct-package-0.1.0.0/Main.hs
+  tests/unpack-checks/correct-package-0.1.0.0/Setup.hs
+  tests/unpack-checks/correct-package-0.1.0.0/correct-package.cabal
+  tests/unpack-checks/missing-configure-0.1.0.0/LICENSE
+  tests/unpack-checks/missing-configure-0.1.0.0/Main.hs
+  tests/unpack-checks/missing-configure-0.1.0.0/Setup.hs
+  tests/unpack-checks/missing-configure-0.1.0.0/missing-configure.cabal
 
 source-repository head
   type: git
@@ -552,6 +560,7 @@ Test-Suite PackageTests
     ghc-options:    -threaded -Wall -fno-warn-orphans
     build-depends:  base,
                     bytestring,
+                    containers,
                     filepath,
                     mtl,
                     tar,

--- a/tests/PackageTestMain.hs
+++ b/tests/PackageTestMain.hs
@@ -1,6 +1,13 @@
-module Main where
+module Main
+  ( main
+  ) where
 
-import qualified Codec.Archive.Tar       as Tar
+import Data.ByteString.Lazy (ByteString)
+import Data.Time (getCurrentTime)
+import Data.List (isInfixOf)
+
+import qualified Codec.Archive.Tar as Tar
+import qualified Codec.Compression.GZip as GZip
 import qualified Test.HUnit as HUnit
 
 import Distribution.Server.Packages.Unpack
@@ -8,31 +15,86 @@ import Distribution.Server.Packages.UnpackTest
 
 import Test.Framework
 import Test.Framework.Providers.HUnit
-import Test.HUnit ( Test(..) )
+import Test.HUnit (Test(..))
+
+main :: IO ()
+main = defaultMain $ hUnitTestToTests allTests
+
+allTests :: HUnit.Test
+allTests =
+  TestList
+    [ TestLabel "Tar file permissions" tarPermissions
+    , TestLabel "Cabal package integrity tests" cabalPackageCheckTests]
+
+tarPermissions :: HUnit.Test
+tarPermissions =
+  TestList
+    [ TestLabel
+        "Good Permissions"
+        (testPermissions "tests/permissions-tarballs/good-perms.tar.gz" goodMangler)
+    , TestLabel
+        "Bad File Permissions"
+        (testPermissions "tests/permissions-tarballs/bad-file-perms.tar.gz" badFileMangler)
+    , TestLabel
+        "Bad Dir Permissions"
+        (testPermissions "tests/permissions-tarballs/bad-dir-perms.tar.gz" badDirMangler)]
 
 goodMangler :: (Tar.Entry -> Maybe CombinedTarErrs)
 goodMangler = const Nothing
+
 badFileMangler :: (Tar.Entry -> Maybe CombinedTarErrs)
-badFileMangler entry = case Tar.entryContent entry of
+badFileMangler entry =
+  case Tar.entryContent entry of
     (Tar.NormalFile _ _) -> Just $ PermissionsError (Tar.entryPath entry) 0o600
     _ -> Nothing
+
 badDirMangler :: (Tar.Entry -> Maybe CombinedTarErrs)
-badDirMangler entry = case Tar.entryContent entry of
-    (Tar.Directory) -> Just $ PermissionsError (Tar.entryPath entry) 0o700
+badDirMangler entry =
+  case Tar.entryContent entry of
+    Tar.Directory -> Just $ PermissionsError (Tar.entryPath entry) 0o700
     _ -> Nothing
 
-goodTest :: HUnit.Test
-goodTest = testPermissions "tests/permissions-tarballs/good-perms.tar.gz" goodMangler
-badFileTest :: HUnit.Test
-badFileTest = testPermissions "tests/permissions-tarballs/bad-file-perms.tar.gz" badFileMangler
-badDirTest :: HUnit.Test
-badDirTest = testPermissions "tests/permissions-tarballs/bad-dir-perms.tar.gz" badDirMangler
+cabalPackageCheckTests :: HUnit.Test
+cabalPackageCheckTests =
+  TestList
+    [ TestLabel "Missing ./configure script" missingConfigureScriptTest
+    , TestLabel "Missing directories in tar file" missingDirsInTarFileTest]
 
-tests :: HUnit.Test
-tests = TestList [
-      TestLabel "Good Permissions" goodTest
-    , TestLabel "Bad File Permissions" badFileTest
-    , TestLabel "Bad Dir Permissions" badDirTest ]
+missingConfigureScriptTest :: HUnit.Test
+missingConfigureScriptTest =
+  TestCase $
+  do tar <- tarGzFile "missing-configure-0.1.0.0"
+     now <- getCurrentTime
+     case unpackPackage now "missing-configure-0.1.0.0.tar.gz" tar of
+       Right _ -> HUnit.assertFailure "expected error"
+       Left err ->
+         HUnit.assertBool
+           ("Error found, but not about missing ./configure: " ++ err)
+           ("The 'build-type' is 'Configure'" `isInfixOf` err)
 
-main :: IO ()
-main = defaultMain $ hUnitTestToTests tests
+-- | Some tar files in hackage are missing directory entries.
+-- Ensure that they can be verified even without the directory entries.
+missingDirsInTarFileTest :: HUnit.Test
+missingDirsInTarFileTest =
+  TestCase $
+  do tar <- fmap keepOnlyFiles (tarGzFile "correct-package-0.1.0.0")
+     now <- getCurrentTime
+     case unpackPackage now "correct-package-0.1.0.0.tar.gz" tar of
+       Right _ -> return ()
+       Left err ->
+         HUnit.assertFailure ("Excpected success but got: " ++ show err)
+
+tarGzFile :: String -> IO ByteString
+tarGzFile name = do
+  entries <- Tar.pack "tests/unpack-checks" [name]
+  return (GZip.compress (Tar.write entries))
+
+-- | Remove all Tar.Entries that are not files.
+keepOnlyFiles :: ByteString -> ByteString
+keepOnlyFiles = GZip.compress . Tar.write . f . Tar.read . GZip.decompress
+  where
+    f = reverse . Tar.foldEntries step [] (error . show)
+    step e acc =
+      case Tar.entryContent e of
+        Tar.NormalFile {} -> e : acc
+        _ -> acc

--- a/tests/unpack-checks/correct-package-0.1.0.0/LICENSE
+++ b/tests/unpack-checks/correct-package-0.1.0.0/LICENSE
@@ -1,0 +1,30 @@
+Copyright (c) 2016, Hackage Server Team
+
+All rights reserved.
+
+Redistribution and use in source and binary forms, with or without
+modification, are permitted provided that the following conditions are met:
+
+    * Redistributions of source code must retain the above copyright
+      notice, this list of conditions and the following disclaimer.
+
+    * Redistributions in binary form must reproduce the above
+      copyright notice, this list of conditions and the following
+      disclaimer in the documentation and/or other materials provided
+      with the distribution.
+
+    * Neither the name of Hackage Server Team nor the names of other
+      contributors may be used to endorse or promote products derived
+      from this software without specific prior written permission.
+
+THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
+"AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
+LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR
+A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT
+OWNER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL,
+SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT
+LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE,
+DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY
+THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+(INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.

--- a/tests/unpack-checks/correct-package-0.1.0.0/Main.hs
+++ b/tests/unpack-checks/correct-package-0.1.0.0/Main.hs
@@ -1,0 +1,4 @@
+module Main where
+
+main :: IO ()
+main = putStrLn "Hello, Haskell!"

--- a/tests/unpack-checks/correct-package-0.1.0.0/Setup.hs
+++ b/tests/unpack-checks/correct-package-0.1.0.0/Setup.hs
@@ -1,0 +1,2 @@
+import Distribution.Simple
+main = defaultMain

--- a/tests/unpack-checks/correct-package-0.1.0.0/correct-package.cabal
+++ b/tests/unpack-checks/correct-package-0.1.0.0/correct-package.cabal
@@ -1,0 +1,16 @@
+name:                correct-package
+version:             0.1.0.0
+synopsis:            Synopsis
+description:         Description
+license:             BSD3
+license-file:        LICENSE
+author:              Hackage Server Team
+maintainer:          no@email.com
+category:            Test case
+build-type:          Simple
+cabal-version:       >=1.10
+
+executable correct-package
+  main-is:             Main.hs
+  build-depends:       base >=4.9 && <4.10
+  default-language:    Haskell2010

--- a/tests/unpack-checks/missing-configure-0.1.0.0/LICENSE
+++ b/tests/unpack-checks/missing-configure-0.1.0.0/LICENSE
@@ -1,0 +1,30 @@
+Copyright (c) 2016, Hackage Server Team
+
+All rights reserved.
+
+Redistribution and use in source and binary forms, with or without
+modification, are permitted provided that the following conditions are met:
+
+    * Redistributions of source code must retain the above copyright
+      notice, this list of conditions and the following disclaimer.
+
+    * Redistributions in binary form must reproduce the above
+      copyright notice, this list of conditions and the following
+      disclaimer in the documentation and/or other materials provided
+      with the distribution.
+
+    * Neither the name of Hackage Server Team nor the names of other
+      contributors may be used to endorse or promote products derived
+      from this software without specific prior written permission.
+
+THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
+"AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
+LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR
+A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT
+OWNER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL,
+SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT
+LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE,
+DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY
+THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+(INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.

--- a/tests/unpack-checks/missing-configure-0.1.0.0/Main.hs
+++ b/tests/unpack-checks/missing-configure-0.1.0.0/Main.hs
@@ -1,0 +1,4 @@
+module Main where
+
+main :: IO ()
+main = putStrLn "Hello, Haskell!"

--- a/tests/unpack-checks/missing-configure-0.1.0.0/Setup.hs
+++ b/tests/unpack-checks/missing-configure-0.1.0.0/Setup.hs
@@ -1,0 +1,2 @@
+import Distribution.Simple
+main = defaultMain

--- a/tests/unpack-checks/missing-configure-0.1.0.0/missing-configure.cabal
+++ b/tests/unpack-checks/missing-configure-0.1.0.0/missing-configure.cabal
@@ -1,0 +1,16 @@
+name:                missing-configure
+version:             0.1.0.0
+synopsis:            Synopsis
+description:         Description
+license:             BSD3
+license-file:        LICENSE
+author:              Hackage Server Team
+maintainer:          no@email.com
+category:            Test case
+build-type:          Configure
+cabal-version:       >=1.10
+
+executable missing-configure
+  main-is:             Main.hs
+  build-depends:       base >=4.9 && <4.10
+  default-language:    Haskell2010


### PR DESCRIPTION
Previously only part of the 'cabal checks' were performed.
With this patch we'll also check for;
 - cabal BOM error (unicode error in .cabal)
 - license file errors
 - missing setup files
 - missing ./configure file
 - missing local paths
 - missing source control info

I've ran these new checks on the latest version of all packages on hackage;
 - 171 packages refer to missing hs-source-dirs.
 - 4 packages refer to missing include-dirs.
 - 2 packages refer to full path extra-lib-dirs that doesn't exist on linux;
     - al-0.1.4.1: 'extra-lib-dirs: C:\Program Files (x86)\OpenAL 1.1 SDK\libs\Win64' directory does not exist.
     - Win32-services: 'extra-lib-dirs: c:\Windows\System32' directory does not exist.
 - 2 packages have multiple .cabal files in the package root.

This fixes #490.