### PR TITLE
Implement API Key authorization

### DIFF
--- a/Distribution/Server/Features/Html.hs
+++ b/Distribution/Server/Features/Html.hs
@@ -723,6 +723,9 @@ mkHtmlUsers UserFeature{..} UserDetailsFeature{..} = HtmlUsers{..}
                 [ toHtml $ display uname ++ " is part of the following groups:"
                 , unordList uriPairs
                 ]
+        , hr
+        , anchor ! [href $ manageUserUri users "" uname] <<
+            "Click here to manage this account"
         ]
 
     addUserForm :: DynamicPath -> ServerPartE Response

--- a/Distribution/Server/Features/UserSignup.hs
+++ b/Distribution/Server/Features/UserSignup.hs
@@ -404,8 +404,7 @@ userSignupFeature ServerEnv{serverBaseURI, serverCron}
 
     nonceInPath :: MonadPlus m => DynamicPath -> m Nonce
     nonceInPath dpath =
-        do raw <- maybe mzero return (lookup "nonce" dpath)
-           parseNonceM raw
+        maybe mzero return (lookup "nonce" dpath >>= parseNonceM)
 
     lookupSignupInfo :: Nonce -> ServerPartE SignupResetInfo
     lookupSignupInfo nonce = querySignupInfo nonce

--- a/Distribution/Server/Features/UserSignup.hs
+++ b/Distribution/Server/Features/UserSignup.hs
@@ -5,7 +5,7 @@ module Distribution.Server.Features.UserSignup (
     initUserSignupFeature,
     UserSignupFeature(..),
     SignupResetInfo(..),
-    
+
     accountSuitableForPasswordReset
   ) where
 
@@ -20,6 +20,7 @@ import Distribution.Server.Features.UserDetails
 
 import Distribution.Server.Users.Group
 import Distribution.Server.Users.Types
+import Distribution.Server.Util.Nonce
 import qualified Distribution.Server.Users.Users as Users
 
 import Data.Map (Map)
@@ -101,9 +102,6 @@ data SignupResetInfo = SignupInfo {
 newtype SignupResetTable = SignupResetTable (Map Nonce SignupResetInfo)
   deriving (Eq, Show, Typeable, MemSize)
 
-newtype Nonce = Nonce ByteString
-  deriving (Eq, Ord, Show, Typeable, MemSize)
-
 emptySignupResetTable :: SignupResetTable
 emptySignupResetTable = SignupResetTable Map.empty
 
@@ -113,20 +111,6 @@ instance MemSize SignupResetInfo where
 
 $(deriveSafeCopy 0 'base ''SignupResetInfo)
 $(deriveSafeCopy 0 'base ''SignupResetTable)
-$(deriveSafeCopy 0 'base ''Nonce)
-
-------------------------------
--- Nonces
---
-
-newRandomNonce :: IO Nonce
-newRandomNonce = do
-  raw <- withFile "/dev/urandom" ReadMode $ \h ->
-           BS.hGet h 10
-  return $! Nonce (Base16.encode raw)
-
-renderNonce :: Nonce -> String
-renderNonce (Nonce nonce) = BS.unpack nonce
 
 ------------------------------
 -- State queries and updates
@@ -226,8 +210,8 @@ importSignupInfo = sequence . map fromRecord . drop 2
     fromRecord :: Record -> Restore (Nonce, SignupResetInfo)
     fromRecord [nonceStr, usernameStr, realnameStr, emailStr, timestampStr] = do
         timestamp <- parseUTCTime "timestamp" timestampStr
-        let nonce      = Nonce (BS.pack nonceStr)
-            signupinfo = SignupInfo {
+        nonce <- parseNonceM nonceStr
+        let signupinfo = SignupInfo {
               signupUserName     = T.pack usernameStr,
               signupRealName     = T.pack realnameStr,
               signupContactEmail = T.pack emailStr,
@@ -259,8 +243,8 @@ importResetInfo = sequence . map fromRecord . drop 2
     fromRecord [nonceStr, useridStr, timestampStr] = do
         userid <- parseText "userid" useridStr
         timestamp <- parseUTCTime "timestamp" timestampStr
-        let nonce      = Nonce (BS.pack nonceStr)
-            signupinfo = ResetInfo {
+        nonce <- parseNonceM nonceStr
+        let signupinfo = ResetInfo {
               resetUserId    = userid,
               nonceTimestamp = timestamp
             }
@@ -289,7 +273,7 @@ initUserSignupFeature :: ServerEnv
                           -> UserDetailsFeature
                           -> UploadFeature
                           -> IO UserSignupFeature)
-initUserSignupFeature env@ServerEnv{ serverStateDir, serverTemplatesDir, 
+initUserSignupFeature env@ServerEnv{ serverStateDir, serverTemplatesDir,
                                      serverTemplatesMode } = do
     -- Canonical state
     signupResetState <- signupResetStateComponent serverStateDir
@@ -419,7 +403,9 @@ userSignupFeature ServerEnv{serverBaseURI, serverCron}
     --
 
     nonceInPath :: MonadPlus m => DynamicPath -> m Nonce
-    nonceInPath dpath = maybe mzero return (Nonce . BS.pack <$> lookup "nonce" dpath)
+    nonceInPath dpath =
+        do raw <- maybe mzero return (lookup "nonce" dpath)
+           parseNonceM raw
 
     lookupSignupInfo :: Nonce -> ServerPartE SignupResetInfo
     lookupSignupInfo nonce = querySignupInfo nonce
@@ -445,7 +431,7 @@ userSignupFeature ServerEnv{serverBaseURI, serverCron}
 
         (username, realname, useremail) <- lookUserNameEmail
 
-        nonce     <- liftIO newRandomNonce
+        nonce     <- liftIO (newRandomNonce 10)
         timestamp <- liftIO getCurrentTime
         let signupInfo = SignupInfo {
               signupUserName     = username,
@@ -591,7 +577,7 @@ userSignupFeature ServerEnv{serverBaseURI, serverCron}
         guardEmailMatches mudetails supplied_useremail
         AccountDetails{..} <- guardSuitableAccountType uinfo mudetails
 
-        nonce     <- liftIO newRandomNonce
+        nonce     <- liftIO (newRandomNonce 10)
         timestamp <- liftIO getCurrentTime
         let resetInfo = ResetInfo {
               resetUserId    = uid,
@@ -701,4 +687,3 @@ accountSuitableForPasswordReset
     (AccountDetails { accountKind = Just AccountKindRealUser })
                                     = True
 accountSuitableForPasswordReset _ _ = False
-

--- a/Distribution/Server/Features/Users.hs
+++ b/Distribution/Server/Features/Users.hs
@@ -518,7 +518,7 @@ userFeature templates usersState adminsState
       guardAuthorised_ [IsUserId uid, InGroup adminGroup]
       action <- look "action"
       case action of
-        "new-auth-key" -> do
+        "new-auth-token" -> do
           origTok <- liftIO generateOriginalToken
           let storeTok = convertToken origTok
           desc <- T.pack <$> look "description"
@@ -532,8 +532,8 @@ userFeature templates usersState adminsState
               ]
             Just Users.ErrNoSuchUserId ->
               errInternalError [MText "uid does not exist"]
-        "revoke-auth-key" -> do
-          authToken <- parseAuthToken . T.pack <$> look "auth-key"
+        "revoke-auth-token" -> do
+          authToken <- parseAuthToken . T.pack <$> look "auth-token"
           case authToken of
             Left err ->
               errBadRequest "Bad auth token"

--- a/Distribution/Server/Features/Users.hs
+++ b/Distribution/Server/Features/Users.hs
@@ -11,6 +11,7 @@ module Distribution.Server.Features.Users (
 
 import Distribution.Server.Framework
 import Distribution.Server.Framework.BackupDump
+import Distribution.Server.Framework.Templating
 import qualified Distribution.Server.Framework.Auth as Auth
 
 import Distribution.Server.Users.Types
@@ -154,6 +155,8 @@ data UserResource = UserResource {
     enabledResource  :: Resource,
     -- | The admin group.
     adminResource :: GroupResource,
+    -- | Manage a user
+    manageUserResource :: Resource,
 
     -- | URI for `userList` given a format.
     userListUri :: String -> String,
@@ -164,7 +167,9 @@ data UserResource = UserResource {
     -- | URI for `enabledResource` given a format and name.
     userEnabledUri  :: String -> UserName -> String,
     -- | URI for `adminResource` given a format.
-    adminPageUri :: String -> String
+    adminPageUri :: String -> String,
+    -- | URI for `manageUserResource` give a format and name
+    manageUserUri :: String -> UserName -> String
 }
 
 instance FromReqURI UserName where
@@ -195,7 +200,7 @@ instance MemSize GroupIndex where
 
 -- TODO: add renaming
 initUserFeature :: ServerEnv -> IO (IO UserFeature)
-initUserFeature ServerEnv{serverStateDir} = do
+initUserFeature ServerEnv{serverStateDir, serverTemplatesDir, serverTemplatesMode} = do
   -- Canonical state
   usersState  <- usersStateComponent  serverStateDir
   adminsState <- adminsStateComponent serverStateDir
@@ -208,6 +213,13 @@ initUserFeature ServerEnv{serverStateDir} = do
   authFailHook  <- newHook
   groupChangedHook <- newHook
 
+  -- Load templates
+  templates <-
+      loadTemplates serverTemplatesMode
+      [serverTemplatesDir, serverTemplatesDir </> "Users"]
+      [ "manage.html", "token-created.html", "token-revoked.html"
+      ]
+
   return $ do
     -- Slightly tricky: we have an almost recursive knot between the group
     -- resource management functions, and creating the admin group
@@ -216,7 +228,8 @@ initUserFeature ServerEnv{serverStateDir} = do
     -- Instead of trying to pull it apart, we just use a 'do rec'
     --
     rec let (feature@UserFeature{groupResourceAt}, adminGroupDesc)
-              = userFeature usersState
+              = userFeature templates
+                            usersState
                             adminsState
                             groupIndex
                             userAdded authFailHook groupChangedHook
@@ -253,7 +266,8 @@ adminsStateComponent stateDir = do
     , resetState   = adminsStateComponent
     }
 
-userFeature :: StateComponent AcidState Users.Users
+userFeature :: Templates
+            -> StateComponent AcidState Users.Users
             -> StateComponent AcidState HackageAdmins
             -> MemState GroupIndex
             -> Hook () ()
@@ -262,7 +276,7 @@ userFeature :: StateComponent AcidState Users.Users
             -> UserGroup
             -> GroupResource
             -> (UserFeature, UserGroup)
-userFeature  usersState adminsState
+userFeature templates usersState adminsState
              groupIndex userAdded authFailHook groupChangedHook
              adminGroup adminResource
   = (UserFeature {..}, adminGroupDesc)
@@ -275,6 +289,7 @@ userFeature  usersState adminsState
             , userPage
             , passwordResource
             , enabledResource
+            , manageUserResource
             ]
           ++ [
               groupResource adminResource
@@ -306,6 +321,14 @@ userFeature  usersState adminsState
           , resourcePut    = [ ("", serveUserPut) ]
           , resourceDelete = [ ("", serveUserDelete) ]
           }
+      , manageUserResource =
+              (resourceAt "/user/:username/manage.:format")
+              { resourceDesc =
+                      [ (GET, "user management page")
+                      ]
+              , resourceGet = [ ("", serveUserManagement) ]
+              , resourcePost = [ ("", runUserManagementAction)]
+              }
       , passwordResource = resourceAt "/user/:username/password.:format"
                            --TODO: PUT
       , enabledResource  = (resourceAt "/user/:username/enabled.:format") {
@@ -328,6 +351,8 @@ userFeature  usersState adminsState
           renderResource (enabledResource  r) [display uname, format]
       , adminPageUri = \format ->
           renderResource (groupResource adminResource) [format]
+      , manageUserUri = \format uname ->
+          renderResource (manageUserResource r) [display uname, format]
       }
 
     -- Queries and updates
@@ -467,6 +492,66 @@ userFeature  usersState adminsState
         Just (Right Users.ErrDeletedUser) ->
           errBadRequest "User deleted"
             [MText "Cannot disable account, it has already been deleted"]
+
+    serveUserManagement :: DynamicPath -> ServerPartE Response
+    serveUserManagement dpath =
+        do (UserName username) <- userNameInPath dpath
+           uid <- lookupUserName (UserName username)
+           guardAuthorised [IsUserId uid, InGroup adminGroup]
+           userInfo <- lookupUserInfo uid
+           let (UserTokenMap knownTokens) = userTokens userInfo
+           template <- getTemplate templates "manage.html"
+           let mkTok (t, desc) =
+                   templateDict
+                   [ templateVal "hash" (display t)
+                   , templateVal "description" desc
+                   ]
+           ok $ toResponse $ template
+               [ "username" $= username
+               , "tokens" $= map mkTok (Map.toList knownTokens)
+               ]
+
+    runUserManagementAction :: DynamicPath -> ServerPartE Response
+    runUserManagementAction dpath =
+        do (UserName username) <- userNameInPath dpath
+           uid <- lookupUserName (UserName username)
+           guardAuthorised [IsUserId uid, InGroup adminGroup]
+           action <- look "action"
+           case action of
+             "new-auth-key" ->
+                 do origTok <- liftIO generateOriginalToken
+                    let storeTok = convertToken origTok
+                    desc <- T.pack <$> look "description"
+                    res <- updateState usersState (AddAuthToken uid storeTok desc)
+                    template <- getTemplate templates "token-created.html"
+                    case res of
+                        Nothing ->
+                            ok $ toResponse $ template
+                            [ "username" $= username
+                            , "token" $= viewOriginalToken origTok
+                            ]
+                        Just Users.ErrNoSuchUserId ->
+                            errInternalError [MText "uid does not exist"]
+             "revoke-auth-key" ->
+                 do authToken <- parseAuthToken . T.pack <$> look "auth-key"
+                    case authToken of
+                      Left err ->
+                          fail $ "Bad auth token: " ++ err
+                      Right at ->
+                          do res <-
+                                 updateState usersState (RevokeAuthToken uid at)
+                             template <- getTemplate templates "token-revoked.html"
+                             case res of
+                               Nothing ->
+                                   ok $ toResponse $ template
+                                   [ "username" $= username
+                                   ]
+                               Just (Left Users.ErrNoSuchUserId) ->
+                                   errInternalError [MText "uid does not exist"]
+                               Just (Right Users.ErrTokenNotOwned) ->
+                                   errBadRequest "Token not owned"
+                                   [MText "Cannot revoke this token, wrong owner!"]
+             _ -> fail "Fatal error: missing implementation for this action"
 
     --
     --  Exported utils for looking up user names in URLs\/paths

--- a/Distribution/Server/Framework/Auth.hs
+++ b/Distribution/Server/Framework/Auth.hs
@@ -53,6 +53,7 @@ import qualified Data.Map as Map
 import qualified Text.ParserCombinators.ReadP as Parse
 import Data.Maybe (listToMaybe)
 import Data.List  (intercalate)
+import qualified Data.Text.Encoding as T
 
 
 ------------------------------------------------------------------------
@@ -104,7 +105,8 @@ checkAuthenticated realm users = do
     return $ case getHeaderAuth req of
       Just (BasicAuth,  ahdr) -> checkBasicAuth  users realm ahdr
       Just (DigestAuth, ahdr) -> checkDigestAuth users       ahdr req
-      Nothing                 -> Left NoAuthError
+      Just (KeyAuth, ahdr) -> checkKeyAuth users ahdr
+      Nothing -> Left NoAuthError
   where
     getHeaderAuth :: Request -> Maybe (AuthType, BS.ByteString)
     getHeaderAuth req =
@@ -112,12 +114,13 @@ checkAuthenticated realm users = do
           Just hdr
             |  BS.isPrefixOf (BS.pack "Digest ") hdr
             -> Just (DigestAuth, BS.drop 7 hdr)
-
+            |  BS.isPrefixOf (BS.pack "ApiKey ") hdr
+            -> Just (KeyAuth, BS.drop 7 hdr)
             |  BS.isPrefixOf (BS.pack "Basic ") hdr
             -> Just (BasicAuth,  BS.drop 6 hdr)
           _ -> Nothing
 
-data AuthType = BasicAuth | DigestAuth
+data AuthType = BasicAuth | DigestAuth | KeyAuth
 
 
 data PrivilegeCondition = InGroup    Group.UserGroup
@@ -155,6 +158,20 @@ checkPriviledged users uid (IsUserId uid':others) =
 
 checkPriviledged _ _ (AnyKnownUser:_) = return True
 
+------------------------------------------------------------------------
+-- Key auth method
+--
+
+-- | Handle a key auth request
+checkKeyAuth :: Users.Users -> BS.ByteString -> Either AuthError (UserId, UserInfo)
+checkKeyAuth users ahdr =
+    do parsedToken <-
+           case Users.parseAuthToken (T.decodeUtf8 ahdr) of
+             Left _ -> Left BadApiKeyError -- TODO: should we display more infos?
+             Right ok -> Right ok
+       (uid, uinfo) <- Users.lookupAuthToken parsedToken users ?! BadApiKeyError
+       _ <- getUserAuth uinfo ?! UserStatusError uid uinfo
+       return (uid, uinfo)
 
 ------------------------------------------------------------------------
 -- Basic auth method
@@ -331,6 +348,7 @@ data AuthError = NoAuthError
                | NoSuchUserError       UserName
                | UserStatusError       UserId UserInfo
                | PasswordMismatchError UserId UserInfo
+               | BadApiKeyError
   deriving Show
 
 authErrorResponse :: MonadIO m => RealmName -> AuthError -> m ErrorResponse
@@ -345,7 +363,9 @@ authErrorResponse realm autherr = do
     toErrorResponse UnrecognizedAuthError =
       ErrorResponse 400 [] "Authorization scheme not recognized" []
 
+    toErrorResponse BadApiKeyError =
+      ErrorResponse 401 [] "Bad api key" []
+
     -- we don't want to leak info for the other cases, so same message for them all:
     toErrorResponse _ =
       ErrorResponse 401 [] "Username or password incorrect" []
-

--- a/Distribution/Server/Framework/Auth.hs
+++ b/Distribution/Server/Framework/Auth.hs
@@ -166,9 +166,9 @@ checkPriviledged _ _ (AnyKnownUser:_) = return True
 checkKeyAuth :: Users.Users -> BS.ByteString -> Either AuthError (UserId, UserInfo)
 checkKeyAuth users ahdr =
     do parsedToken <-
-           case Users.parseAuthToken (T.decodeUtf8 ahdr) of
+           case Users.parseOriginalToken (T.decodeUtf8 ahdr) of
              Left _ -> Left BadApiKeyError -- TODO: should we display more infos?
-             Right ok -> Right ok
+             Right ok -> Right (Users.convertToken ok)
        (uid, uinfo) <- Users.lookupAuthToken parsedToken users ?! BadApiKeyError
        _ <- getUserAuth uinfo ?! UserStatusError uid uinfo
        return (uid, uinfo)

--- a/Distribution/Server/Framework/MemSize.hs
+++ b/Distribution/Server/Framework/MemSize.hs
@@ -20,6 +20,7 @@ import Data.Sequence (Seq)
 import qualified Data.Foldable as Foldable
 import qualified Data.ByteString as BS
 import qualified Data.ByteString.Lazy as LBS
+import qualified Data.ByteString.Short as BSS
 import qualified Data.Text as T
 import Data.Time (UTCTime, Day)
 import Data.Ix
@@ -159,6 +160,11 @@ instance MemSize a => MemSize (Seq a) where
 instance MemSize BS.ByteString where
   memSize s = let (w,t) = divMod (BS.length s) wordSize
                in 5 + w + signum t
+
+instance MemSize BSS.ShortByteString where
+  memSize s =
+      let (w,t) = divMod (BSS.length s) wordSize
+      in 5 + w + signum t
 
 instance MemSize LBS.ByteString where
   memSize s = sum [ 1 + memSize c | c <- LBS.toChunks s ]

--- a/Distribution/Server/Users/AuthToken.hs
+++ b/Distribution/Server/Users/AuthToken.hs
@@ -1,17 +1,17 @@
 {-# LANGUAGE DeriveDataTypeable, GeneralizedNewtypeDeriving, TemplateHaskell #-}
 {-# LANGUAGE TypeFamilies #-}
 module Distribution.Server.Users.AuthToken
-    ( AuthToken(..)
-    , parseAuthToken
-    , OriginalToken(..)
+    ( AuthToken
+    , parseAuthToken, parseAuthTokenM, renderAuthToken
+    , OriginalToken
     , convertToken, viewOriginalToken, generateOriginalToken
     , parseOriginalToken
     )
 where
 
 import Distribution.Server.Framework.MemSize
+import Distribution.Server.Util.Nonce
 
-import System.Random.MWC
 import Distribution.Text
          ( Text(..) )
 import qualified Distribution.Compat.ReadP as Parse
@@ -21,31 +21,32 @@ import qualified Data.Text as T
 import qualified Data.Text.Encoding as T
 import qualified Data.Vector as V
 import qualified Data.ByteString as BS
+import qualified Data.ByteString.Short as BSS
 import qualified Data.ByteString.Base16 as BS16
 import qualified Crypto.Hash.SHA256 as SHA256
 
 import Control.Applicative ((<$>))
 import Data.Aeson (ToJSON, FromJSON)
-import Data.SafeCopy (base, deriveSafeCopy)
+import Data.SafeCopy
 import Data.Typeable (Typeable)
 
 -- | Contains the original token which will be shown to the user
 -- once and is NOT stored on the server. The user is expected
 -- to provide this token on each request that should be
 -- authed by it
-newtype OriginalToken = OriginalToken BS.ByteString
+newtype OriginalToken = OriginalToken Nonce
     deriving (Eq, Ord, Show, Typeable)
 
 -- | Contains a hash of the original token
-newtype AuthToken = AuthToken T.Text
-    deriving (Eq, Ord, Read, Show, Typeable, MemSize, ToJSON, FromJSON)
+newtype AuthToken = AuthToken BSS.ShortByteString
+    deriving (Eq, Ord, Read, Show, Typeable, MemSize)
 
 convertToken :: OriginalToken -> AuthToken
 convertToken (OriginalToken bs) =
-    AuthToken $ T.decodeUtf8 $ BS16.encode (SHA256.hash bs)
+    AuthToken $ BSS.toShort $ SHA256.hash $ getRawNonceBytes bs
 
 viewOriginalToken :: OriginalToken -> T.Text
-viewOriginalToken (OriginalToken ot) = T.decodeUtf8 . BS16.encode $ ot
+viewOriginalToken (OriginalToken ot) = T.pack $ renderNonce ot
 
 -- | Generate a random 32 byte auth token. The token is represented as
 -- in textual base16 way so it can easily be printed and parsed.
@@ -53,30 +54,36 @@ viewOriginalToken (OriginalToken ot) = T.decodeUtf8 . BS16.encode $ ot
 -- calls 'withSystemRandom' for each token, but for the current
 -- use case we only generate tokens infrequently so this should be fine.
 generateOriginalToken :: IO OriginalToken
-generateOriginalToken =
-    do randomBytes <-
-           BS.pack . V.toList <$>
-           (withSystemRandom . asGenIO) (`uniformVector` 32)
-       return (OriginalToken randomBytes)
+generateOriginalToken = OriginalToken <$> newRandomNonce 32
+
+parseOriginalToken :: T.Text -> Either String OriginalToken
+parseOriginalToken t = OriginalToken <$> parseNonce (T.unpack t)
+
+parseAuthTokenM :: Monad m => T.Text -> m AuthToken
+parseAuthTokenM t =
+    case parseAuthToken t of
+      Left err -> fail err
+      Right ok -> return ok
 
 parseAuthToken :: T.Text -> Either String AuthToken
 parseAuthToken t
     | T.length t /= 64 = Left "auth token must be 64 charaters long"
     | not (T.all Char.isHexDigit t) = Left "only hex digits are allowed in tokens"
-    | otherwise = Right (AuthToken t)
+    | otherwise =
+          Right $ AuthToken $ BSS.toShort $ fst $ BS16.decode $ T.encodeUtf8 t
 
-parseOriginalToken :: T.Text -> Either String OriginalToken
-parseOriginalToken t
-    | T.length t /= 64 = Left "original auth token must be 64 charaters long"
-    | not (T.all Char.isHexDigit t) = Left "only hex digits are allowed in tokens"
-    | otherwise = Right (OriginalToken $ fst $ BS16.decode $ T.encodeUtf8 t)
+renderAuthToken :: AuthToken -> T.Text
+renderAuthToken (AuthToken bss) = T.decodeUtf8 $ BS16.encode $ BSS.fromShort bss
 
 instance Text AuthToken where
-    disp (AuthToken tok) = Disp.text . T.unpack $ tok
+    disp tok = Disp.text . T.unpack . renderAuthToken $ tok
     parse =
         Parse.munch1 Char.isHexDigit >>= \x ->
         case parseAuthToken (T.pack x) of
           Left err -> fail err
           Right ok -> return ok
 
-$(deriveSafeCopy 0 'base ''AuthToken)
+instance SafeCopy AuthToken where
+    putCopy (AuthToken bs) = contain $ safePut (BSS.fromShort bs)
+    getCopy =
+        contain $ AuthToken . BSS.toShort <$> safeGet

--- a/Distribution/Server/Users/AuthToken.hs
+++ b/Distribution/Server/Users/AuthToken.hs
@@ -1,0 +1,47 @@
+{-# LANGUAGE DeriveDataTypeable, GeneralizedNewtypeDeriving, TemplateHaskell #-}
+{-# LANGUAGE TypeFamilies #-}
+module Distribution.Server.Users.AuthToken
+    ( AuthToken(..)
+    , generateAuthToken
+    )
+where
+
+import Distribution.Server.Framework.MemSize
+
+import System.Random.MWC
+import Distribution.Text
+         ( Text(..) )
+import qualified Distribution.Compat.ReadP as Parse
+import qualified Text.PrettyPrint          as Disp
+import qualified Data.Char as Char
+import qualified Data.Text as T
+import qualified Data.Text.Encoding as T
+import qualified Data.Vector as V
+import qualified Data.ByteString as BS
+import qualified Data.ByteString.Base16 as BS16
+
+import Control.Applicative ((<$>))
+import Data.Aeson (ToJSON, FromJSON)
+import Data.SafeCopy (base, deriveSafeCopy)
+import Data.Typeable (Typeable)
+
+newtype AuthToken = AuthToken T.Text
+    deriving (Eq, Ord, Read, Show, Typeable, MemSize, ToJSON, FromJSON)
+
+-- | Generate a random 64 byte auth token. The token is represented as
+-- in textual base16 way so it can easily be printed and parsed.
+-- Note that this operation is not very efficient because it
+-- calls 'withSystemRandom' for each token, but for the current
+-- use case we only generate tokens infrequently so this should be fine.
+generateAuthToken :: IO AuthToken
+generateAuthToken =
+    do randomBytes <-
+           BS16.encode . BS.pack . V.toList <$>
+           (withSystemRandom . asGenIO) (`uniformVector` 64)
+       return (AuthToken $ T.decodeUtf8 randomBytes)
+
+instance Text AuthToken where
+    disp (AuthToken tok) = Disp.text . T.unpack $ tok
+    parse = AuthToken . T.pack <$> Parse.munch1 Char.isHexDigit
+
+$(deriveSafeCopy 0 'base ''AuthToken)

--- a/Distribution/Server/Users/AuthToken.hs
+++ b/Distribution/Server/Users/AuthToken.hs
@@ -47,7 +47,7 @@ convertToken (OriginalToken bs) =
 viewOriginalToken :: OriginalToken -> T.Text
 viewOriginalToken (OriginalToken ot) = T.decodeUtf8 . BS16.encode $ ot
 
--- | Generate a random 64 byte auth token. The token is represented as
+-- | Generate a random 32 byte auth token. The token is represented as
 -- in textual base16 way so it can easily be printed and parsed.
 -- Note that this operation is not very efficient because it
 -- calls 'withSystemRandom' for each token, but for the current

--- a/Distribution/Server/Users/AuthToken.hs
+++ b/Distribution/Server/Users/AuthToken.hs
@@ -61,14 +61,14 @@ generateOriginalToken =
 
 parseAuthToken :: T.Text -> Either String AuthToken
 parseAuthToken t
-    | T.length t /= 64 = Left "auth token must be 32 charaters long"
-    | T.all Char.isHexDigit t = Left "only hex digits are allowed in tokens"
+    | T.length t /= 64 = Left "auth token must be 64 charaters long"
+    | not (T.all Char.isHexDigit t) = Left "only hex digits are allowed in tokens"
     | otherwise = Right (AuthToken t)
 
 parseOriginalToken :: T.Text -> Either String OriginalToken
 parseOriginalToken t
-    | T.length t /= 64 = Left "original auth token must be 32 charaters long"
-    | T.all Char.isHexDigit t = Left "only hex digits are allowed in tokens"
+    | T.length t /= 64 = Left "original auth token must be 64 charaters long"
+    | not (T.all Char.isHexDigit t) = Left "only hex digits are allowed in tokens"
     | otherwise = Right (OriginalToken $ fst $ BS16.decode $ T.encodeUtf8 t)
 
 instance Text AuthToken where

--- a/Distribution/Server/Users/AuthToken.hs
+++ b/Distribution/Server/Users/AuthToken.hs
@@ -2,8 +2,10 @@
 {-# LANGUAGE TypeFamilies #-}
 module Distribution.Server.Users.AuthToken
     ( AuthToken(..)
-    , generateAuthToken
     , parseAuthToken
+    , OriginalToken(..)
+    , convertToken, viewOriginalToken, generateOriginalToken
+    , parseOriginalToken
     )
 where
 
@@ -20,32 +22,54 @@ import qualified Data.Text.Encoding as T
 import qualified Data.Vector as V
 import qualified Data.ByteString as BS
 import qualified Data.ByteString.Base16 as BS16
+import qualified Crypto.Hash.SHA256 as SHA256
 
 import Control.Applicative ((<$>))
 import Data.Aeson (ToJSON, FromJSON)
 import Data.SafeCopy (base, deriveSafeCopy)
 import Data.Typeable (Typeable)
 
+-- | Contains the original token which will be shown to the user
+-- once and is NOT stored on the server. The user is expected
+-- to provide this token on each request that should be
+-- authed by it
+newtype OriginalToken = OriginalToken BS.ByteString
+    deriving (Eq, Ord, Show, Typeable)
+
+-- | Contains a hash of the original token
 newtype AuthToken = AuthToken T.Text
     deriving (Eq, Ord, Read, Show, Typeable, MemSize, ToJSON, FromJSON)
+
+convertToken :: OriginalToken -> AuthToken
+convertToken (OriginalToken bs) =
+    AuthToken $ T.decodeUtf8 $ BS16.encode (SHA256.hash bs)
+
+viewOriginalToken :: OriginalToken -> T.Text
+viewOriginalToken (OriginalToken ot) = T.decodeUtf8 . BS16.encode $ ot
 
 -- | Generate a random 64 byte auth token. The token is represented as
 -- in textual base16 way so it can easily be printed and parsed.
 -- Note that this operation is not very efficient because it
 -- calls 'withSystemRandom' for each token, but for the current
 -- use case we only generate tokens infrequently so this should be fine.
-generateAuthToken :: IO AuthToken
-generateAuthToken =
+generateOriginalToken :: IO OriginalToken
+generateOriginalToken =
     do randomBytes <-
-           BS16.encode . BS.pack . V.toList <$>
-           (withSystemRandom . asGenIO) (`uniformVector` 64)
-       return (AuthToken $ T.decodeUtf8 randomBytes)
+           BS.pack . V.toList <$>
+           (withSystemRandom . asGenIO) (`uniformVector` 32)
+       return (OriginalToken randomBytes)
 
 parseAuthToken :: T.Text -> Either String AuthToken
 parseAuthToken t
-    | T.length t /= 32 = Left "auth token must be 32 charaters long"
+    | T.length t /= 64 = Left "auth token must be 32 charaters long"
     | T.all Char.isHexDigit t = Left "only hex digits are allowed in tokens"
     | otherwise = Right (AuthToken t)
+
+parseOriginalToken :: T.Text -> Either String OriginalToken
+parseOriginalToken t
+    | T.length t /= 64 = Left "original auth token must be 32 charaters long"
+    | T.all Char.isHexDigit t = Left "only hex digits are allowed in tokens"
+    | otherwise = Right (OriginalToken $ fst $ BS16.decode $ T.encodeUtf8 t)
 
 instance Text AuthToken where
     disp (AuthToken tok) = Disp.text . T.unpack $ tok

--- a/Distribution/Server/Users/State.hs
+++ b/Distribution/Server/Users/State.hs
@@ -18,6 +18,7 @@ import Data.Typeable (Typeable)
 
 import Control.Monad.Reader
 import qualified Control.Monad.State as State
+import qualified Data.Text as T
 
 initialUsers :: Users.Users
 initialUsers = Users.emptyUsers
@@ -54,10 +55,10 @@ setUserName uid uname =
   updateUsers_ $ Users.setUserName uid uname
 
 addAuthToken ::
-    UserId -> AuthToken
+    UserId -> AuthToken -> T.Text
     -> Update Users.Users (Maybe Users.ErrNoSuchUserId)
-addAuthToken uid authToken =
-  updateUsers_ $ Users.addAuthToken uid authToken
+addAuthToken uid authToken description =
+  updateUsers_ $ Users.addAuthToken uid authToken description
 
 revokeAuthToken ::
     UserId -> AuthToken

--- a/Distribution/Server/Users/State.hs
+++ b/Distribution/Server/Users/State.hs
@@ -53,6 +53,18 @@ setUserName :: UserId -> UserName -> Update Users.Users (Maybe (Either Users.Err
 setUserName uid uname =
   updateUsers_ $ Users.setUserName uid uname
 
+addAuthToken ::
+    UserId -> AuthToken
+    -> Update Users.Users (Maybe Users.ErrNoSuchUserId)
+addAuthToken uid authToken =
+  updateUsers_ $ Users.addAuthToken uid authToken
+
+revokeAuthToken ::
+    UserId -> AuthToken
+    -> Update Users.Users (Maybe (Either Users.ErrNoSuchUserId Users.ErrTokenNotOwned))
+revokeAuthToken uid authToken =
+  updateUsers_ $ Users.revokeAuthToken uid authToken
+
 -- updates the user db with a simpler function
 updateUsers_ :: (Users.Users -> Either err Users.Users) -> Update Users.Users (Maybe err)
 updateUsers_ upd = do
@@ -85,6 +97,8 @@ $(makeAcidic ''Users.Users [ 'addUserEnabled
                           , 'deleteUser
                           , 'getUserDb
                           , 'replaceUserDb
+                          , 'addAuthToken
+                          , 'revokeAuthToken
                           ])
 
 -----------------------------------------------------
@@ -163,4 +177,3 @@ $(makeAcidic ''MirrorClients
                     ,'addMirrorClient
                     ,'removeMirrorClient
                     ,'replaceMirrorClients])
-

--- a/Distribution/Server/Users/Types.hs
+++ b/Distribution/Server/Users/Types.hs
@@ -1,11 +1,14 @@
 {-# LANGUAGE DeriveDataTypeable, GeneralizedNewtypeDeriving, TemplateHaskell #-}
+{-# LANGUAGE TypeFamilies #-}
 module Distribution.Server.Users.Types (
     module Distribution.Server.Users.Types,
+    module Distribution.Server.Users.AuthToken,
     module Distribution.Server.Framework.AuthTypes
   ) where
 
 import Distribution.Server.Framework.AuthTypes
 import Distribution.Server.Framework.MemSize
+import Distribution.Server.Users.AuthToken
 
 import Distribution.Text
          ( Text(..) )
@@ -13,10 +16,12 @@ import qualified Distribution.Server.Util.Parse as Parse
 import qualified Distribution.Compat.ReadP as Parse
 import qualified Text.PrettyPrint          as Disp
 import qualified Data.Char as Char
+import qualified Data.Text as T
+import qualified Data.Set as S
 
 import Control.Applicative ((<$>))
 import Data.Aeson (ToJSON, FromJSON)
-import Data.SafeCopy (base, deriveSafeCopy)
+import Data.SafeCopy (base, extension, deriveSafeCopy, Migrate(..))
 import Data.Typeable (Typeable)
 
 
@@ -28,13 +33,22 @@ newtype UserName  = UserName String
 
 data UserInfo = UserInfo {
                   userName   :: !UserName,
-                  userStatus :: !UserStatus
+                  userStatus :: !UserStatus,
+                  userTokens :: !UserTokenSet
+                } deriving (Eq, Show, Typeable)
+
+data UserInfo_v0 = UserInfo_v0 {
+                  userName_v0   :: !UserName,
+                  userStatus_v0 :: !UserStatus
                 } deriving (Eq, Show, Typeable)
 
 data UserStatus = AccountEnabled  UserAuth
                 | AccountDisabled (Maybe UserAuth)
                 | AccountDeleted
     deriving (Eq, Show, Typeable)
+
+newtype UserTokenSet = UserTokenSet (S.Set AuthToken)
+    deriving (Show, Eq, Typeable, MemSize)
 
 newtype UserAuth = UserAuth PasswdHash
     deriving (Show, Eq, Typeable)
@@ -45,7 +59,7 @@ isActiveAccount (AccountDisabled _) = True
 isActiveAccount  AccountDeleted     = False
 
 instance MemSize UserInfo where
-    memSize (UserInfo a b) = memSize2 a b
+    memSize (UserInfo a b c) = memSize3 a b c
 
 instance MemSize UserStatus where
     memSize (AccountEnabled  a) = memSize1 a
@@ -54,7 +68,6 @@ instance MemSize UserStatus where
 
 instance MemSize UserAuth where
     memSize (UserAuth a) = memSize1 a
-
 
 instance Text UserId where
     disp (UserId uid) = Disp.int uid
@@ -67,8 +80,19 @@ instance Text UserName where
 isValidUserNameChar :: Char -> Bool
 isValidUserNameChar c = (c < '\127' && Char.isAlphaNum c) || (c == '_')
 
+instance Migrate UserInfo where
+    type MigrateFrom UserInfo = UserInfo_v0
+    migrate v0 =
+        UserInfo
+        { userName = userName_v0 v0
+        , userStatus = userStatus_v0 v0
+        , userTokens = UserTokenSet S.empty
+        }
+
 $(deriveSafeCopy 0 'base ''UserId)
 $(deriveSafeCopy 0 'base ''UserName)
 $(deriveSafeCopy 1 'base ''UserAuth)
 $(deriveSafeCopy 0 'base ''UserStatus)
-$(deriveSafeCopy 0 'base ''UserInfo)
+$(deriveSafeCopy 0 'base ''UserTokenSet)
+$(deriveSafeCopy 0 'base ''UserInfo_v0)
+$(deriveSafeCopy 1 'extension ''UserInfo)

--- a/Distribution/Server/Users/Types.hs
+++ b/Distribution/Server/Users/Types.hs
@@ -17,7 +17,7 @@ import qualified Distribution.Compat.ReadP as Parse
 import qualified Text.PrettyPrint          as Disp
 import qualified Data.Char as Char
 import qualified Data.Text as T
-import qualified Data.Set as S
+import qualified Data.Map as M
 
 import Control.Applicative ((<$>))
 import Data.Aeson (ToJSON, FromJSON)
@@ -34,7 +34,7 @@ newtype UserName  = UserName String
 data UserInfo = UserInfo {
                   userName   :: !UserName,
                   userStatus :: !UserStatus,
-                  userTokens :: !UserTokenSet
+                  userTokens :: !UserTokenMap
                 } deriving (Eq, Show, Typeable)
 
 data UserInfo_v0 = UserInfo_v0 {
@@ -47,7 +47,8 @@ data UserStatus = AccountEnabled  UserAuth
                 | AccountDeleted
     deriving (Eq, Show, Typeable)
 
-newtype UserTokenSet = UserTokenSet (S.Set AuthToken)
+newtype UserTokenMap
+    = UserTokenMap { unUserTokenMap :: M.Map AuthToken T.Text }
     deriving (Show, Eq, Typeable, MemSize)
 
 newtype UserAuth = UserAuth PasswdHash
@@ -86,13 +87,13 @@ instance Migrate UserInfo where
         UserInfo
         { userName = userName_v0 v0
         , userStatus = userStatus_v0 v0
-        , userTokens = UserTokenSet S.empty
+        , userTokens = UserTokenMap M.empty
         }
 
 $(deriveSafeCopy 0 'base ''UserId)
 $(deriveSafeCopy 0 'base ''UserName)
 $(deriveSafeCopy 1 'base ''UserAuth)
 $(deriveSafeCopy 0 'base ''UserStatus)
-$(deriveSafeCopy 0 'base ''UserTokenSet)
+$(deriveSafeCopy 0 'base ''UserTokenMap)
 $(deriveSafeCopy 0 'base ''UserInfo_v0)
 $(deriveSafeCopy 1 'extension ''UserInfo)

--- a/Distribution/Server/Users/Types.hs
+++ b/Distribution/Server/Users/Types.hs
@@ -37,11 +37,6 @@ data UserInfo = UserInfo {
                   userTokens :: !UserTokenMap
                 } deriving (Eq, Show, Typeable)
 
-data UserInfo_v0 = UserInfo_v0 {
-                  userName_v0   :: !UserName,
-                  userStatus_v0 :: !UserStatus
-                } deriving (Eq, Show, Typeable)
-
 data UserStatus = AccountEnabled  UserAuth
                 | AccountDisabled (Maybe UserAuth)
                 | AccountDeleted
@@ -80,6 +75,11 @@ instance Text UserName where
 
 isValidUserNameChar :: Char -> Bool
 isValidUserNameChar c = (c < '\127' && Char.isAlphaNum c) || (c == '_')
+
+data UserInfo_v0 = UserInfo_v0 {
+                  userName_v0   :: !UserName,
+                  userStatus_v0 :: !UserStatus
+                } deriving (Eq, Show, Typeable)
 
 instance Migrate UserInfo where
     type MigrateFrom UserInfo = UserInfo_v0

--- a/Distribution/Server/Users/Users.hs
+++ b/Distribution/Server/Users/Users.hs
@@ -70,31 +70,8 @@ data Users = Users {
   }
   deriving (Eq, Typeable, Show)
 
-data Users_v0 = Users_v0 {
-    -- | A map from UserId to UserInfo
-    userIdMap_v0   :: !(IntMap.IntMap UserInfo),
-    -- | A map from active UserNames to the UserId for that name
-    userNameMap_v0 :: !(Map.Map UserName UserId),
-    -- | The next available UserId
-    nextId_v0      :: !UserId
-  }
-  deriving (Eq, Typeable, Show)
-
 instance MemSize Users where
   memSize (Users a b c d) = memSize4 a b c d
-
-instance Migrate Users where
-    type MigrateFrom Users = Users_v0
-    migrate v0 =
-        Users
-        { userIdMap = userIdMap_v0 v0
-        , userNameMap = userNameMap_v0 v0
-        , nextId = nextId_v0 v0
-        , authTokenMap = Map.empty
-        }
-
-$(deriveSafeCopy 0 'base ''Users_v0)
-$(deriveSafeCopy 1 'extension ''Users)
 
 checkinvariant :: Users -> Users
 checkinvariant users = assert (invariant users) users
@@ -404,3 +381,26 @@ enumerateActiveUsers :: Users -> [(UserId, UserInfo)]
 enumerateActiveUsers users =
     [ (UserId uid, uinfo) | (uid, uinfo) <- IntMap.assocs (userIdMap users)
                           , isActiveAccount (userStatus uinfo) ]
+
+data Users_v0 = Users_v0 {
+    -- | A map from UserId to UserInfo
+    userIdMap_v0   :: !(IntMap.IntMap UserInfo),
+    -- | A map from active UserNames to the UserId for that name
+    userNameMap_v0 :: !(Map.Map UserName UserId),
+    -- | The next available UserId
+    nextId_v0      :: !UserId
+  }
+  deriving (Eq, Typeable, Show)
+
+instance Migrate Users where
+    type MigrateFrom Users = Users_v0
+    migrate v0 =
+        Users
+        { userIdMap = userIdMap_v0 v0
+        , userNameMap = userNameMap_v0 v0
+        , nextId = nextId_v0 v0
+        , authTokenMap = Map.empty
+        }
+
+$(deriveSafeCopy 0 'base ''Users_v0)
+$(deriveSafeCopy 1 'extension ''Users)

--- a/Distribution/Server/Users/Users.hs
+++ b/Distribution/Server/Users/Users.hs
@@ -20,6 +20,7 @@ module Distribution.Server.Users.Users (
     -- * Lookup
     lookupUserId,
     lookupUserName,
+    lookupAuthToken,
 
     -- ** Lookup utils
     userIdToName,
@@ -174,6 +175,12 @@ lookupUserName uname users = do
       Just uid -> Just (uid, fromMaybe impossible (lookupUserId uid users))
   where
     impossible = error "lookupUserName: invariant violation"
+
+lookupAuthToken :: AuthToken -> Users -> Maybe (UserId, UserInfo)
+lookupAuthToken authTok users =
+    do uid <- Map.lookup authTok (authTokenMap users)
+       uinfo <- lookupUserId uid users
+       return (uid, uinfo)
 
 -- | Convert a 'UserId' to a 'UserName'. If the user id doesn't exist,
 -- an ugly placeholder is used instead.

--- a/Distribution/Server/Util/Nonce.hs
+++ b/Distribution/Server/Util/Nonce.hs
@@ -1,6 +1,7 @@
+{-# LANGUAGE DeriveDataTypeable #-}
+{-# LANGUAGE GeneralizedNewtypeDeriving #-}
 {-# LANGUAGE TemplateHaskell #-}
 {-# LANGUAGE TypeFamilies #-}
-{-# LANGUAGE GeneralizedNewtypeDeriving #-}
 module Distribution.Server.Util.Nonce
     ( newRandomNonce
     , renderNonce, parseNonce, parseNonceM
@@ -11,21 +12,22 @@ where
 
 import Distribution.Server.Framework.MemSize
 
-import qualified Data.Char as Char
 import Data.ByteString (ByteString)
-import qualified Data.ByteString.Char8 as BS -- Only used for ASCII data
-import qualified Data.ByteString.Base16 as Base16
-import Data.Typeable
 import Data.SafeCopy (base, extension, deriveSafeCopy, Migrate(..))
+import Data.Typeable
 import System.IO
+import qualified Data.ByteString.Base16 as Base16
+import qualified Data.ByteString.Char8 as BS -- Only used for ASCII data
+import qualified Data.Char as Char
 
 newtype Nonce = Nonce ByteString
   deriving (Eq, Ord, Show, Typeable, MemSize)
 
 newRandomNonce :: Int -> IO Nonce
 newRandomNonce len = do
-  raw <- withFile "/dev/urandom" ReadMode $ \h ->
-           BS.hGet h len
+  raw <-
+      withFile "/dev/urandom" ReadMode $ \h ->
+      BS.hGet h len
   return $! Nonce raw
 
 getRawNonceBytes :: Nonce -> ByteString

--- a/Distribution/Server/Util/Nonce.hs
+++ b/Distribution/Server/Util/Nonce.hs
@@ -1,0 +1,58 @@
+{-# LANGUAGE TemplateHaskell #-}
+{-# LANGUAGE TypeFamilies #-}
+{-# LANGUAGE GeneralizedNewtypeDeriving #-}
+module Distribution.Server.Util.Nonce
+    ( newRandomNonce
+    , renderNonce, parseNonce, parseNonceM
+    , getRawNonceBytes
+    , Nonce
+    )
+where
+
+import Distribution.Server.Framework.MemSize
+
+import qualified Data.Char as Char
+import Data.ByteString (ByteString)
+import qualified Data.ByteString.Char8 as BS -- Only used for ASCII data
+import qualified Data.ByteString.Base16 as Base16
+import Data.Typeable
+import Data.SafeCopy (base, extension, deriveSafeCopy, Migrate(..))
+import System.IO
+
+newtype Nonce = Nonce ByteString
+  deriving (Eq, Ord, Show, Typeable, MemSize)
+
+newRandomNonce :: Int -> IO Nonce
+newRandomNonce len = do
+  raw <- withFile "/dev/urandom" ReadMode $ \h ->
+           BS.hGet h len
+  return $! Nonce raw
+
+getRawNonceBytes :: Nonce -> ByteString
+getRawNonceBytes (Nonce b) = b
+
+renderNonce :: Nonce -> String
+renderNonce (Nonce nonce) = BS.unpack (Base16.encode nonce)
+
+parseNonce :: String -> Either String Nonce
+parseNonce t
+    | not (all Char.isHexDigit t) = Left "only hex digits are allowed in tokens"
+    | otherwise = Right (Nonce $ fst $ Base16.decode $ BS.pack t)
+
+parseNonceM :: Monad m => String -> m Nonce
+parseNonceM t =
+    case parseNonce t of
+      Left err -> fail err
+      Right ok -> return ok
+
+-- Nonce and Nonce_v0 have the same type, but the "new" nonce is
+-- internally NOT base16 encoded
+newtype Nonce_v0 = Nonce_v0 ByteString
+  deriving (Eq, Ord, Show, Typeable, MemSize)
+
+instance Migrate Nonce where
+    type MigrateFrom Nonce = Nonce_v0
+    migrate (Nonce_v0 x) = Nonce $ fst $ Base16.decode x
+
+$(deriveSafeCopy 0 'base ''Nonce_v0)
+$(deriveSafeCopy 1 'extension ''Nonce)

--- a/datafiles/templates/Users/manage.html.st
+++ b/datafiles/templates/Users/manage.html.st
@@ -12,35 +12,35 @@ $hackagePageHeader()$
 <h2>Manage user account $username$</h2>
 <p>This site collects operations you can do to manage your user account</p>
 
-<h3>API Keys</h3>
+<h3>Authentication Tokens</h3>
 <p>
-  You can register API authentication keys to use them to for example have services like continouos integration upload packages on your behalf without providing them your username and/or password.
+  You can register API authentication token to use them to for example have services like continouos integration upload packages on your behalf without providing them your username and/or password.
 </p>
 
-<h4>Active keys</h4>
+<h4>Active tokens</h4>
 <ul>
 $tokens:{token|
   <li>
     $token.description$
     <form action="/user/$username$/manage" method="post" enctype="multipart/form-data">
-        <input type="hidden" name="action" value="revoke-auth-key" />
-        <input type="hidden" name="auth-key" value="$token.hash$" />
-        <input type="submit" value="Revoke this key" />
+        <input type="hidden" name="action" value="revoke-auth-token" />
+        <input type="hidden" name="auth-token" value="$token.hash$" />
+        <input type="submit" value="Revoke this token" />
     </form>
   </li>
 }$
 </ul>
-<h4>Register new key</h4>
+<h4>Register new token</h4>
 <p>
-  To register a new key please provide a description for it. After registering
-  the key it will be shown to you once and you can not recover it after from
+  To register a new token please provide a description for it. After registering
+  the token it will be shown to you once and you can not recover it after from
   the site. Please be sure to store it in a safe place as it currently has
   the same privileges as your username and password.
 </p>
 <form action="/user/$username$/manage" method="post" enctype="multipart/form-data">
   Description: <input type="text" name="description" /> <br />
-  <input type="hidden" name="action" value="new-auth-key" />
-  <input type="submit" value="Generate new key" />
+  <input type="hidden" name="action" value="new-auth-token" />
+  <input type="submit" value="Generate new token" />
 </form>
 
 

--- a/datafiles/templates/Users/manage.html.st
+++ b/datafiles/templates/Users/manage.html.st
@@ -1,0 +1,56 @@
+<!DOCTYPE html>
+<html>
+<head>
+$hackageCssTheme()$
+<title>Manage your user account | Hackage</title>
+</head>
+
+<body>
+$hackagePageHeader()$
+
+<div id="content">
+<h2>Manage user account $username$</h2>
+<p>This site collects operations you can do to manage your user account</p>
+
+<h3>API Keys</h3>
+<p>
+  You can register API authentication keys to use them to for example have services like continouos integration upload packages on your behalf without providing them your username and/or password.
+</p>
+
+<h4>Active keys</h4>
+<ul>
+$tokens:{token|
+  <li>
+    $token.description$
+    <form action="/user/$username$/manage" method="post" enctype="multipart/form-data">
+        <input type="hidden" name="action" value="revoke-auth-key" />
+        <input type="hidden" name="auth-key" value="$token.hash$" />
+        <input type="submit" value="Revoke this key" />
+    </form>
+  </li>
+}$
+</ul>
+<h4>Register new key</h4>
+<p>
+  To register a new key please provide a description for it. After registering
+  the key it will be shown to you once and you can not recover it after from
+  the site. Please be sure to store it in a safe place as it currently has
+  the same privileges as your username and password.
+</p>
+<form action="/user/$username$/manage" method="post" enctype="multipart/form-data">
+  Description: <input type="text" name="description" /> <br />
+  <input type="hidden" name="action" value="new-auth-key" />
+  <input type="submit" value="Generate new key" />
+</form>
+
+
+<h3>Other options</h3>
+
+<ul>
+  <li>
+    <a href="/user/$username$/password">Change your password</a>
+  </li>
+</ul>
+
+</div>
+</body></html>

--- a/datafiles/templates/Users/token-created.html.st
+++ b/datafiles/templates/Users/token-created.html.st
@@ -1,0 +1,29 @@
+<!DOCTYPE html>
+<html>
+<head>
+$hackageCssTheme()$
+<title>Api key generated | Hackage</title>
+</head>
+
+<body>
+$hackagePageHeader()$
+
+<div id="content">
+<h2>New api key for $username$</h2>
+<p>
+  A new api key was successfully generated. Please keep it in a safe place and do
+  not loose it. You can revoke it from the user management page.
+</p>
+
+<h3>API Key: $token$</h3>
+
+<ul>
+  <li>
+    <a href="/user/$username$/manage">
+      I've stored the key. Go back to management page.
+    </a>
+  </li>
+</ul>
+
+</div>
+</body></html>

--- a/datafiles/templates/Users/token-created.html.st
+++ b/datafiles/templates/Users/token-created.html.st
@@ -2,25 +2,25 @@
 <html>
 <head>
 $hackageCssTheme()$
-<title>Api key generated | Hackage</title>
+<title>Auth token generated | Hackage</title>
 </head>
 
 <body>
 $hackagePageHeader()$
 
 <div id="content">
-<h2>New api key for $username$</h2>
+<h2>New auth token for $username$</h2>
 <p>
-  A new api key was successfully generated. Please keep it in a safe place and do
+  A new token was successfully generated. Please keep it in a safe place and do
   not loose it. You can revoke it from the user management page.
 </p>
 
-<h3>API Key: $token$</h3>
+<h3>Auth token: $token$</h3>
 
 <ul>
   <li>
     <a href="/user/$username$/manage">
-      I've stored the key. Go back to management page.
+      I've stored the token. Go back to management page.
     </a>
   </li>
 </ul>

--- a/datafiles/templates/Users/token-revoked.html.st
+++ b/datafiles/templates/Users/token-revoked.html.st
@@ -1,0 +1,26 @@
+<!DOCTYPE html>
+<html>
+<head>
+$hackageCssTheme()$
+<title>Api key revoked | Hackage</title>
+</head>
+
+<body>
+$hackagePageHeader()$
+
+<div id="content">
+<h2>Revoked api key for $username$</h2>
+<p>
+  Your api key was revoked and it can no longer be used for authentication.
+</p>
+
+<ul>
+  <li>
+    <a href="/user/$username$/manage">
+      Go back to management page
+    </a>
+  </li>
+</ul>
+
+</div>
+</body></html>

--- a/datafiles/templates/Users/token-revoked.html.st
+++ b/datafiles/templates/Users/token-revoked.html.st
@@ -2,16 +2,16 @@
 <html>
 <head>
 $hackageCssTheme()$
-<title>Api key revoked | Hackage</title>
+<title>Auth token revoked | Hackage</title>
 </head>
 
 <body>
 $hackagePageHeader()$
 
 <div id="content">
-<h2>Revoked api key for $username$</h2>
+<h2>Revoked auth token for $username$</h2>
 <p>
-  Your api key was revoked and it can no longer be used for authentication.
+  Your auth token was revoked and it can no longer be used for authentication.
 </p>
 
 <ul>

--- a/hackage-server.cabal
+++ b/hackage-server.cabal
@@ -40,6 +40,7 @@ data-files:
   templates/UserSignupReset/*.html.st
   templates/UserSignupReset/*.email.st
   templates/AdminFrontend/*.html.st
+  templates/Users/*.html.st
 
   static/*.css
   static/*.ico

--- a/hackage-server.cabal
+++ b/hackage-server.cabal
@@ -175,6 +175,7 @@ executable hackage-server
     Distribution.Server.Util.ContentType
     Distribution.Server.Util.SigTerm
     Distribution.Server.Util.ReadDigest
+    Distribution.Server.Util.Nonce
 
     Distribution.Server.Features
     Distribution.Server.Features.Core
@@ -325,7 +326,6 @@ executable hackage-server
     cryptohash-md5    == 0.11.*,
     cryptohash-sha256 == 0.11.*,
     binary,
-    mwc-random >= 0.13 && < 0.14,
     base16-bytestring >= 0.1 && < 0.2
 
   if ! flag(minimal)
@@ -388,7 +388,6 @@ executable hackage-mirror
     cryptohash-sha256,
     parsec,
     process >= 1.2.0,
-    mwc-random >= 0.13 && < 0.14,
     base16-bytestring >= 0.1 && < 0.2,
     hackage-security >= 0.5.1 && < 0.6,
     hackage-security-HTTP
@@ -433,7 +432,6 @@ executable hackage-build
     random,
     unix,
     cryptohash-sha256,
-    mwc-random >= 0.13 && < 0.14,
     base16-bytestring >= 0.1 && < 0.2,
     -- Runtime dependency only:
     hscolour >= 1.8

--- a/hackage-server.cabal
+++ b/hackage-server.cabal
@@ -161,6 +161,7 @@ executable hackage-server
     Distribution.Server.Users.Types
     Distribution.Server.Users.Backup
     Distribution.Server.Users.Users
+    Distribution.Server.Users.AuthToken
     Distribution.Server.Users.UserIdSet
 
     Distribution.Server.Util.Histogram
@@ -322,7 +323,9 @@ executable hackage-server
     ed25519,
     cryptohash-md5    == 0.11.*,
     cryptohash-sha256 == 0.11.*,
-    binary
+    binary,
+    mwc-random >= 0.13 && < 0.14,
+    base16-bytestring >= 0.1 && < 0.2
 
   if ! flag(minimal)
     build-depends:
@@ -384,6 +387,8 @@ executable hackage-mirror
     cryptohash-sha256,
     parsec,
     process >= 1.2.0,
+    mwc-random >= 0.13 && < 0.14,
+    base16-bytestring >= 0.1 && < 0.2,
     hackage-security >= 0.5.1 && < 0.6,
     hackage-security-HTTP
   default-language:   Haskell2010
@@ -427,6 +432,8 @@ executable hackage-build
     random,
     unix,
     cryptohash-sha256,
+    mwc-random >= 0.13 && < 0.14,
+    base16-bytestring >= 0.1 && < 0.2,
     -- Runtime dependency only:
     hscolour >= 1.8
   default-language: Haskell2010


### PR DESCRIPTION
This basically implements #416 after a discussion with @dcoutts at MuniHac2016.

This PR introduces a new user management page which only admins and the user owning the account can access. There is a link to reset the password and a form to allocate a new api key or revoke existing keys. Keys are generated from random 512 bits and are stored hashed with sha256 in server. Users and programs can then set the header `Authorization: ApiKey [API-KEY]` to authorize. Currently using this key is equal to login in with username/password, but in the future we might like to be able to create restricted api keys that can only do certain features. An example would be an api key for a build bot that can only upload a certain package or only documentation for packages.