### PR TITLE
Enhance Tagging feature

### DIFF
--- a/Distribution/Server/Features.hs
+++ b/Distribution/Server/Features.hs
@@ -241,6 +241,7 @@ initHackageFeatures env@ServerEnv{serverVerbosity = verbosity} = do
     tagsFeature     <- mkTagsFeature
                          coreFeature
                          uploadFeature
+                         usersFeature
 
     versionsFeature <- mkVersionsFeature
                          coreFeature

--- a/Distribution/Server/Features/Tags.hs
+++ b/Distribution/Server/Features/Tags.hs
@@ -9,16 +9,14 @@ module Distribution.Server.Features.Tags (
     constructTagIndex
   ) where
 
-import Control.Applicative (optional)
-
 import Distribution.Server.Framework
 import Distribution.Server.Framework.BackupDump
 
 import Distribution.Server.Features.Tags.State
 import Distribution.Server.Features.Tags.Backup
-
 import Distribution.Server.Features.Core
 import Distribution.Server.Features.Upload
+import Distribution.Server.Features.Users
 
 import qualified Distribution.Server.Packages.PackageIndex as PackageIndex
 import Distribution.Server.Packages.PackageIndex (PackageIndex)
@@ -47,11 +45,14 @@ data TagsFeature = TagsFeature {
 
     queryGetTagList     :: forall m. MonadIO m => m [(Tag, Set PackageName)],
     queryTagsForPackage :: forall m. MonadIO m => PackageName -> m (Set Tag),
+    queryReviewTagsForPackage :: forall m. MonadIO m => PackageName -> m (Set Tag,Set Tag),
+    queryAliasForTag :: forall m. MonadIO m => Tag -> m Tag,
 
     -- All package names that were modified, and all tags that were modified
     -- In almost all cases, one of these will be a singleton. Happstack
     -- functions should be used to query the resultant state.
     tagsUpdated :: Hook (Set PackageName, Set Tag) (),
+
     -- Calculated tags are used so that other features can reserve a
     -- tag for their own use (a calculated, rather than freely
     -- assignable, tag). It is a subset of the main mapping.
@@ -63,7 +64,8 @@ data TagsFeature = TagsFeature {
 
     withTagPath :: forall a. DynamicPath -> (Tag -> Set PackageName -> ServerPartE a) -> ServerPartE a,
     collectTags :: forall m. MonadIO m => Set PackageName -> m (Map PackageName (Set Tag)),
-    putTags     :: PackageName -> ServerPartE ()
+    putTags     :: Maybe String -> Maybe String -> Maybe String -> Maybe String -> PackageName -> ServerPartE (),
+    mergeTags   :: Maybe String -> Tag -> ServerPartE ()
 
 }
 
@@ -75,6 +77,8 @@ data TagsResource = TagsResource {
     tagListing :: Resource,
     packageTagsListing :: Resource,
     packageTagsEdit :: Resource,
+    tagAliasEdit :: Resource,
+    tagAliasEditForm :: Resource,
 
     tagUri :: String -> Tag -> String,
     tagsUri :: String -> String,
@@ -84,29 +88,33 @@ data TagsResource = TagsResource {
 initTagsFeature :: ServerEnv
                 -> IO (CoreFeature
                     -> UploadFeature
+                    -> UserFeature
                     -> IO TagsFeature)
 initTagsFeature ServerEnv{serverStateDir} = do
     tagsState <- tagsStateComponent serverStateDir
+    tagAlias <- tagsAliasComponent serverStateDir
     specials  <- newMemStateWHNF emptyPackageTags
     updateTag <- newHook
 
-    return $ \core@CoreFeature{..} upload -> do
-      let feature = tagsFeature core upload tagsState specials updateTag
+    return $ \core@CoreFeature{..} upload user -> do
+      let feature = tagsFeature core upload user tagsState tagAlias specials updateTag
 
       registerHookJust packageChangeHook isPackageChangeAny $ \(pkgid, mpkginfo) ->
         case mpkginfo of
           Nothing      -> return ()
           Just pkginfo -> do
             let pkgname = packageName pkgid
-                tags = Set.fromList . constructImmutableTags . pkgDesc $ pkginfo
-            updateState tagsState . SetPackageTags pkgname $ tags
-            runHook_ updateTag (Set.singleton pkgname, tags)
+                tags = constructImmutableTags . pkgDesc $ pkginfo
+            aliases <- mapM (queryState tagAlias . GetTagAlias) tags
+            let newtags = Set.fromList aliases
+            updateState tagsState . SetPackageTags pkgname $ newtags
+            runHook_ updateTag (Set.singleton pkgname, newtags)
 
       return feature
 
 tagsStateComponent :: FilePath -> IO (StateComponent AcidState PackageTags)
 tagsStateComponent stateDir = do
-  st <- openLocalStateFrom (stateDir </> "db" </> "Tags") initialPackageTags
+  st <- openLocalStateFrom (stateDir </> "db" </> "Tags" </> "Existing") initialPackageTags
   return StateComponent {
       stateDesc    = "Package tags"
     , stateHandle  = st
@@ -117,18 +125,33 @@ tagsStateComponent stateDir = do
     , resetState   = tagsStateComponent
     }
 
+tagsAliasComponent :: FilePath -> IO (StateComponent AcidState TagAlias)
+tagsAliasComponent stateDir = do
+  st <- openLocalStateFrom (stateDir </> "db" </> "Tags" </> "Alias") emptyTagAlias
+  return StateComponent {
+      stateDesc    = "Tags Alias"
+    , stateHandle  = st
+    , getState     = query st GetTagAliasesState
+    , putState     = update st . AddTagAliasesState
+    , backupState  = \_ aliases -> [csvToBackup ["aliases.csv"] $ aliasToCSV aliases]
+    , restoreState = aliasBackup
+    , resetState   = tagsAliasComponent
+    }
+
 tagsFeature :: CoreFeature
             -> UploadFeature
+            -> UserFeature
             -> StateComponent AcidState PackageTags
+            -> StateComponent AcidState TagAlias
             -> MemState PackageTags
             -> Hook (Set PackageName, Set Tag) ()
             -> TagsFeature
 
-tagsFeature CoreFeature{ queryGetPackageIndex
-                       , coreResource = CoreResource { guardValidPackageName }
-                       }
-            UploadFeature{ guardAuthorisedAsMaintainerOrTrustee }
+tagsFeature CoreFeature{ queryGetPackageIndex }
+            UploadFeature{ maintainersGroup, trusteesGroup }
+            UserFeature{ guardAuthorised' }
             tagsState
+            tagsAlias
             calculatedTags
             tagsUpdated
   = TagsFeature{..}
@@ -136,6 +159,8 @@ tagsFeature CoreFeature{ queryGetPackageIndex
     tagsResource = fix $ \r -> TagsResource
         { tagsListing = resourceAt "/packages/tags/.:format"
         , tagListing = resourceAt "/packages/tag/:tag.:format"
+        , tagAliasEdit = resourceAt "/packages/tag/:tag/alias"
+        , tagAliasEditForm = resourceAt "/packages/tag/:tag/alias/edit"
         , packageTagsListing = resourceAt "/package/:package/tags.:format"
         , packageTagsEdit    = resourceAt "/package/:package/tags/edit"
         , tagUri = \format tag -> renderResource (tagListing r) [display tag, format]
@@ -169,13 +194,21 @@ tagsFeature CoreFeature{ queryGetPackageIndex
     initImmutableTags = do
             index <- queryGetPackageIndex
             let calcTags = tagPackages $ constructImmutableTagIndex index
-            forM_ (Map.toList calcTags) $ uncurry setCalculatedTag
+            aliases <- mapM (queryState tagsAlias . GetTagAlias) $ Map.keys calcTags
+            let calcTags' = Map.toList . Map.fromListWith Set.union $ zip aliases (Map.elems calcTags)
+            forM_ calcTags' $ uncurry setCalculatedTag
 
     queryGetTagList :: MonadIO m => m [(Tag, Set PackageName)]
     queryGetTagList = queryState tagsState GetTagList
 
     queryTagsForPackage :: MonadIO m => PackageName -> m (Set Tag)
     queryTagsForPackage pkgname = queryState tagsState (TagsForPackage pkgname)
+
+    queryAliasForTag :: MonadIO m => Tag -> m Tag
+    queryAliasForTag tag = queryState tagsAlias (GetTagAlias tag)
+
+    queryReviewTagsForPackage :: MonadIO m => PackageName -> m (Set Tag,Set Tag)
+    queryReviewTagsForPackage pkgname = queryState tagsState (LookupReviewTags pkgname)
 
     setCalculatedTag :: Tag -> Set PackageName -> IO ()
     setCalculatedTag tag pkgs = do
@@ -195,18 +228,68 @@ tagsFeature CoreFeature{ queryGetPackageIndex
         pkgMap <- liftM packageTags $ queryState tagsState GetPackageTags
         return $ Map.fromDistinctAscList . map (\pkg -> (pkg, Map.findWithDefault Set.empty pkg pkgMap)) $ Set.toList pkgs
 
-    putTags :: PackageName -> ServerPartE ()
-    putTags pkgname = do
-      guardValidPackageName pkgname
-      guardAuthorisedAsMaintainerOrTrustee pkgname
-      mtags <- optional $ look "tags"
-      case simpleParse =<< mtags of
-          Just (TagList tags) -> do
-              calcTags <- fmap (packageToTags pkgname) $ readMemState calculatedTags
-              let tagSet = Set.fromList tags `Set.union` calcTags
-              void $ updateState tagsState $ SetPackageTags pkgname tagSet
-              runHook_ tagsUpdated (Set.singleton pkgname, tagSet)
-              return ()
+    mergeTags :: Maybe String -> Tag -> ServerPartE ()
+    mergeTags targetTag deprTag =
+        case simpleParse =<< targetTag of
+            Just (Tag orig) -> do
+                index <- queryGetPackageIndex
+                void $ updateState tagsAlias $ AddTagAlias (Tag orig) deprTag
+                void $ constructMergedTagIndex (Tag orig) deprTag index
+            _ -> errBadRequest "Tag not recognised" [MText "Couldn't parse tag. It should be a single tag."]
+
+    -- tags on merging
+    constructMergedTagIndex :: forall m. (Functor m, MonadIO m) => Tag -> Tag -> PackageIndex PkgInfo -> m PackageTags
+    constructMergedTagIndex orig depr = foldM addToTags emptyPackageTags . PackageIndex.allPackagesByName
+      where addToTags calcTags pkgList = do
+                let info = pkgDesc $ last pkgList
+                    !pn = packageName info
+                pkgTags <- queryTagsForPackage pn
+                if Set.member depr pkgTags
+                    then do
+                        let newTags = Set.delete depr (Set.insert orig pkgTags)
+                        void $ updateState tagsState $ SetPackageTags pn newTags
+                        runHook_ tagsUpdated (Set.singleton pn, newTags)
+                        return $ setTags pn newTags calcTags
+                    else return $ setTags pn pkgTags calcTags
+
+    putTags :: Maybe String -> Maybe String -> Maybe String -> Maybe String -> PackageName -> ServerPartE ()
+    putTags addns delns raddns rdelns pkgname =
+      case simpleParse =<< addns of
+          Just (TagList add) ->
+                case simpleParse =<< delns of
+                    Just (TagList del) -> do
+                        trustainer <- guardAuthorised' [InGroup (maintainersGroup pkgname), InGroup trusteesGroup]
+                        user <- guardAuthorised' [AnyKnownUser]
+                        if trustainer
+                            then do
+                                calcTags <- queryTagsForPackage pkgname
+                                aliases <- mapM (queryState tagsAlias . GetTagAlias) add
+                                revTags <- queryReviewTagsForPackage pkgname
+                                let tagSet = (addTags `Set.union` calcTags) `Set.difference` delTags
+                                    addTags = Set.fromList aliases
+                                    delTags = Set.fromList del
+                                    rdel' = case simpleParse =<< rdelns of
+                                        Just (TagList rdel) -> rdel
+                                        Nothing -> []
+                                    radd' = case simpleParse =<< raddns of
+                                        Just (TagList radd) -> radd
+                                        Nothing -> []
+                                    addRev = Set.difference (fst revTags) (Set.fromList add `Set.union` Set.fromList radd')
+                                    delRev = Set.difference (snd revTags) (Set.fromList del `Set.union` Set.fromList rdel')
+                                void $ updateState tagsState $ SetPackageTags pkgname tagSet
+                                void $ updateState tagsState $ InsertReviewTags' pkgname addRev delRev
+                                runHook_ tagsUpdated (Set.singleton pkgname, tagSet)
+                                return ()
+                            else if user
+                                then do
+                                    aliases <- mapM (queryState tagsAlias . GetTagAlias) add
+                                    calcTags <- queryTagsForPackage pkgname
+                                    let addTags = Set.fromList aliases `Set.difference` calcTags
+                                        delTags = Set.fromList del `Set.intersection` calcTags
+                                    void $ updateState tagsState $ InsertReviewTags pkgname addTags delTags
+                                    return ()
+                                else errBadRequest "Authorization Error" [MText "You need to be logged in to propose tags"]
+                    _ -> errBadRequest "Tags not recognized" [MText "Couldn't parse your tag list. It should be comma separated with any number of alphanumerical tags. Tags can also also have -+#*."]
           Nothing -> errBadRequest "Tags not recognized" [MText "Couldn't parse your tag list. It should be comma separated with any number of alphanumerical tags. Tags can also also have -+#*."]
 
 -- initial tags, on import
@@ -249,6 +332,7 @@ constructImmutableTags genDesc =
     ++ (if he then [Tag "program"] else [])
     ++ (if ht then [Tag "test"] else [])
     ++ (if hb then [Tag "benchmark"] else [])
+    ++ constructCategoryTags desc
   where
     licenseToTag :: License -> [Tag]
     licenseToTag l = case l of

--- a/Distribution/Server/Features/Tags/Backup.hs
+++ b/Distribution/Server/Features/Tags/Backup.hs
@@ -1,7 +1,10 @@
 module Distribution.Server.Features.Tags.Backup (
     tagsBackup,
+    aliasBackup,
     tagsToCSV,
-    tagsToRecord
+    aliasToCSV,
+    tagsToRecord,
+    aliasToRecord,
   ) where
 
 import Distribution.Server.Features.Tags.State
@@ -28,6 +31,19 @@ updateTags tagsState = RestoreBackup {
         else return (updateTags tagsState)
   , restoreFinalize = return tagsState
   }
+aliasBackup :: RestoreBackup TagAlias
+aliasBackup = updateAlias emptyTagAlias
+
+updateAlias :: TagAlias -> RestoreBackup TagAlias
+updateAlias tagAliases = RestoreBackup {
+    restoreEntry = \(BackupByteString entry bs) ->
+      if entry == ["tagAlias.csv"]
+        then do csv <- importCSV "tagAlias.csv" bs
+                tagAliases' <- updateFromCSVA csv tagAliases
+                return (updateAlias tagAliases')
+        else return (updateAlias tagAliases)
+  , restoreFinalize = return tagAliases
+  }
 
 updateFromCSV :: CSV -> PackageTags -> Restore PackageTags
 updateFromCSV = concatM . map fromRecord
@@ -39,11 +55,26 @@ updateFromCSV = concatM . map fromRecord
       return (setTags pkgname (Set.fromList tags) tagsState)
     fromRecord x _ = fail $ "Invalid tags record: " ++ show x
 
+updateFromCSVA :: CSV -> TagAlias -> Restore TagAlias
+updateFromCSVA = concatM . map fromRecord
+  where
+    fromRecord :: Record -> TagAlias -> Restore TagAlias
+    fromRecord (canonical:aliases) tagsAlias | not (null aliases) = do
+      tag <- parseText "tag" canonical
+      alias <- mapM (parseText "tag") aliases
+      return (setAliases tag (Set.fromList alias) tagsAlias)
+    fromRecord x _ = fail $ "Invalid tags record: " ++ show x
+
 ------------------------------------------------------------------------------
 tagsToCSV :: PackageTags -> CSV
 tagsToCSV = map (\(p, t) -> tagsToRecord p $ Set.toList t)
           . Map.toList . packageTags
 
+aliasToCSV :: TagAlias -> CSV
+aliasToCSV (TagAlias ta) = map (\(t, a) -> aliasToRecord t $ Set.toList a) . Map.toList $ ta
+
 tagsToRecord :: PackageName -> [Tag] -> Record -- [String]
 tagsToRecord pkgname tags = display pkgname:map display tags
 
+aliasToRecord :: Tag -> [Tag] -> Record -- [String]
+aliasToRecord canonical aliases = display canonical:map display aliases

--- a/Distribution/Server/Features/Tags/State.hs
+++ b/Distribution/Server/Features/Tags/State.hs
@@ -64,11 +64,38 @@ data PackageTags = PackageTags {
     -- the primary index
     packageTags :: Map PackageName (Set Tag),
     -- a secondary reverse mapping
-    tagPackages :: Map Tag (Set PackageName)
+    tagPackages :: Map Tag (Set PackageName),
+    -- Packagename (Proposed Additions, Proposed Deletions)
+    reviewTags :: Map PackageName (Set Tag, Set Tag)
 } deriving (Eq, Show, Typeable)
 
+
+data TagAlias = TagAlias (Map Tag (Set Tag)) deriving (Eq, Show, Typeable)
+
+addTagAlias :: Tag -> Tag -> Update TagAlias ()
+addTagAlias tag alias = do
+        TagAlias  m <- get
+        put (TagAlias (Map.insertWith Set.union tag (Set.singleton alias) m))
+
+lookupTagAlias :: Tag -> Query TagAlias (Maybe (Set Tag))
+lookupTagAlias tag
+    = do TagAlias m <- ask
+         return (Map.lookup tag m)
+
+getTagAlias :: Tag -> Query TagAlias Tag
+getTagAlias tag
+    = do TagAlias m <- ask
+         if tag `elem` Map.keys m
+            then return tag
+            else if tag `Set.member` foldr Set.union Set.empty (Map.elems m)
+                then return $ head (Map.keys $ Map.filter (tag `Set.member`) m)
+                else return tag
+
 emptyPackageTags :: PackageTags
-emptyPackageTags = PackageTags Map.empty Map.empty
+emptyPackageTags = PackageTags Map.empty Map.empty Map.empty
+
+emptyTagAlias :: TagAlias
+emptyTagAlias = TagAlias Map.empty
 
 tagToPackages :: Tag -> PackageTags -> Set PackageName
 tagToPackages tag = Map.findWithDefault Set.empty tag . tagPackages
@@ -77,36 +104,40 @@ packageToTags :: PackageName -> PackageTags -> Set Tag
 packageToTags pkg = Map.findWithDefault Set.empty pkg . packageTags
 
 alterTags :: PackageName -> Maybe (Set Tag) -> PackageTags -> PackageTags
-alterTags name mtagList (PackageTags tags packages) =
+alterTags name mtagList pt@(PackageTags tags packages _) =
     let tagList = fromMaybe Set.empty mtagList
         oldTags = Map.findWithDefault Set.empty name tags
         adjustPlusTags pkgMap tag' = addSetMap tag' name pkgMap
         adjustMinusTags pkgMap tag' = removeSetMap tag' name pkgMap
         packages' = flip (foldl' adjustPlusTags) (Set.toList $ Set.difference tagList oldTags)
                   $ foldl' adjustMinusTags packages (Set.toList $ Set.difference oldTags tagList)
-    in PackageTags (Map.alter (const mtagList) name tags) packages'
+    in pt{
+        packageTags = Map.alter (const mtagList) name tags,
+        tagPackages = packages'
+    }
 
 setTags :: PackageName -> Set Tag -> PackageTags -> PackageTags
 setTags pkgname tagList = alterTags pkgname (keepSet tagList)
+
+setAliases :: Tag -> Set Tag -> TagAlias -> TagAlias
+setAliases tag aliases (TagAlias ta) = TagAlias (Map.insertWith Set.union tag aliases ta)
 
 deletePackageTags :: PackageName -> PackageTags -> PackageTags
 deletePackageTags name = alterTags name Nothing
 
 addTag :: PackageName -> Tag -> PackageTags -> Maybe PackageTags
-addTag name tag (PackageTags tags packages) =
+addTag name tag (PackageTags tags packages review) =
     let existing = Map.findWithDefault Set.empty name tags
-    in case tag `Set.member` existing of
-        True  -> Nothing
-        False -> Just $ PackageTags (addSetMap name tag tags)
-                                    (addSetMap tag name packages)
+    in if tag `Set.member` existing then Nothing else Just $ PackageTags (addSetMap name tag tags)
+                                   (addSetMap tag name packages)
+                                   review
 
 removeTag :: PackageName -> Tag -> PackageTags -> Maybe PackageTags
-removeTag name tag (PackageTags tags packages) =
+removeTag name tag (PackageTags tags packages review) =
     let existing = Map.findWithDefault Set.empty name tags
-    in case tag `Set.member` existing of
-        True -> Just $ PackageTags (removeSetMap name tag tags)
-                                   (removeSetMap tag name packages)
-        False -> Nothing
+    in if tag `Set.member` existing then Just $ PackageTags (removeSetMap name tag tags)
+                                  (removeSetMap tag name packages)
+                                  review else Nothing
 
 addSetMap :: (Ord k, Ord a) => k -> a -> Map k (Set a) -> Map k (Set a)
 addSetMap key val = Map.alter (Just . Set.insert val . fromMaybe Set.empty) key
@@ -115,14 +146,14 @@ removeSetMap :: (Ord k, Ord a) => k -> a -> Map k (Set a) -> Map k (Set a)
 removeSetMap key val = Map.update (keepSet . Set.delete val) key
 
 alterTag :: Tag -> Maybe (Set PackageName) -> PackageTags -> PackageTags
-alterTag tag mpkgList (PackageTags tags packages) =
+alterTag tag mpkgList (PackageTags tags packages review) =
     let pkgList = fromMaybe Set.empty mpkgList
         oldPkgs = Map.findWithDefault Set.empty tag packages
         adjustPlusPkgs tagMap name' = addSetMap name' tag tagMap
         adjustMinusPkgs tagMap name' = removeSetMap name' tag tagMap
         tags' = flip (foldl' adjustPlusPkgs) (Set.toList $ Set.difference pkgList oldPkgs)
               $ foldl' adjustMinusPkgs tags (Set.toList $ Set.difference oldPkgs pkgList)
-    in PackageTags tags' (Map.alter (const mpkgList) tag packages)
+    in PackageTags tags' (Map.alter (const mpkgList) tag packages) review
 
 keepSet :: Ord a => Set a -> Maybe (Set a)
 keepSet s = if Set.null s then Nothing else Just s
@@ -135,19 +166,20 @@ deleteTag :: Tag -> PackageTags -> PackageTags
 deleteTag tag = alterTag tag Nothing
 
 renameTag :: Tag -> Tag -> PackageTags -> PackageTags
-renameTag tag tag' pkgTags@(PackageTags _ packages) =
+renameTag tag tag' pkgTags@(PackageTags _ packages _) =
     let oldPkgs = Map.findWithDefault Set.empty tag packages
     in setTag tag' oldPkgs . deleteTag tag $ pkgTags
 -------------------------------------------------------------------------------
 
 $(deriveSafeCopy 0 'base ''Tag)
 $(deriveSafeCopy 0 'base ''PackageTags)
+$(deriveSafeCopy 0 'base ''TagAlias)
 
 instance NFData PackageTags where
-    rnf (PackageTags a b) = rnf a `seq` rnf b
+    rnf (PackageTags a b c) = rnf a `seq` rnf b `seq` rnf c
 
 instance MemSize PackageTags where
-    memSize (PackageTags a b) = memSize2 a b
+    memSize (PackageTags a b c) = memSize3 a b c
 
 initialPackageTags :: PackageTags
 initialPackageTags = emptyPackageTags
@@ -167,11 +199,19 @@ getPackageTags = ask
 replacePackageTags :: PackageTags -> Update PackageTags ()
 replacePackageTags = put
 
+getTagAliasesState :: Query TagAlias TagAlias
+getTagAliasesState = ask
+
+addTagAliasesState :: TagAlias -> Update TagAlias ()
+addTagAliasesState = put
+
+
 setPackageTags :: PackageName -> Set Tag -> Update PackageTags ()
 setPackageTags name tagList = modify $ setTags name tagList
 
 setTagPackages :: Tag -> Set PackageName -> Update PackageTags ()
 setTagPackages tag pkgList = modify $ setTag tag pkgList
+
 
 -- | Tag a package. Returns True if the element was inserted, and False if
 -- the tag as already present (same result though)
@@ -191,7 +231,37 @@ removePackageTag name tag = do
         Nothing -> return False
         Just pkgTags' -> put pkgTags' >> return True
 
-makeAcidic ''PackageTags ['tagsForPackage
+clearReviewTags :: PackageName -> Update PackageTags ()
+clearReviewTags pkgname = do
+        PackageTags p t r <- get
+        put (PackageTags p t (Map.insert pkgname (Set.empty,Set.empty) r))
+
+insertReviewTags :: PackageName -> Set Tag -> Set Tag -> Update PackageTags ()
+insertReviewTags pkgname add del = do
+        PackageTags p t r <- get
+        put (PackageTags p t (Map.insertWith insertReviewHelper pkgname (add,del) r))
+
+insertReviewTags' :: PackageName -> Set Tag -> Set Tag -> Update PackageTags ()
+insertReviewTags' pkgname add del = do
+        PackageTags p t r <- get
+        put (PackageTags p t (Map.insert pkgname (add,del) r))
+
+
+insertReviewHelper :: (Set Tag, Set Tag) -> (Set Tag, Set Tag) -> (Set Tag, Set Tag)
+insertReviewHelper (a,b) (c,d) = (Set.union a c, Set.union b d)
+
+lookupReviewTags :: PackageName -> Query PackageTags (Set Tag, Set Tag)
+lookupReviewTags pkgname = asks $ Map.findWithDefault (Set.empty, Set.empty) pkgname . reviewTags
+
+
+$(makeAcidic ''TagAlias ['addTagAlias
+                        ,'getTagAlias
+                        ,'lookupTagAlias
+                        ,'addTagAliasesState
+                        ,'getTagAliasesState
+                      ])
+
+$(makeAcidic ''PackageTags ['tagsForPackage
                          ,'packagesForTag
                          ,'getTagList
                          ,'getPackageTags
@@ -200,5 +270,10 @@ makeAcidic ''PackageTags ['tagsForPackage
                          ,'setTagPackages
                          ,'addPackageTag
                          ,'removePackageTag
-                         ]
+                         ,'insertReviewTags
+                         ,'insertReviewTags'
+                         ,'lookupReviewTags
+                         ,'clearReviewTags
+                         ])
+
 

--- a/Distribution/Server/Packages/Render.hs
+++ b/Distribution/Server/Packages/Render.hs
@@ -169,8 +169,9 @@ data IsBuildable = Buildable
 
 categorySplit :: String -> [String]
 categorySplit xs | all isSpace xs = []
-categorySplit xs = map (dropWhile isSpace) $ splitOn ',' xs
+categorySplit xs = if last res == "" then init res else res
   where
+    res = map (dropWhile isSpace) $ splitOn ',' xs
     splitOn x ys = front : case back of
                            [] -> []
                            (_:ys') -> splitOn x ys'

--- a/datafiles/templates/Html/package-page.html.st
+++ b/datafiles/templates/Html/package-page.html.st
@@ -19,7 +19,8 @@
 
     <h1>The $package.name$ package</h1>
     <div style="font-size: small">
-      [<a href="/packages/tags">Tags</a>:$tags$]
+      [ <a href="/packages/tags">Tags: </a>$tags$ ]
+      [ <a href="/package/$package.name$/tags/edit">Propose Tags </a> ]
     </div>
 
     $if(isDeprecated)$

--- a/datafiles/templates/Html/tag-edit.html.st
+++ b/datafiles/templates/Html/tag-edit.html.st
@@ -1,0 +1,157 @@
+<!DOCTYPE html>
+<html>
+
+    <head>
+        $hackageCssTheme()$
+        <title>Edit package tags | Hackage</title>
+        <script src="/static/jquery.min.js"></script>
+        <style>
+            .accept {
+                color: green;
+            }
+            .reject {
+                color: red;
+            }
+            .eadd,
+            .edel {
+                clear: both;
+            }
+            #additions,
+            #deletions {
+                list-style: none;
+                margin: 0px;
+            }
+            #additions li,
+            #deletions li {
+                padding: 1%;
+                margin: 1%;
+                float: left;
+                display: inline-block;
+                border: 1px solid black;
+            }
+            #additions:hover,
+            #deletions:hover {
+                background: white;
+            }
+        </style>
+    </head>
+
+    <body>
+        $hackagePageHeader()$
+        <div id="content">
+            Set tags for <a href="/package/$pkgname$">$pkgname$</a>
+            <div class="box">
+                <p><b>Current Tags</b>
+                    <br />$tags$</p>
+                <form method="post" action="/package/$pkgname$/tags">
+                    <input type="hidden" name="_method" id="_method" value="PUT" />
+                    <dl>
+                        <dd>
+                            <label for="addns">Propose Additions </label>
+                            <input type="text" value="" name="addns" id="addns" />
+                        </dd>
+                    </dl>
+                    <dl>
+                        <dd>
+                            <label for="delns">Propose Deletions </label>
+                            <input type="text" value="" name="delns" id="delns" />
+                        </dd>
+                    </dl>
+                    <input hidden="true" type="text" value="" name="raddns" id="raddns" />
+                    <input hidden="true" type="text" value="" name="rdelns" id="rdelns" />
+                    <input type="submit" value="Propose tags" />
+                </form>
+                $if(isuser)$
+                <div class="proposals">
+                    <big>Other proposals</big>
+                    <span class="eadd"><br><b>additions: </b>$addns$</span>
+                    <span class="edel"><br><b>deletions: </b>$delns$</span>
+                </div>
+                $endif$ $if(istrustee)$
+                <div id="trustee" class="proposals">
+                    <big>Proposals</big>
+                    <span class="eadd"><br><b>additions: </b>
+                  <ul id ="additions"></ul>
+              </span>
+                    <div style="clear:both"> </div>
+                    <span class="edel"><br><b>deletions: </b>
+                  <ul id = "deletions"></ul>
+              </span>
+                </div>
+                <script>
+                    var insert = function(element, tag) {
+                        if (element.val().trim())
+                            element.val(element.val() + ',' + tag)
+                        else
+                            element.val(tag)
+                    }
+
+                    \$("#trustee").on("click", "li span", function(e) {
+                        \$(this).parent().hide()
+                        var tag = \$(this).parent().text().trim().split(' ')[0]
+                        if (\$(this).attr('class') == 'accept') {
+                            if (\$(this).parent().parent().attr('id') == 'additions')
+                                insert(\$("#addns"), tag)
+                            else if (\$(this).parent().parent().attr('id') == 'deletions')
+                                insert(\$("#delns"), tag)
+                        } else if (\$(this).attr('class') == 'reject') {
+                            if (\$(this).parent().parent().attr('id') == 'additions')
+                                insert(\$("#raddns"), tag)
+                            else if (\$(this).parent().parent().attr('id') == 'deletions')
+                                insert(\$("#rdelns"), tag)
+                        }
+                    })
+                    if ("$delns$".trim() == "" && "$addns$".trim() == "")\$('.proposals').each(function(i, obj) {
+                        \$(this).hide()
+                    });
+                    var aList = \$('#additions')
+                    var dList = \$("#deletions")
+
+                    if ("$addns$".trim() != "") {
+                        var ads = "$addns$".replace(/\s/g, '').split(',')
+                        \$.each(ads, function(i) {
+                            var li = \$('<li/>')
+                                .text(ads[i])
+                                .appendTo(aList);
+                            var aaa = \$("<span class='accept'> &#x2713;</span> <span class='reject'>&#x2717;</span>")
+                                .appendTo(li);
+                        });
+                    }
+
+
+                    if ("$delns$".trim() != "") {
+                        var dels = "$delns$".replace(/\s/g, '').split(',')
+
+                        \$.each(dels, function(i) {
+                            var li = \$('<li/>')
+                                .text(dels[i])
+                                .appendTo(dList);
+                            var aaa = \$("<span class='accept'> &#x2713;</span> <span class='reject'>&#x2717;<span>")
+                                .appendTo(li);
+                        });
+                    }
+
+                </script>
+                $endif$
+                <div style="clear:both"> </div>
+            </div>
+        </div>
+        $footer()$
+    </body>
+    <script>
+        if ("$addns$".trim() == "" || "$delns$".trim() == "") {
+            if ("$addns$".trim() != "")
+                \$(".edel").each(function(i, obj) {
+                    \$(this).hide()
+                });
+            else if ("$delns$".trim() != "")
+                \$(".eadd").each(function(i, obj) {
+                    \$(this).hide()
+                });
+            else
+                \$(".proposals").each(function(i, obj) {
+                    \$(this).hide()
+                });
+        }
+    </script>
+</html>


### PR DESCRIPTION
- UI for proposing tag changes

- Clickable UI for accepting/rejecting tags

- Add GET method to /package/:pkgname/tags

- Categories are parsed into tags

- Tag aliasing support
  (When a trustee aliases Tag abcd -> Tag abc, all packages that were earlier
  tagged `abcd` get tagged to `abc` and any new packages tagged `abcd` get
  retagged `abc` on upload)

This has been factored out of the HSoC work #514 by @SooryaN

The code has been refactored & cleaned up by Duncan, Gershom and Herbert.