### PR TITLE
updated parseTime to parseTimeM

### DIFF
--- a/Distribution/Client/ParseApacheLogs.hs
+++ b/Distribution/Client/ParseApacheLogs.hs
@@ -17,7 +17,7 @@ import Data.Maybe (catMaybes)
 import Data.Attoparsec.Char8 (Parser)
 import Data.Map (Map)
 import Data.Time.Calendar (Day)
-import Data.Time.Format (parseTime)
+import Data.Time.Format (parseTimeM)
 import qualified Data.ByteString.Char8      as SBS
 import qualified Data.Attoparsec.Char8      as Att
 import qualified Data.ByteString.Lazy.Char8 as LBS
@@ -94,7 +94,7 @@ parseGET :: (SBS.ByteString, SBS.ByteString, SBS.ByteString) -> Maybe (PackageNa
 parseGET (pkgNameStr, pkgVersionStr, dayStr) = do
   name    <- simpleParse . SBS.unpack $ pkgNameStr
   version <- simpleParse . SBS.unpack $ pkgVersionStr
-  day     <- parseTime defaultTimeLocale "%d/%b/%Y:%T %z" . SBS.unpack $ dayStr
+  day     <- parseTimeM True defaultTimeLocale "%d/%b/%Y:%T %z" . SBS.unpack $ dayStr
   return (name, version, day)
 
 methodGET, packagesDir, archiveDir, targzExt :: SBS.ByteString

--- a/Distribution/Client/UploadLog.hs
+++ b/Distribution/Client/UploadLog.hs
@@ -38,7 +38,7 @@ import Data.Time.Clock
 import Data.Time.LocalTime
          ( zonedTimeToUTC )
 import Data.Time.Format
-         ( readsTime, formatTime )
+         ( readSTime, formatTime )
 import Data.Time.Locale.Compat
          ( defaultTimeLocale )
 import Data.List
@@ -54,7 +54,7 @@ instance Text Entry where
         Disp.text (formatTime defaultTimeLocale "%c" time)
     <+> disp user <+> disp pkgid
   parse = do
-    time <- Parse.readS_to_P (readsTime defaultTimeLocale "%c")
+    time <- Parse.readS_to_P (readSTime True defaultTimeLocale "%c")
     Parse.skipSpaces
     user <- parse
     Parse.skipSpaces

--- a/Distribution/Client/UserAddressesDb.hs
+++ b/Distribution/Client/UserAddressesDb.hs
@@ -18,7 +18,7 @@ import qualified Data.Text.Encoding.Error as T
 import qualified Data.Text.Read           as T
 import Data.Functor
 import Data.Char (chr)
-import Data.Time (UTCTime, parseTime, zonedTimeToUTC)
+import Data.Time (UTCTime, parseTimeM, zonedTimeToUTC)
 import System.Locale (defaultTimeLocale)
 
 type UserAddressesDb = [UserEntry]
@@ -67,7 +67,7 @@ parseLine line
         fixTimeBreakage fs = fs
 
     readTime = fmap zonedTimeToUTC
-             . parseTime defaultTimeLocale "%c"
+             . parseTimeM True defaultTimeLocale "%c"
 
 -- Unfortunately the file uses mixed encoding, mostly UTF8
 -- but some Latin1 and some Html escape sequences

--- a/Distribution/Server/Features/Mirror.hs
+++ b/Distribution/Server/Features/Mirror.hs
@@ -26,7 +26,7 @@ import Distribution.PackageDescription.Parse (parsePackageDescription)
 import Distribution.ParseUtils (ParseResult(..), locatedErrorMsg, showPWarning)
 
 import Data.Time.Clock (getCurrentTime)
-import Data.Time.Format (formatTime, parseTime)
+import Data.Time.Format (formatTime, parseTimeM)
 import Data.Time.Locale.Compat (defaultTimeLocale)
 import qualified Distribution.Server.Util.GZip as GZip
 
@@ -221,7 +221,7 @@ mirrorFeature ServerEnv{serverBlobStore = store}
         guardAuthorised_ [InGroup mirrorGroup]
         pkgid <- packageInPath dpath
         timeContent <- expectTextPlain
-        case parseTime defaultTimeLocale "%c" (unpackUTF8 timeContent) of
+        case parseTimeM True defaultTimeLocale "%c" (unpackUTF8 timeContent) of
           Nothing -> errBadRequest "Could not parse upload time" []
           Just t  -> do
             existed <- updateSetPackageUploadTime pkgid t

--- a/Distribution/Server/Framework/BackupRestore.hs
+++ b/Distribution/Server/Framework/BackupRestore.hs
@@ -164,7 +164,7 @@ parseRead label str = case readConsume reads str of
 
 parseUTCTime :: (Monad m, MonadError String m) => String -> String -> m UTCTime
 parseUTCTime label str =
-    case Time.parseTime defaultTimeLocale timeFormatSpec str of
+    case Time.parseTimeM True defaultTimeLocale timeFormatSpec str of
       Nothing -> throwError $ "Unable to parse UTC timestamp " ++ label ++ ": " ++ str
       Just x  -> return x
 

--- a/hackage-server.cabal
+++ b/hackage-server.cabal
@@ -285,7 +285,7 @@ executable hackage-server
     blaze-builder >= 0.4,
     text       >= 0.11,
     split      >= 0.2,
-    time       >= 1.1 && < 1.7,
+    time       >= 1.5,
     time-locale-compat >= 0.1.0.1,
 --    old-locale >= 1.0,
     deepseq    == 1.1.* || > 1.3.0,


### PR DESCRIPTION
fix warning

```
Distribution/Server/Features/Mirror.hs:224:14: Warning:
    In the use of ‘parseTime’
    (imported from Data.Time.Format, but defined in time-1.5.0.1:Data.Time.Format.Parse):
    Deprecated: "use "parseTimeM True" instead"
```