### PR TITLE
Use session cookie to keep track of login-state

### DIFF
--- a/Distribution/Server/Features/Users.hs
+++ b/Distribution/Server/Features/Users.hs
@@ -37,6 +37,8 @@ import qualified Data.Text as T
 
 import Distribution.Text (display, simpleParse)
 
+import Happstack.Server.Cookie (addCookie, mkCookie, CookieLife(Session))
+import Happstack.Server.RqData (lookCookieValue)
 
 -- | A feature to allow manipulation of the database of users.
 --
@@ -407,11 +409,45 @@ userFeature templates usersState adminsState
         users   <- queryGetUserDb
         guardAuthenticatedWithErrHook users
 
+    -- [Note about authentication & `authn` hint cookie]
+    --
+    -- HTTP clients usually don't perform http authentication eagerly
+    -- (especially w/ digest auth). However, 'checkAuthenticated'
+    -- needs to a way to detect whether the browser has cached
+    -- credentials, and validate them if available.
+    --
+    -- In order to workaround this HTTP property, we keep a
+    -- client-side boolean state /hint/ in the transient `authn`
+    -- session cookie, which is supposed to have more or less the same
+    -- lifetime as the browser's cached http authentication:
+    --
+    --  - authn="1"  when the user session is /assumed/ to be authenticated
+    --               (i.e. the browser will supply credentials when asked)
+    --  - authn="0"  when the user session is /assumed/ to be anonymous
+    --
+    -- Any other state (and when the `authn` cookie isn't present) is
+    -- handled like the authn="0" case
+    --
+    -- The authn="0" state is the default state.
+    --
+    -- The authn="1" state will be entered automatically whenever HTTP
+    -- authentication succeeds; whenever an authentication error
+    -- occurs, the authn="0" state is set.
+    --
+    -- IMPORTANT: We use the client-side `authn` cookie only as a hint;
+    --            it cannot be used to bypass authentication
+    --            validation.  If the `authn` cookie gets out of sync it
+    --            will be re-synced on the next authentication
+    --            attempt.
+
     -- As above but using the given userdb snapshot
+    -- See note about "authn" cookie above
     guardAuthenticatedWithErrHook :: Users.Users -> ServerPartE UserId
     guardAuthenticatedWithErrHook users = do
         (uid,_) <- Auth.checkAuthenticated realm users
                    >>= either handleAuthError return
+        addCookie Session (mkCookie "authn" "1")
+        -- Set-Cookie:authn="1";Path=/;Version="1"
         return uid
       where
         realm = Auth.hackageRealm --TODO: should be configurable
@@ -420,11 +456,20 @@ userFeature templates usersState adminsState
         handleAuthError err = do
           defaultResponse  <- Auth.authErrorResponse realm err
           overrideResponse <- msum <$> runHook authFailHook err
-          throwError (fromMaybe defaultResponse overrideResponse)
+          let resp' = fromMaybe defaultResponse overrideResponse
+              -- reset authn to "0" on auth failures
+              resp'' = resp' { errorHeaders = ("Set-Cookie","authn=\"0\";Path=/;Version=\"1\""):errorHeaders resp' }
+          throwError resp''
 
     -- Check if there is an authenticated userid, and return info, if so.
+    -- See note about "authn" cookie above
     checkAuthenticated :: ServerPartE (Maybe (UserId, UserInfo))
     checkAuthenticated = do
+        authn <- optional (lookCookieValue "authn")
+        case authn of
+          Just "1" -> void guardAuthenticated
+          _        -> pure ()
+
         users <- queryGetUserDb
         either (const Nothing) Just `fmap` Auth.checkAuthenticated Auth.hackageRealm users
 


### PR DESCRIPTION
HTTP clients usually don't perform http authentication eagerly
(especially w/ digest auth). However, 'checkAuthenticated'
needs to a way to detect whether the browser has cached
credentials, and validate them if available.

See source-code comment for more details.