### PR TITLE
(460) Fixes rendering of changelog markdown (line-endings issue)

### DIFF
--- a/Distribution/Server/Features/PackageContents.hs
+++ b/Distribution/Server/Features/PackageContents.hs
@@ -29,6 +29,7 @@ import qualified Data.Text                as T
 import qualified Data.Text.Encoding       as T
 import qualified Data.Text.Encoding.Error as T
 import qualified Data.ByteString.Lazy as BS (ByteString, toStrict)
+import qualified Data.ByteString.Char8 as C8
 import qualified Text.XHtml.Strict as XHtml
 import           Text.XHtml.Strict ((<<), (!))
 import System.FilePath.Posix (takeExtension)
@@ -204,7 +205,7 @@ packageContentsFeature CoreFeature{ coreResource = CoreResource{
 renderMarkdown :: BS.ByteString -> XHtml.Html
 renderMarkdown = XHtml.primHtml . Blaze.renderHtml
                . Markdown.renderDoc . Markdown.markdown opts
-               . T.decodeUtf8With T.lenientDecode . BS.toStrict
+               . T.decodeUtf8With T.lenientDecode . convertNewLine . BS.toStrict
   where
     opts =
       Markdown.Options
@@ -213,6 +214,9 @@ renderMarkdown = XHtml.primHtml . Blaze.renderHtml
         , Markdown.preserveHardBreaks = False
         , Markdown.debug              = False
         }
+
+convertNewLine :: C8.ByteString -> C8.ByteString
+convertNewLine = C8.concat . C8.split '\r'
 
 supposedToBeMarkdown :: FilePath -> Bool
 supposedToBeMarkdown fname = takeExtension fname `elem` [".md", ".markdown"]

--- a/Distribution/Server/Features/PackageContents.hs
+++ b/Distribution/Server/Features/PackageContents.hs
@@ -216,7 +216,7 @@ renderMarkdown = XHtml.primHtml . Blaze.renderHtml
         }
 
 convertNewLine :: C8.ByteString -> C8.ByteString
-convertNewLine = C8.concat . C8.split '\r'
+convertNewLine = C8.filter (/= '\r')
 
 supposedToBeMarkdown :: FilePath -> Bool
 supposedToBeMarkdown fname = takeExtension fname `elem` [".md", ".markdown"]


### PR DESCRIPTION
Fixing issue: https://github.com/haskell/hackage-server/issues/460 - rendering of changelog markdown (line-endings issue)

w/ @chrissound

![screenshot from 2016-10-08 16-02-46](https://cloud.githubusercontent.com/assets/16495735/19213991/4dedcac2-8d71-11e6-950e-925ba148586b.png)
