### PR TITLE
Avoid checking useless tarball permissions when mirroring (fixes #483)

### DIFF
--- a/Distribution/Server/Packages/Unpack.hs
+++ b/Distribution/Server/Packages/Unpack.hs
@@ -395,7 +395,7 @@ tarballChecks :: Bool -> UTCTime -> FilePath
 tarballChecks lax now expectedDir =
     (if not lax then checkFutureTimes now else id)
   . checkTarbomb expectedDir
-  . checkUselessPermissions
+  . (if not lax then checkUselessPermissions else id)
   . (if lax then ignoreShortTrailer
             else fmapTarError (either id PortabilityError)
                . Tar.checkPortability)


### PR DESCRIPTION
This lets us mirror existing packages which have been uploaded prior to #409 properly.