### PR TITLE
Switch to https://validator.w3.org/ validation service

### DIFF
--- a/hackage-server.cabal
+++ b/hackage-server.cabal
@@ -517,6 +517,8 @@ Test-Suite HighLevelTest
                     directory,
                     filepath,
                     HTTP,
+                    io-streams == 1.3.*,
+                    http-streams >= 0.8.4 && < 0.9,
                     network,
                     process,
                     tar,

--- a/tests/CreateUserTest.hs
+++ b/tests/CreateUserTest.hs
@@ -9,7 +9,7 @@
   1. Port `testPort` (currently 8392) must be available on localhost
   2. You must have sendmail configured so that it can send emails to external
      domains (for user registration) -- currently we use mailinator.com accounts
-  3. You must allow for outgoing HTTP traffic, as we POST to html5.validator.nu
+  3. You must allow for outgoing HTTP traffic, as we POST to validator.w3.org
      for HTML validation.
 -}
 

--- a/tests/HighLevelTest.hs
+++ b/tests/HighLevelTest.hs
@@ -5,7 +5,7 @@
   System requirements:
 
   1. Port `testPort` (currently 8392) must be available on localhost
-  2. You must allow for outgoing HTTP traffic, as we POST to html5.validator.nu
+  2. You must allow for outgoing HTTP traffic, as we POST to validator.w3.org
      for HTML validation.
 -}
 

--- a/tests/HttpUtils.hs
+++ b/tests/HttpUtils.hs
@@ -199,7 +199,7 @@ getValidateResult :: Authorization -> String
                   -> IO (String, Maybe ValidateResult)
 getValidateResult auth url = do
           body <- execRequest auth (getRequest url)
-          result <- (Just <$> invokeHtml5Validate body) `catch` handler
+          result <- (Just `fmap` invokeHtml5Validate body) `catch` handler
           return (body, result)
   where handler :: IOException -> IO (Maybe ValidateResult)
         handler _ = return Nothing

--- a/tests/HttpUtils.hs
+++ b/tests/HttpUtils.hs
@@ -18,7 +18,7 @@ module HttpUtils (
   , execRequest'
   , responseHeader
   , execPostFile
-  -- * Interface to html5.validator.nu
+  -- * Interface to validator.w3.org
   , validate
 ) where
 
@@ -155,9 +155,9 @@ badResponse rsp =
         ++ rspBody rsp
 
 {------------------------------------------------------------------------------
-  Interface to html5.validator.nu
+  Interface to validator.w3.org
 
-  NOTE: We only parse bits of the information returned by html5.validator.nu
+  NOTE: We only parse bits of the information returned by validator.w3.org
 ------------------------------------------------------------------------------}
 
 data ValidateResult = ValidateResult {

--- a/tests/HttpUtils.hs
+++ b/tests/HttpUtils.hs
@@ -29,6 +29,10 @@ import Network.HTTP hiding (user)
 import Network.HTTP.Auth
 import Data.Aeson (Value(..), FromJSON(..), (.:))
 
+import qualified Network.Http.Client as HC
+import qualified System.IO.Streams as Streams
+import qualified Data.ByteString.Builder as BB
+
 import qualified Data.ByteString.Char8  as BS
 import qualified Data.ByteString.Base64 as Base64
 
@@ -195,18 +199,10 @@ getValidateResult :: Authorization -> String
                   -> IO (String, Maybe ValidateResult)
 getValidateResult auth url = do
           body <- execRequest auth (getRequest url)
-          result <-
-            catch
-            (do
-                json <- execRequest NoAuth
-                        (postRequestWithBody validatorURL "text/html" body)
-                result <- decodeJSON json
-                return $ Just result)
-            handler
+          result <- (Just <$> invokeHtml5Validate body) `catch` handler
           return (body, result)
   where handler :: IOException -> IO (Maybe ValidateResult)
         handler _ = return Nothing
-        validatorURL = "http://html5.validator.nu?out=json&charset=UTF-8"
 
 validationErrors :: ValidateResult -> [String]
 validationErrors = aux [] . validateMessages
@@ -223,3 +219,17 @@ validate auth url = do
   case mres of
     Just result -> return (body, validationErrors result)
     Nothing -> return (body, ["Couldn't connect to validation service"])
+
+
+invokeHtml5Validate :: String -> IO ValidateResult
+invokeHtml5Validate htmlToValidate = do
+    HC.withConnection (HC.establishConnection "https://validator.w3.org") $ \c -> do
+        let q = HC.buildRequest1 $ do
+                  HC.http HC.POST "/nu/?out=json"
+                  HC.setContentType "text/html; charset=utf-8"
+                  HC.setHeader "User-Agent" "hackage-server-testsuite/0.1"
+
+        HC.sendRequest c q bodyStreamer
+        HC.receiveResponse c HC.jsonHandler
+  where
+    bodyStreamer = Streams.write (Just $ BB.stringUtf8 htmlToValidate)


### PR DESCRIPTION
The previously used one at http://html5.validator.nu has been down for
some time now. However, https://validator.w3.org/ requires TLS support,
so we need to use `http-streams`.