### PR TITLE
Make adding hackage security data atomic with package upload

### DIFF
--- a/Distribution/Server/Features/Core.hs
+++ b/Distribution/Server/Features/Core.hs
@@ -506,7 +506,7 @@ coreFeature ServerEnv{serverBlobStore = store} UserFeature{..}
           (userName userInfo)
           additionalEntries
 
-      loginfo maxBound ("updateState(AddPackage2," ++ display pkgid ++ ") -> " ++ show successFlag)
+      loginfo maxBound ("updateState(AddPackage3," ++ display pkgid ++ ") -> " ++ show successFlag)
       if successFlag
         then runHook_ packageChangeHook (PackageChangeAdd pkginfo)
         else return ()

--- a/Distribution/Server/Features/Core.hs
+++ b/Distribution/Server/Features/Core.hs
@@ -1,4 +1,7 @@
-{-# LANGUAGE RankNTypes, NamedFieldPuns, RecordWildCards, RecursiveDo #-}
+{-# LANGUAGE NamedFieldPuns  #-}
+{-# LANGUAGE RankNTypes      #-}
+{-# LANGUAGE RecordWildCards #-}
+{-# LANGUAGE RecursiveDo     #-}
 module Distribution.Server.Features.Core (
     CoreFeature(..),
     CoreResource(..),
@@ -18,38 +21,40 @@ module Distribution.Server.Features.Core (
   ) where
 
 -- stdlib
-import Data.Aeson (Value(..))
-import Data.ByteString.Lazy (ByteString)
-import Data.Maybe (isNothing)
-import Data.Time.Clock (UTCTime, getCurrentTime)
-import Data.Time.Format (formatTime)
-import Data.Time.Locale.Compat (defaultTimeLocale)
-import qualified Codec.Compression.GZip as GZip
-import qualified Data.Foldable          as Foldable
-import qualified Data.HashMap.Strict    as HashMap
-import qualified Data.Text              as Text
-import qualified Data.Vector            as Vec
+import qualified Codec.Compression.GZip                             as GZip
+import           Data.Aeson                                         (Value (..))
+import           Data.ByteString.Lazy                               (ByteString)
+import qualified Data.Foldable                                      as Foldable
+import qualified Data.HashMap.Strict                                as HashMap
+import           Data.Maybe                                         (isNothing)
+import qualified Data.Text                                          as Text
+import           Data.Time.Clock                                    (UTCTime, getCurrentTime)
+import           Data.Time.Format                                   (formatTime)
+import           Data.Time.Locale.Compat                            (defaultTimeLocale)
+import qualified Data.Vector                                        as Vec
 
 -- hackage
-import Distribution.Server.Features.Core.Backup
-import Distribution.Server.Features.Core.State
-import Distribution.Server.Features.Security.Migration
-import Distribution.Server.Features.Users
-import Distribution.Server.Framework
-import Distribution.Server.Packages.Index (TarIndexEntry(..))
-import Distribution.Server.Packages.PackageIndex (PackageIndex)
-import Distribution.Server.Packages.Types
-import Distribution.Server.Users.Types (UserId, userName)
-import Distribution.Server.Users.Users (userIdToName, lookupUserId)
+import           Distribution.Server.Features.Core.Backup
+import           Distribution.Server.Features.Core.State
+import           Distribution.Server.Features.Security.Migration
+import           Distribution.Server.Features.Users
+import           Distribution.Server.Framework
 import qualified Distribution.Server.Framework.BlobStorage          as BlobStorage
 import qualified Distribution.Server.Framework.ResponseContentTypes as Resource
+import           Distribution.Server.Packages.Index                 (TarIndexEntry (..))
 import qualified Distribution.Server.Packages.Index                 as Packages.Index
+import           Distribution.Server.Packages.PackageIndex          (PackageIndex)
 import qualified Distribution.Server.Packages.PackageIndex          as PackageIndex
+import           Distribution.Server.Packages.Types
+import           Distribution.Server.Users.Types                    (UserId,
+                                                                     userName)
+import           Distribution.Server.Users.Users                    (lookupUserId,
+                                                                     userIdToName)
 
 -- Cabal
-import Distribution.Text (display)
-import Distribution.Package
-import Distribution.Version (nullVersion)
+import           Distribution.Package
+import           Distribution.Text                                  (display)
+import           Distribution.Version                               (nullVersion)
 
 -- | The core feature, responsible for the main package index and all access
 -- and modifications of it.
@@ -497,7 +502,7 @@ coreFeature ServerEnv{serverBlobStore = store} UserFeature{..}
       let Just userInfo = lookupUserId uid usersdb
 
       let pkginfo = mkPackageInfo pkgid cabalFile uploadinfo mtarball
-      additionalEntries <- concat <$> runHook preIndexUpdateHook  (PackageChangeAdd pkginfo)
+      additionalEntries <- concat `liftM` runHook preIndexUpdateHook  (PackageChangeAdd pkginfo)
 
       successFlag <- updateState packagesState $
         AddPackage3

--- a/Distribution/Server/Features/Security.hs
+++ b/Distribution/Server/Features/Security.hs
@@ -50,6 +50,14 @@ initSecurityFeature env = do
        -- which will override any previous one.
        --
        -- TODO: We cannot deal with deletes (they are a problem elsewhere too)
+       --
+       -- NOTE: this hook is in general _not atomic_ with the package index update related to it.
+       -- It is atomic _only_ in the PackageChangeAdd case. As most other significant cases are no-ops
+       -- at the moment for adding index entries, this should be ok. (The exception is updated tarball
+       -- but this is only used for the mirror client).
+       --
+       -- If in the future more stuff is registered here, we may need to change code elsewhere
+       -- to ensure that it is added atomically as well...
        registerHook (preIndexUpdateHook coreFeature) $ \chg -> do
          let (ents,msg) = case chg of
                       PackageChangeAdd      pkg -> (indexEntriesFor pkg,"PackageChangeAdd")
@@ -245,4 +253,3 @@ getTUFFile :: Sec.Path Sec.Absolute -> IO TUFFile
 getTUFFile file =
     Sec.withFile file Sec.ReadMode $ \h ->
       evaluate . mkTUFFile =<< BS.Lazy.hGetContents h
-


### PR DESCRIPTION
Should fix #488 for future uploads.

The note on line 337 or so is key. Rather than refactor _every_ transaction to accept additional tarball entries, this change, attempting to be minimal, _only_ refactors the `AddPackage` call, and its sole point of usage in `updateAddPackage`.

The only provider of the `preIndexUpdateHook` at the moment is hackage security, and the hook itself is only not a no-op for adding packages and updating tarballs (the latter only used by hackage mirror). As we extend the hook we may need to make more things atomic. But for the time being this is intended as a minimal refactor to fix the bug, with enough attendant comments to point the way for future work.