### PR TITLE
BuildClient: Add simple retry policy for failed doc builds

### DIFF
--- a/hackage-server.cabal
+++ b/hackage-server.cabal
@@ -431,7 +431,7 @@ executable hackage-build
   build-depends:
     base,
     containers, array, vector, bytestring, text, pretty,
-    filepath, directory, process >= 1.0,
+    filepath, directory >= 1.2.5, process >= 1.0,
     time,
     time-locale-compat >= 0.1.0.1,
     tar,      zlib,


### PR DESCRIPTION
I've been noticing a fair number of Hackage packages lacking
documentation due to apparently transient issues (e.g. somehow a package
entering the build queue despite having no entry in the package index,
see #543).

Here we add a simple retry policy; attempting to build a failing package
up to a given number of attempts. The number of failures is now
persisted in the failure file.