### PR TITLE
WIP: Validate doc-index.json on doctarball upload

### DIFF
--- a/hackage-server.cabal
+++ b/hackage-server.cabal
@@ -347,6 +347,7 @@ library lib-server
                , split                 ^>= 0.2
                , stm                   ^>= 2.4
                , tagged                ^>= 0.8.5
+               , tagsoup               ^>= 0.14
                , tar                   ^>= 0.5
                , text                  ^>= 1.2.2
                , time-locale-compat    ^>= 0.1.0.1


### PR DESCRIPTION
This is the validation part for the new haddock doc-index.json feature. 

- [X] Integration into documentation upload
- [X] Disallow non-whitelisted tags
- [] Disallow hrefs which do not point to hackage docs.