### PR TITLE
Extend voting interface to allow score

### DIFF
--- a/Distribution/Server/Features.hs
+++ b/Distribution/Server/Features.hs
@@ -257,6 +257,7 @@ initHackageFeatures env@ServerEnv{serverVerbosity = verbosity} = do
                          coreFeature
                          -- [reverse index disabled] reverseFeature
                          downloadFeature
+                         votesFeature
                          tagsFeature
                          versionsFeature
 

--- a/Distribution/Server/Features/Votes/State.hs
+++ b/Distribution/Server/Features/Votes/State.hs
@@ -15,47 +15,70 @@ import Distribution.Server.Users.State ()
 import Data.Typeable
 import Data.Map (Map)
 import qualified Data.Map as Map
+import Data.List
 import Data.Maybe (fromMaybe)
-
+import Control.Arrow ((&&&))
 import Data.Acid     (Query, Update, makeAcidic)
-import Data.SafeCopy (base, deriveSafeCopy)
+import Data.SafeCopy (base, extension, deriveSafeCopy, Migrate(..))
 
 import qualified Control.Monad.State as State
 import Control.Monad.Reader.Class (ask)
 
+type Score = Int
 
-newtype VotesState = VotesState { votesMap :: Map PackageName UserIdSet }
+newtype VotesState_v0 = VotesState_v0 { votesMap :: Map PackageName UserIdSet }
+
+newtype VotesState = VotesState (Map PackageName (Map UserId Score))
   deriving (Show, Eq, Typeable, MemSize)
 
-$(deriveSafeCopy 0 'base ''VotesState)
+-- SafeCopy instances
+deriveSafeCopy 1 'extension ''VotesState
+
+deriveSafeCopy 0 'base      ''VotesState_v0
+
+instance Migrate VotesState where
+    type MigrateFrom VotesState = VotesState_v0
+
+    migrate (VotesState_v0 m) = VotesState (Map.map go m)
+      where
+        go :: UserIdSet -> Map UserId Score
+        go = Map.fromList . map (\x->(x,3)) . UserIdSet.toList
+
+--
 
 initialVotesState :: VotesState
 initialVotesState = VotesState Map.empty
 
 -- helper function
-userVotedForPackage :: PackageName -> UserId -> Map PackageName UserIdSet -> Bool
+userVotedForPackage :: PackageName -> UserId -> Map PackageName (Map UserId Score) -> Bool
 userVotedForPackage pkgname uid votes =
     case Map.lookup pkgname votes of
       Nothing     -> False
-      Just uidset -> UserIdSet.member uid uidset
+      Just m -> case Map.lookup uid m of
+                  Nothing -> False
+                  Just _ -> True
+
+-- Using La Placian rule of succession to calculate scoring
+votesScore :: Map UserId Score -> Float
+votesScore m =
+    let grouping = map (head &&& length) . group . sort . Map.elems $ m
+        score =  fromIntegral (sum $ map (uncurry (*)) grouping) / fromIntegral (4 + foldr (\(_,b) -> (+b) ) 0 grouping)
+    in score*10
 
 -- All the acid state transactions
 
-addVote :: PackageName -> UserId -> Update VotesState Bool
-addVote pkgname uid = do
+addVote :: PackageName -> UserId -> Score -> Update VotesState Float
+addVote pkgname uid score = do
     VotesState votes <- State.get
-    if userVotedForPackage pkgname uid votes
-      then return False
-      else do let votes' = Map.alter insert pkgname votes
-                  insert = Just . UserIdSet.insert uid . fromMaybe UserIdSet.empty
-              State.put $! VotesState votes'
-              return True
+    let votes' = Map.insertWith Map.union pkgname (Map.singleton uid score) votes
+    State.put $! VotesState votes'
+    return $ votesScore $ fromMaybe Map.empty $ Map.lookup pkgname votes'
 
 removeVote :: PackageName -> UserId -> Update VotesState Bool
 removeVote pkgname uid = do
     VotesState votes <- State.get
     if userVotedForPackage pkgname uid votes
-       then do let votes' = Map.adjust (UserIdSet.delete uid) pkgname votes
+       then do let votes' = Map.adjust (Map.delete uid) pkgname votes
                State.put $! VotesState votes'
                return True
        else return False
@@ -65,14 +88,26 @@ getPackageVoteCount pkgname = do
     VotesState votes <- ask
     case Map.lookup pkgname votes of
       Nothing     -> return 0
-      Just uidset -> return $! UserIdSet.size uidset
+      Just m      -> return $! Map.size m
+
+getPackageVoteScore :: PackageName -> Query VotesState Float
+getPackageVoteScore pkgname = do
+    VotesState votes <- ask
+    case Map.lookup pkgname votes of
+      Nothing     -> return 0
+      Just m      -> return $! votesScore m
 
 getPackageUserVoted :: PackageName -> UserId -> Query VotesState Bool
 getPackageUserVoted pkgname uid = do
     VotesState votes <- ask
     return $! userVotedForPackage pkgname uid votes
 
-getAllPackageVoteSets :: Query VotesState (Map PackageName UserIdSet)
+getPackageUserVote :: PackageName -> UserId -> Query VotesState (Maybe Score)
+getPackageUserVote pkgname uid = do
+    VotesState votes <- ask
+    return $! Map.lookup uid =<< Map.lookup pkgname votes
+
+getAllPackageVoteSets :: Query VotesState (Map PackageName (Map UserId Score))
 getAllPackageVoteSets = do
     VotesState votes <- ask
     return votes
@@ -91,7 +126,9 @@ makeAcidic
   [ 'addVote
   , 'removeVote
   , 'getPackageVoteCount
+  , 'getPackageVoteScore
   , 'getPackageUserVoted
+  , 'getPackageUserVote
   , 'getAllPackageVoteSets
   , 'getVotesState
   , 'replaceVotesState

--- a/datafiles/templates/Html/package-page.html.st
+++ b/datafiles/templates/Html/package-page.html.st
@@ -6,6 +6,7 @@
     $package.name$$if(package.optional.hasSynopsis)$: $package.optional.synopsis$$endif$
   </title>
   <link rel="canonical" href="$baseurl$/package/$package.name$" />
+  <script src="/static/jquery.min.js"></script>
 </head>
 
 <body>
@@ -151,8 +152,18 @@
         </tr>
 
         <tr>
-          <th>Votes</th>
-          <td>$votesSection$</td>
+          <th>Rating</th>
+          <td>$score$ ($votes$ ratings)
+          $if(userRating)$
+            <input type="hidden" id="userRating" value="$userRating$">
+          $endif$
+              [<a href="" class="clear-rating">clear rating</a>]
+            <ul class="star-rating">
+              <li class="star" id="1">&lambda;</li>
+              <li class="star" id="2">&lambda;</li>
+              <li class="star" id="3">&lambda;</li>
+            </ul>
+          </td>
         </tr>
         <tr>
           <th>Status</th>
@@ -197,6 +208,7 @@
 
   </div> <!-- /content -->
 
+  $packagePageAssets()$
   $footer()$
 
 </body>

--- a/datafiles/templates/packagePageAssets.st
+++ b/datafiles/templates/packagePageAssets.st
@@ -1,0 +1,190 @@
+<style>
+  #overlay {
+    position: fixed;
+    top: 0;
+    left: 0;
+    width: 100%;
+    height: 100%;
+    background: #000;
+    opacity: 0.5;
+    filter: alpha(opacity=50);
+  }
+
+  #modal {
+    position: absolute;
+    width: 200px !;
+    background: rgba(0, 0, 0, 0.2);
+    border-radius: 14px;
+    padding: 8px;
+  }
+
+  #content {
+    border-radius: 8px;
+    background: #fff;
+    padding: 20px;
+  }
+
+  #close {
+    position: absolute;
+    background: url(data:image/png;base64,iVBORw0KGgoAAAANSUhEUgAAABgAAAAbCAYAAABm409WAAAAGXRFWHRTb2Z0d2FyZQBBZG9iZSBJbWFnZVJlYWR5ccllPAAABCdJREFUeNqcVl1IbFUUnjNzr47enLFkvKUoDNk1S0kxDPHBH4gCTfHJH4jgYgrpg1APmqjQS2gggiLViyBdkEAxjARFSPBBfPCv/LcRS5tSlLzXMcdxZvWt3d6HmTkzXW8LPs45a6/1rbX3XmvvYzL9hxBRC/AjRZcD4BGQE41Di0JciMfnQDF/n5+fm2ZmZkxnZ2e6TWFhoSknJ4T3a03TmkxPE5C/q9JbX1+nmpoaslgsxEPhSE9Pp6GhIbq5uVEuU8DztyLv7e2NShwOzIRcLpdy/S4auQNws0VHR8etiIORmppKh4eHKshXkQLwZtH4+Pgzkyvk5+cHL1dOMLmTNV6vV6xrsFNxcTHV1tZSSkpKiL6srIyam5spLS0tRM97IuWRHsDv97ezZmRkxJDV3t4enZ6e0sDAADkcDqGrqqqizc1NwdLe3m7YeFXCeoBAIPADa8rLyw0BZmdnhfX19TX19fVRY2OjTg4/amhoMPisra2J8YuLizeY3wzDfVY4nU6DcW5uLq2srAiHy8tLQi+I96urK1EM8fHxBp/h4WGV1EMOYOF3VsTExETdPO4JJZx5T08Pmc3miPZc4iwej+dTMweAwxOOZLfbja2uaSabzcaFoOtQKSYkY0pISIhY8jzGgqLx8zMO0xXp8XKEZ1NZWUk7Ozv6smxvb6vsaHBwkJKTkw0+XOossP2AAzx3dHQkeqClpcVgPDY2pm9yW1sblZSU0OLiotD5fD6qqKgIsefu56pj6ezsfJ0DJMzNzX3MCt798ADd3d20sbFBXV1dhOXSj4apqSmanp6mvLy8EPvq6mpBfnJysoLvFBEAyHK73aL26uvrQxx4CYqKigzVkp2dTRkZGSHnFb9vbW2JAPPz84MqwD3glYmJiS954Pj4WDj+n6Oiv7//3w47ONjhEx24zwGsQDrw9tLS0s/qmH7WINwTSpqamrqgywXE0X0XSAYKkpKSPgL572zEGxW+XNHuhNHRUZ28tbX1G+jLgQwuINHJgA14ALyXmJj4GY6H35TD8vKyqB5utri4OEHKs+Py5Y7l7mbBrefDMfI9xj8E3gJeBGLVtRkr1+tN4H3gC1TPT1gyD91CJicnT7Kysr6F3yfAOzJ7Lh6LupMt3HDAC3I/MoFXgZfr6upeKy0tvV9QUHAvMzPzjtVq1fb39/27u7vehYWFx2gq1+rq6hZseWP5+QvwB/AY8GlBl/8dIF4GSQWcEmmAg08SOVO2vQE8AP8FuAE+ml3Ar8CfktzLB7UW9odxV87ELjee1/ElGSBRjvGeXQMXwKkkdMusOeATOe6P9NuiZhIr+8MuiW2yImJkAJ7BpSQ7B/6S73/zsnDmssoi/hdpkkQFskrEyhlqMjvO8ioIPqkPPPXHK2hMkwWgYFbXuCRThIFwYiX/CDAA8quvgv5A6LkAAAAASUVORK5CYII=) 0 0 no-repeat;
+    width: 24px;
+    height: 27px;
+    display: block;
+    text-indent: -9999px;
+    top: -7px;
+    right: -7px;
+  }
+
+  .cool {
+    color: gold;
+  }
+
+  .uncool {
+    color: black;
+  }
+
+  .star-rating {
+    margin: 0;
+    list-style-type: none;
+    font-size: 150%;
+    color: black;
+  }
+
+  .star-rating li {
+    float: left;
+    margin: 0 1% 0 1%;
+  }
+
+  .clear-rating {
+    font-size: small;
+  }
+
+</style>
+
+<script>
+  var modal = (function() {
+    var
+      method = {},
+      overlay,
+      modal,
+      content,
+      close;
+
+    // Center the modal in the viewport
+    method.center = function() {
+      var top, left;
+
+      top = Math.max(\$(window).height() - modal.outerHeight(), 0) / 2;
+      left = Math.max(\$(window).width() - modal.outerWidth(), 0) / 2;
+
+      modal.css({
+        top: top + \$(window).scrollTop(),
+        left: left + \$(window).scrollLeft()
+      });
+    };
+
+    // Open the modal
+    method.open = function(settings) {
+      content.empty().append(settings.content);
+
+      modal.css({
+        width: settings.width || 'auto',
+        height: settings.height || 'auto'
+      });
+
+      method.center();
+      \$(window).bind('resize.modal', method.center);
+      modal.show();
+      overlay.show();
+    };
+
+    // Close the modal
+    method.close = function() {
+      modal.hide();
+      overlay.hide();
+      content.empty();
+      \$(window).unbind('resize.modal');
+    };
+
+    // Generate the HTML and add it to the document
+    overlay = \$('<div id="overlay"></div>');
+    modal = \$('<div id="modal"></div>');
+    content = \$('<div id="content"></div>');
+    close = \$('<a id="close" href="#">close</a>');
+
+    modal.hide();
+    overlay.hide();
+    modal.append(content, close);
+
+    \$(document).ready(function() {
+      \$('body').append(overlay, modal);
+    });
+
+    close.click(function(e) {
+      e.preventDefault();
+      method.close();
+    });
+
+    return method;
+  }());
+</script>
+
+<script>
+  var votesUrl = '/package/$package.name$/votes';
+  var star = {
+    "selected": false
+  };
+  \$('.star').mouseenter(function() {
+    if (star.selected === false) {
+      fill_stars(this.id, "in");
+    }
+  });
+  \$('.star').mouseleave(function() {
+    if (star.selected === false) {
+      fill_stars(this.id, "out");
+    }
+  });
+  \$('.star').click(function() {
+    fill_stars(3, "out");
+    fill_stars(this.id, "in");
+    star.selected = true;
+    star.id = this.id;
+    var formData = {
+      score: this.id
+    }
+    \$.post(votesUrl, formData).done(function(data) {
+        if(data != "Package voted for successfully") {
+            modal.open({ content: data});
+	}
+    });
+  });
+  \$('.clear-rating').click(function(e) {
+    e.preventDefault()
+    fill_stars(3, "out");
+    star.selected = false;
+    \$.ajax({
+      url: votesUrl,
+      type: 'DELETE',
+      success: function(result) {
+        if(result != "Package vote removed successfully") {
+          modal.open({ content: result });
+	}
+      }
+    });
+  });
+  \$(function() {
+       var userRating = parseInt(\$("#userRating").val(),10);
+       if(userRating > 0) {fill_stars(userRating,"in")}
+       star.selected = true;
+       star.id=userRating
+  });
+  var fill_stars = function(num, direction) {
+    if (direction === "in")
+      for (i = 0; i <= parseInt(num); i++)
+        \$("#" + i).removeClass('uncool').addClass('cool');
+    else
+      for (i = 0; i <= parseInt(num); i++)
+        \$("#" + i).removeClass('cool').addClass('uncool');
+  }
+
+</script>


### PR DESCRIPTION
This extends the package voting mechanism from boolean "stars"
to integral "lambdas", and using the statistical method outlined
in

-  http://www.evanmiller.org/how-not-to-sort-by-average-rating.html

to compute an overall score.

This has been factored out of the HSoC work #514 by @SooryaN

The code has been refactored & cleaned up by Duncan, Gershom and myself.

----

TODOs:

- [x] Validate vote-update HTTP request data (you can currently vote an arbitrary rating other than {1,2,3})