### PR TITLE
Read haddocks new meta.json and prepare for QuickNav

### DIFF
--- a/Distribution/Server/Features/Html.hs
+++ b/Distribution/Server/Features/Html.hs
@@ -48,6 +48,7 @@ import qualified Distribution.Server.Pages.Group as Pages
 -- [reverse index disabled] import qualified Distribution.Server.Pages.Reverse as Pages
 import qualified Distribution.Server.Pages.Index as Pages
 import Distribution.Server.Util.CountingMap (cmFind, cmToList)
+import Distribution.Server.Util.DocMeta (loadTarDocMeta)
 import Distribution.Server.Util.ServeTarball (loadTarEntry)
 import Distribution.Simple.Utils ( cabalVersion )
 
@@ -567,6 +568,7 @@ mkHtmlCore ServerEnv{serverBaseURI}
           documentationFeature reportsFeature realpkg
         mdocIndex     <- maybe (return Nothing)
           (liftM Just . liftIO . cachedTarIndex) mdoctarblob
+        mdocMeta      <- loadTarDocMeta mdocIndex pkgid
 
         let infoUrl = fmap (\_ -> preferredPackageUri versions "" pkgname) $
               sumRange prefInfo
@@ -592,7 +594,7 @@ mkHtmlCore ServerEnv{serverBaseURI}
           ] ++
           -- Items not related to IO (mostly pure functions)
           PagesNew.packagePageTemplate render
-            mdocIndex mreadme
+            mdocIndex mdocMeta mreadme
             docURL distributions
             deprs
             utilities

--- a/Distribution/Server/Pages/PackageFromTemplate.hs
+++ b/Distribution/Server/Pages/PackageFromTemplate.hs
@@ -8,6 +8,7 @@ module Distribution.Server.Pages.PackageFromTemplate
 import Distribution.Server.Framework.Templating
 import Distribution.Server.Features.PreferredVersions
 
+import Distribution.Server.Util.DocMeta
 import Distribution.Server.Packages.Render
 import Distribution.Server.Users.Types (userStatus, userName, isActiveAccount)
 import Data.TarIndex (TarIndex)
@@ -73,18 +74,19 @@ import Distribution.Server.Features.Html.HtmlUtilities
 --    package's upload time, the last time it was updated, and the number of
 --    votes it has.
 packagePageTemplate :: PackageRender
-            -> Maybe TarIndex -> Maybe BS.ByteString
+            -> Maybe TarIndex -> Maybe DocMeta -> Maybe BS.ByteString
             -> URL -> [(DistroName, DistroPackageInfo)]
             -> Maybe [PackageName]
             -> HtmlUtilities
             -> [TemplateAttr]
 packagePageTemplate render
-            mdocIndex mreadme
+            mdocIndex mdocMeta mreadme
             docURL distributions
             deprs utilities =
   -- The main two namespaces
   [ "package"           $= packageFieldsTemplate
   , "hackage"           $= hackageFieldsTemplate
+  , "doc"               $= docFieldsTemplate
   ] ++
 
   -- Miscellaneous things that could still stand to be refactored a bit.
@@ -134,6 +136,11 @@ packagePageTemplate render
       , templateVal "maintainer"    (Old.maintainField $ rendMaintainer render)
       , templateVal "buildDepends"  (snd (Old.renderDependencies render))
       , templateVal "optional"      optionalPackageInfoTemplate
+      ]
+
+    docFieldsTemplate = templateDict $
+      [ templateVal "hasQuickNavV1" hasQuickNavV1
+      , templateVal "baseUrl" docURL
       ]
 
     -- Fields that may be empty, along with booleans to see if they're present.
@@ -242,6 +249,14 @@ packagePageTemplate render
                 intersperse (toHtml ", ") .
                 map (packageNameLink utilities) $ fors
       Nothing -> noHtml
+
+    hasQuickNavGen :: Maybe DocMeta -> Version -> Bool
+    hasQuickNavGen (Just docMeta) expected =
+      docMetaHaddockVersion docMeta == expected
+    hasQuickNavGen _ _ = False
+
+    hasQuickNavV1 :: Bool
+    hasQuickNavV1 = hasQuickNavGen mdocMeta (mkVersion [2, 18, 2])
 
 -- #ToDo: Pick out several interesting versions to display, with a link to
 -- display all versions.

--- a/Distribution/Server/Util/DocMeta.hs
+++ b/Distribution/Server/Util/DocMeta.hs
@@ -25,7 +25,7 @@ newtype JsonVersion = JV Version
 instance FromJSON JsonVersion where
   parseJSON = withText "Version" $ \s ->
     case simpleParse (Text.unpack s) of
-      Just version -> pure (JV version)
+      Just version -> return (JV version)
       Nothing      -> mzero
 
 data DocMeta = DocMeta {

--- a/Distribution/Server/Util/DocMeta.hs
+++ b/Distribution/Server/Util/DocMeta.hs
@@ -37,11 +37,11 @@ instance FromJSON DocMeta where
     JV haddockVersion <- o .: "haddock_version"
     return DocMeta { docMetaHaddockVersion = haddockVersion }
 
-loadTarDocMeta :: MonadIO m => Maybe TarIndex -> PackageId -> m (Maybe DocMeta)
-loadTarDocMeta (Just docIndex) pkgid =
+loadTarDocMeta :: MonadIO m => FilePath -> TarIndex -> PackageId -> m (Maybe DocMeta)
+loadTarDocMeta tarball docIndex pkgid =
   case TarIndex.lookup docIndex docMetaPath of
     Just (TarIndex.TarFileEntry docMetaEntryOff) -> do
-      docMetaEntryContent <- liftIO (loadTarEntry docMetaPath docMetaEntryOff)
+      docMetaEntryContent <- liftIO (loadTarEntry tarball docMetaEntryOff)
       case docMetaEntryContent of
         Right (_, docMetaContent) ->
           return (parseDocMeta docMetaContent)
@@ -49,8 +49,6 @@ loadTarDocMeta (Just docIndex) pkgid =
     _ -> return Nothing
   where
     docMetaPath = packageDocMetaTarPath pkgid
-loadTarDocMeta _ _ = return Nothing
-
 
 parseDocMeta :: Data.ByteString.Lazy.ByteString -> Maybe DocMeta
 parseDocMeta = decode

--- a/Distribution/Server/Util/DocMeta.hs
+++ b/Distribution/Server/Util/DocMeta.hs
@@ -1,0 +1,60 @@
+{-# LANGUAGE OverloadedStrings #-}
+module Distribution.Server.Util.DocMeta (
+    DocMeta(..)
+  , loadTarDocMeta
+  , parseDocMeta
+  , packageDocMetaTarPath
+  ) where
+
+import Control.Monad (mzero)
+import Control.Monad.IO.Class
+import Data.Aeson
+import qualified Data.ByteString.Lazy
+import Data.TarIndex (TarIndex)
+import qualified Data.TarIndex as TarIndex
+import qualified Data.Text as Text
+import Distribution.Package
+import Distribution.Text (display, simpleParse)
+import Distribution.Version (Version)
+import System.FilePath ((</>))
+
+import Distribution.Server.Util.ServeTarball (loadTarEntry)
+
+newtype JsonVersion = JV Version
+
+instance FromJSON JsonVersion where
+  parseJSON = withText "Version" $ \s ->
+    case simpleParse (Text.unpack s) of
+      Just version -> pure (JV version)
+      Nothing      -> mzero
+
+data DocMeta = DocMeta {
+  docMetaHaddockVersion :: !Version
+}
+
+instance FromJSON DocMeta where
+  parseJSON = withObject "DocMeta" $ \o -> do
+    JV haddockVersion <- o .: "haddock_version"
+    return DocMeta { docMetaHaddockVersion = haddockVersion }
+
+loadTarDocMeta :: MonadIO m => Maybe TarIndex -> PackageId -> m (Maybe DocMeta)
+loadTarDocMeta (Just docIndex) pkgid =
+  case TarIndex.lookup docIndex docMetaPath of
+    Just (TarIndex.TarFileEntry docMetaEntryOff) -> do
+      docMetaEntryContent <- liftIO (loadTarEntry docMetaPath docMetaEntryOff)
+      case docMetaEntryContent of
+        Right (_, docMetaContent) ->
+          return (parseDocMeta docMetaContent)
+        Left _ -> return Nothing
+    _ -> return Nothing
+  where
+    docMetaPath = packageDocMetaTarPath pkgid
+loadTarDocMeta _ _ = return Nothing
+
+
+parseDocMeta :: Data.ByteString.Lazy.ByteString -> Maybe DocMeta
+parseDocMeta = decode
+
+packageDocMetaTarPath :: PackageId -> FilePath
+packageDocMetaTarPath pkgid =
+  display pkgid ++ "-docs" </> "meta.json"

--- a/datafiles/templates/Html/package-page.html.st
+++ b/datafiles/templates/Html/package-page.html.st
@@ -224,7 +224,7 @@
   <script src="$doc.baseUrl$/preact.js" type="text/javascript"></script>
   <script src="$doc.baseUrl$/fuse.js" type="text/javascript"></script>
   <script src="$doc.baseUrl$/index.js" type="text/javascript"></script>
-  <script type="text/javascript"> quickNav.init("$doc.baseUrl$"); </script>
+  <script type="text/javascript"> quickNav.init("$doc.baseUrl$", function() {}); </script>
   $endif$
 </body>
 </html>

--- a/datafiles/templates/Html/package-page.html.st
+++ b/datafiles/templates/Html/package-page.html.st
@@ -220,5 +220,11 @@
   $packagePageAssets()$
   $footer()$
 
+  $if(doc.hasQuickNavV1)$
+  <script src="$doc.baseUrl$/preact.js" type="text/javascript"></script>
+  <script src="$doc.baseUrl$/fuse.js" type="text/javascript"></script>
+  <script src="$doc.baseUrl$/index.js" type="text/javascript"></script>
+  <script type="text/javascript"> quickNav.init("$doc.baseUrl$"); </script>
+  $endif$
 </body>
 </html>

--- a/hackage-server.cabal
+++ b/hackage-server.cabal
@@ -188,6 +188,7 @@ library lib-server
     Distribution.Server.Util.Histogram
     Distribution.Server.Util.CountingMap
     Distribution.Server.Util.CabalRevisions
+    Distribution.Server.Util.DocMeta              
     Distribution.Server.Util.Parse
     Distribution.Server.Util.ServeTarball
     -- [unused] Distribution.Server.Util.TarIndex


### PR DESCRIPTION
@hvr This PR teaches hackage to read haddocks new `meta.json`. `meta.json` contains useful additional information about the generated documentation (see https://github.com/haskell/haddock/pull/676). 

We use the additional information to integrate haddocks new QuickNav feature on the package page. As this integration is likely to change in the future it is guarded by the haddock version. 