### PR TITLE
Various queuing improvements

### DIFF
--- a/BuildClient.hs
+++ b/BuildClient.hs
@@ -478,9 +478,10 @@ buildOnce opts pkgs = keepGoing $ do
     shouldBuild :: DocInfo -> Bool
     shouldBuild docInfo =
         case docInfoHasDocs docInfo of
-          DocsNotBuilt -> null pkgs || any (isSelectedPackage pkgid) pkgs
-          _            -> False
+          DocsNotBuilt -> null pkgs || is_selected
+          _            -> is_selected -- rebuild package if the user explicitly requested it
       where
+        is_selected = any (isSelectedPackage pkgid) pkgs
         pkgid = docInfoPackage docInfo
 
     -- do versionless matching if no version was given

--- a/BuildClient.hs
+++ b/BuildClient.hs
@@ -566,7 +566,7 @@ mkPackageFailed opts = do
 
     writeFailedCache :: FilePath -> M.Map PackageId Int -> IO ()
     writeFailedCache cache_dir pkgs =
-      writeFile (cache_dir </> "failed")
+      writeUTF8File (cache_dir </> "failed")
       $ unlines
       $ map (\(pkgid,n) -> show $ disp pkgid Disp.<+> disp n)
       $ M.assocs pkgs

--- a/BuildClient.hs
+++ b/BuildClient.hs
@@ -40,6 +40,7 @@ import System.Directory
 import System.Console.GetOpt
 import System.Process
 import System.IO
+import Control.Concurrent
 
 import Paths_hackage_server (version)
 
@@ -432,6 +433,7 @@ buildOnce opts pkgs = keepGoing $ do
 
         pkgIdsHaveDocs <- getDocumentationStats verbosity config has_failed
         infoStats verbosity Nothing pkgIdsHaveDocs
+        threadDelay (10^7)
 
         let orderBuilds :: BuildOrder -> [DocInfo] -> [DocInfo]
             orderBuilds LatestVersionFirst =

--- a/BuildClient.hs
+++ b/BuildClient.hs
@@ -604,7 +604,7 @@ buildPackage verbosity opts config docInfo = do
              -- Always build the package, even when it's been built
              -- before. This lets us regenerate documentation when
              -- dependencies are updated.
-             "--reinstall",
+             "--reinstall", "--force-reinstalls",
              -- We know where this documentation will
              -- eventually be hosted, bake that in.
              -- The wiki claims we shouldn't include the

--- a/rundocs.sh
+++ b/rundocs.sh
@@ -2,6 +2,6 @@
 
 while true
 do
-  dist/build/hackage-build/hackage-build build --run-time=25
+  dist/build/hackage-build/hackage-build build --run-time=120
   sleep 300
 done

--- a/rundocs.sh
+++ b/rundocs.sh
@@ -2,6 +2,6 @@
 
 while true
 do
-  dist/build/hackage-build/hackage-build build --run-time=120
+  dist/build/hackage-build/hackage-build build --run-time=120 --build-order=recent-uploads-first
   sleep 300
 done


### PR DESCRIPTION
This branch implements a new build ordering mode, which sorts packages to be built by upload date. It also fixes a non-atomic update of the `failed` file which could result in corruption. Finally, it includes a number of changes that I found uncommitted in the doc builder's working tree.