### PR TITLE
Prepare for QuickJump v1

### DIFF
--- a/Distribution/Server/Pages/PackageFromTemplate.hs
+++ b/Distribution/Server/Pages/PackageFromTemplate.hs
@@ -135,8 +135,7 @@ packagePageTemplate render
       ]
 
     docFieldsTemplate = templateDict $
-      [ templateVal "hasQuickNavV0" hasQuickNavV0
-      , templateVal "hasQuickNavV1" hasQuickNavV1
+      [ templateVal "hasQuickNavV1" hasQuickNavV1
       , templateVal "baseUrl" docURL
       ]
 
@@ -247,8 +246,6 @@ packagePageTemplate render
                 map (packageNameLink utilities) $ fors
       Nothing -> noHtml
 
-    -- starting with haddock 2.19.1 QuickJump is versioned
-    -- explicitly.
     hasQuickNavVersion :: Int -> Bool
     hasQuickNavVersion expected
       | Just docMeta <- mdocMeta
@@ -257,20 +254,11 @@ packagePageTemplate render
       | otherwise
       = False
 
-    -- the initial prototype didn't have a separate versioning
-    -- scheme for the QuickJump feature.
-    hasQuickNavV0 :: Bool
-    hasQuickNavV0
-      | Just docMeta <- mdocMeta
-      , Nothing      <- docMetaQuickJumpVersion docMeta
-      = docMetaHaddockVersion docMeta == mkVersion [2, 18, 2]
-      | otherwise = False
-
     hasQuickNavV1 :: Bool
     hasQuickNavV1 = hasQuickNavVersion 1
 
     hasQuickNav :: Bool
-    hasQuickNav = hasQuickNavV0 || hasQuickNavV1
+    hasQuickNav = hasQuickNavV1
 
 -- #ToDo: Pick out several interesting versions to display, with a link to
 -- display all versions.

--- a/Distribution/Server/Util/DocMeta.hs
+++ b/Distribution/Server/Util/DocMeta.hs
@@ -1,6 +1,8 @@
 {-# LANGUAGE OverloadedStrings #-}
+{-# LANGUAGE RecordWildCards   #-}
 module Distribution.Server.Util.DocMeta (
     DocMeta(..)
+  , QuickJumpVersion
   , loadTarDocMeta
   , parseDocMeta
   , packageDocMetaTarPath
@@ -28,14 +30,18 @@ instance FromJSON JsonVersion where
       Just version -> return (JV version)
       Nothing      -> mzero
 
+type QuickJumpVersion = Int
+
 data DocMeta = DocMeta {
-  docMetaHaddockVersion :: !Version
+  docMetaHaddockVersion   :: !Version,
+  docMetaQuickJumpVersion :: !(Maybe QuickJumpVersion)
 }
 
 instance FromJSON DocMeta where
   parseJSON = withObject "DocMeta" $ \o -> do
-    JV haddockVersion <- o .: "haddock_version"
-    return DocMeta { docMetaHaddockVersion = haddockVersion }
+    JV docMetaHaddockVersion <- o .:  "haddock_version"
+    docMetaQuickJumpVersion  <- o .:? "quickjump_version"
+    return DocMeta{..}
 
 loadTarDocMeta :: MonadIO m => FilePath -> TarIndex -> PackageId -> m (Maybe DocMeta)
 loadTarDocMeta tarball docIndex pkgid =

--- a/datafiles/templates/Html/package-page.html.st
+++ b/datafiles/templates/Html/package-page.html.st
@@ -1,8 +1,11 @@
 <!DOCTYPE html>
 <html>
 <head>
-  $if(doc.hasQuickNavV1)$
+  $if(doc.hasQuickNavV0)$
   <link href="$doc.baseUrl$/ocean.css" rel="stylesheet" type="text/css" title="Ocean" />
+  $endif$
+  $if(doc.hasQuickNavV1)$
+  <link href="$doc.baseUrl$/quick-jump.css" rel="stylesheet" type="text/css" title="QuickJump" />
   $endif$
   $hackageCssTheme()$
   <title>
@@ -232,10 +235,14 @@
   $packagePageAssets()$
   $footer()$
 
-  $if(doc.hasQuickNavV1)$
+  $if(doc.hasQuickNavV0)$
   <script src="$doc.baseUrl$/preact.js" type="text/javascript"></script>
   <script src="$doc.baseUrl$/fuse.js" type="text/javascript"></script>
   <script src="$doc.baseUrl$/index.js" type="text/javascript"></script>
+  <script type="text/javascript"> quickNav.init("$doc.baseUrl$", function(toggle) {var t = document.getElementById('quickjump-trigger');if (t) {t.onclick = function(e) { e.preventDefault(); toggle(); };}}); </script>
+  $endif$
+  $if(doc.hasQuicknavV1)$
+  <script src="$doc.baseUrl$/quick-jump.js" type="text/javascript"></script>
   <script type="text/javascript"> quickNav.init("$doc.baseUrl$", function(toggle) {var t = document.getElementById('quickjump-trigger');if (t) {t.onclick = function(e) { e.preventDefault(); toggle(); };}}); </script>
   $endif$
 </body>

--- a/datafiles/templates/Html/package-page.html.st
+++ b/datafiles/templates/Html/package-page.html.st
@@ -1,9 +1,6 @@
 <!DOCTYPE html>
 <html>
 <head>
-  $if(doc.hasQuickNavV0)$
-  <link href="$doc.baseUrl$/ocean.css" rel="stylesheet" type="text/css" title="Ocean" />
-  $endif$
   $if(doc.hasQuickNavV1)$
   <link href="$doc.baseUrl$/quick-jump.css" rel="stylesheet" type="text/css" title="QuickJump" />
   $endif$
@@ -235,12 +232,6 @@
   $packagePageAssets()$
   $footer()$
 
-  $if(doc.hasQuickNavV0)$
-  <script src="$doc.baseUrl$/preact.js" type="text/javascript"></script>
-  <script src="$doc.baseUrl$/fuse.js" type="text/javascript"></script>
-  <script src="$doc.baseUrl$/index.js" type="text/javascript"></script>
-  <script type="text/javascript"> quickNav.init("$doc.baseUrl$", function(toggle) {var t = document.getElementById('quickjump-trigger');if (t) {t.onclick = function(e) { e.preventDefault(); toggle(); };}}); </script>
-  $endif$
   $if(doc.hasQuicknavV1)$
   <script src="$doc.baseUrl$/quick-jump.js" type="text/javascript"></script>
   <script type="text/javascript"> quickNav.init("$doc.baseUrl$", function(toggle) {var t = document.getElementById('quickjump-trigger');if (t) {t.onclick = function(e) { e.preventDefault(); toggle(); };}}); </script>

--- a/datafiles/templates/Html/package-page.html.st
+++ b/datafiles/templates/Html/package-page.html.st
@@ -232,8 +232,8 @@
   $packagePageAssets()$
   $footer()$
 
-  $if(doc.hasQuicknavV1)$
-  <script src="$doc.baseUrl$/quick-jump.js" type="text/javascript"></script>
+  $if(doc.hasQuickNavV1)$
+  <script src="$doc.baseUrl$/quick-jump.min.js" type="text/javascript"></script>
   <script type="text/javascript"> quickNav.init("$doc.baseUrl$", function(toggle) {var t = document.getElementById('quickjump-trigger');if (t) {t.onclick = function(e) { e.preventDefault(); toggle(); };}}); </script>
   $endif$
 </body>


### PR DESCRIPTION
We cleaned up the javascript and css integration in haddock. 

And as of https://github.com/haskell/haddock/commit/aca68f620beb07f9bdebdf52948c6ea670be4980 we explicitly version the QuickJump ABI. This should make integration with hackage easier in the future.