### PR TITLE
Improve appearance and readability

### DIFF
--- a/Distribution/Server/Features/Html.hs
+++ b/Distribution/Server/Features/Html.hs
@@ -1364,10 +1364,10 @@ mkHtmlPreferred HtmlUtilities{..}
                   , intercalate ", " (map display deprs)]
         , toHtml "The version range given to this package, therefore, is " +++ strong (toHtml $ rendSumRange pref)
         , h4 << "Versions affected"
-        , paragraph << "Orange versions are normal versions. Green are those out of any preferred version ranges. Gray are deprecated."
-        , paragraph << (snd $ Pages.renderVersion
-                                  (PackageIdentifier pkgname $ nullVersion)
-                                  (classifyVersions prefInfo $ map packageVersion pkgs) Nothing)
+        , paragraph << "Green versions are normal versions. Yellow are those out of any preferred version ranges. Red are deprecated."
+        , paragraph ! [theclass "versions"] << snd (Pages.renderVersion
+                              (PackageIdentifier pkgname nullVersion)
+                              (classifyVersions prefInfo $ map packageVersion pkgs) Nothing)
         ]
 
     servePutPreferred :: DynamicPath -> ServerPartE Response

--- a/Distribution/Server/Pages/Package.hs
+++ b/Distribution/Server/Pages/Package.hs
@@ -440,7 +440,7 @@ renderVersion (PackageIdentifier pname pversion) allVersions info =
                                ++ map versionedLink laterVersions
         versionedLink (v, s) = anchor ! (status s ++ [href $ packageURL $ PackageIdentifier pname v]) << display v
         status st = case st of
-            NormalVersion -> []
+            NormalVersion -> [theclass "normal"]
             DeprecatedVersion  -> [theclass "deprecated"]
             UnpreferredVersion -> [theclass "unpreferred"]
         infoHtml = case info of Nothing -> noHtml; Just str -> " (" +++ (anchor ! [href str] << "info") +++ ")"

--- a/datafiles/static/hackage.css
+++ b/datafiles/static/hackage.css
@@ -51,7 +51,7 @@ a[href]:hover { text-decoration:underline; }
  */
 
 body {
-	font: 300 14px/1.85 "Merriweather Sans", sans-serif;
+	font: 400 15px/1.85 'Open Sans', sans-serif;
 	*font-size:small; /* for IE */
 	*font:x-small; /* for IE in quirks mode */
 }
@@ -218,7 +218,7 @@ pre {
     text-align: left;
     float: right;
     display: inline-table;
-    margin: 3px 2em 0 2em;
+    margin: 2px 2em 0 2em;
   }
 
   #content {

--- a/datafiles/static/hackage.css
+++ b/datafiles/static/hackage.css
@@ -190,14 +190,14 @@ ul.links li a, ul.links li form {
 }
 
 pre {
-  padding: 17px;
-  margin: 1em 0 2em 0;
+  padding: 1rem;
+  margin: 0px;
   background-color: rgba(0, 0, 0, .033);
   overflow: auto;
-  border-bottom: 0.25em solid white;
-  /* white border adds some space below the box to compensate
-     for visual extra space that paragraphs have between baseline
-     and the bounding box */
+}
+
+pre + pre {
+  margin-top: 0.4em;
 }
 
 .src {

--- a/datafiles/static/hackage.css
+++ b/datafiles/static/hackage.css
@@ -224,7 +224,7 @@ pre {
     text-align: left;
     float: right;
     display: inline-table;
-    margin: 2px 2em 0 2em;
+    margin: 0.35em 2em 0 2em;
   }
 
   #content {
@@ -271,10 +271,10 @@ pre {
 
 
 #page-header {
-  background: rgb(94, 81, 132);
-  border-bottom: 5px solid rgba(69, 59, 97, 0.5);
+  background: #5E5184;
+  border-bottom: 0.35em solid rgba(69, 59, 97, 0.5);
   color: #ddd;
-  padding: 0.6em 0 0.2em 0;
+  padding: 0.6em 0 0.3em 0;
   position: relative;
   font-size: 1.2em;
   margin: 0 auto;
@@ -287,7 +287,7 @@ pre {
   font-weight: bold;
   font-style: normal;
   padding-left: 2.2em;
-  font-size: 1.05rem;
+  font-size: 1rem;
 }
 
 #page-header a:link, #page-header a:visited { color: white; }

--- a/datafiles/static/hackage.css
+++ b/datafiles/static/hackage.css
@@ -17,8 +17,16 @@ body {
   position: relative;
 }
 
+table, ul {
+	line-height: 1.35rem;
+}
+
+ul li + li {
+	margin-top: 0.4rem;
+}
+
 p {
-  margin: 0.8em 0;
+  margin-top: 1.1rem;
 }
 
 ul, ol {
@@ -51,7 +59,7 @@ a[href]:hover { text-decoration:underline; }
  */
 
 body {
-	font: 400 16px/1.75 'Open Sans', sans-serif;
+	font: 400 16px/1.6 'Open Sans', sans-serif;
 	*font-size:small; /* for IE */
 	*font:x-small; /* for IE in quirks mode */
 }
@@ -119,13 +127,12 @@ pre, code, kbd, samp, .src {
 
 .caption, h1, h2, h3, h4, h5, h6 {
   font-weight: bold;
-  color: rgb(142, 80, 132);
-  margin: 2em 0 1em 0;
+  color: #5E5184;
+  margin: 1.8em 0 0.95em 0;
   line-height: 1.25em;
 }
 
 h1:first-of-type {
-    color: rgb(94, 81, 132);
     font-size: 2em;
 }
 
@@ -139,7 +146,7 @@ h1 + h2, h2 + h3, h3 + h4, h4 + h5, h5 + h6 {
 }
 
 p + ul {
-  margin-top: 1em;
+  margin-top: 0.75em;
 }
 
 ul + p {
@@ -164,21 +171,21 @@ ul.links li a, ul.links li form {
 .show { display: inherit; }
 .clear { clear: both; }
 
-.collapser {
-  background-image: url(minus.gif);
-  background-repeat: no-repeat;
+.collapser:before, .expander:before {
+  font-size: 0.9em;
+  color: #5E5184;
+  display: inline-block;
+  padding-right: 7px;
 }
-.expander {
-  background-image: url(plus.gif);
-  background-repeat: no-repeat;
+
+.collapser:before {
+  content: '-'
 }
-p.caption.collapser,
-p.caption.expander {
-  background-position: 0 0.4em;
+.expander:before {
+  content: "+";
 }
+
 .collapser, .expander {
-  padding-left: 14px;
-  margin-left: -14px;
   cursor: pointer;
 }
 
@@ -277,9 +284,10 @@ pre {
   background: url(icons/ic_haskell_grayscale_32.svg) no-repeat 0em;
   color: white;
   margin: 0 2em;
-  font-weight: normal;
+  font-weight: bold;
   font-style: normal;
   padding-left: 2.2em;
+  font-size: 1.05rem;
 }
 
 #page-header a:link, #page-header a:visited { color: white; }
@@ -433,14 +441,6 @@ ul.links li form button {
   margin: 0;
   font-size: 1px;
   padding: 0;
-}
-
-#synopsis p.caption.collapser {
-  background: url(synopsis.png) no-repeat -64px -8px;
-}
-
-#synopsis p.caption.expander {
-  background: url(synopsis.png) no-repeat 0px -8px;
 }
 
 #synopsis ul {
@@ -715,10 +715,6 @@ table.simpletable th, table.simpletable td {
   padding: 0.2em 1em;
 }
 
-table.properties td, table.properties th {
-  padding: 1px 0.25em;
-}
-
 table.properties td:first-child, table.properties th:first-child {
   padding-left: 0;
 }
@@ -746,12 +742,14 @@ table.fancy th {
   background: #f0f0f0;
 }
 
-table.fancy td, table.fancy th {
+table.fancy td, table.properties td,
+table.fancy th, table.properties th {
   padding: 0.25em 0.5em;
 }
 
-table {
-  line-height: 1.5em;
+table.properties tr th:first-child {
+  text-align: right;
+  padding-right: 12px;
 }
 
 table.dataTable.compact.fancy tbody th,

--- a/datafiles/static/hackage.css
+++ b/datafiles/static/hackage.css
@@ -749,6 +749,15 @@ table.fancy td, table.fancy th {
   padding: 0.25em 0.5em;
 }
 
+table {
+  line-height: 1.5em;
+}
+
+table.dataTable.compact.fancy tbody th,
+table.dataTable.compact.fancy tbody td {
+  padding: 6px 10px;
+}
+
 ul.searchresults li {
   margin-bottom: 1em;
 }

--- a/datafiles/static/hackage.css
+++ b/datafiles/static/hackage.css
@@ -222,7 +222,8 @@ pre {
 
   #content {
     width: 55vw;
-    max-width: 1200px;
+    max-width: 1450px;
+    min-width: 830px;
   }
 }
 

--- a/datafiles/static/hackage.css
+++ b/datafiles/static/hackage.css
@@ -15,6 +15,12 @@ body {
   text-align: left;
   min-height: 100%;
   position: relative;
+  -webkit-text-size-adjust: 100%;
+  -webkit-font-feature-settings: "kern" 1;
+  -moz-font-feature-settings: "kern" 1;
+  -o-font-feature-settings: "kern" 1;
+  font-feature-settings: "kern" 1;
+  font-kerning: normal;
 }
 
 table, ul {
@@ -89,6 +95,10 @@ pre, code, kbd, samp, .src {
 	line-height: 1.54em;
 }
 
+#page-header .links {
+  font-size: 1rem;
+}
+
 .links, .link {
   font-size: 85%; /* 11pt */
 }
@@ -114,10 +124,6 @@ pre, code, kbd, samp, .src {
     border-left: 6px solid #2196F3;
     padding: 0.01em 16px;
     margin-bottom: 8px;
-}
-
-#table-of-contents, #synopsis  {
-  /* font-size: 85%; /* 11pt */
 }
 
 
@@ -225,6 +231,13 @@ pre + pre {
     float: right;
     display: inline-table;
     margin: 0.35em 2em 0 2em;
+  }
+
+  #table-of-contents {
+    position: fixed;
+    left: 10px;
+    max-width: 10vw;
+    top: 10.2em;
   }
 
   #content {
@@ -391,18 +404,15 @@ ul.links li form button {
 /* @group Front Matter */
 
 #table-of-contents {
-  float: right;
-  clear: right;
-  background: #faf9dc;
-  border: 1px solid #d8d7ad;
-  padding: 0.5em 1em;
-  max-width: 20em;
-  margin: 0.5em 0 1em 1em;
+  background:  #f7f7f7;
+  padding: 1em;
+  margin: 1em 0 2em 0;
 }
 
 #table-of-contents .caption {
   text-align: left;
   margin: 0;
+  font-size: 1.08rem;
 }
 
 #table-of-contents ul {

--- a/datafiles/static/hackage.css
+++ b/datafiles/static/hackage.css
@@ -121,6 +121,7 @@ pre, code, kbd, samp, .src {
   font-weight: bold;
   color: rgb(142, 80, 132);
   margin: 2em 0 1em 0;
+  line-height: 1.25em;
 }
 
 h1:first-of-type {
@@ -143,14 +144,6 @@ p + ul {
 
 ul + p {
   margin-top: 2em;
-}
-
-ul.links {
-  list-style: none;
-  text-align: left;
-  float: right;
-  display: inline-table;
-  margin: 0 2em 0 2em;
 }
 
 ul.links li {
@@ -211,14 +204,57 @@ pre {
 
 /* @end */
 
+
+/* @group responsive */
+
+@media only screen and (min-width: 950px) {
+  #page-header {
+    text-align: left;
+    text-align: left;
+  }
+
+  #page-header ul.links {
+    list-style: none;
+    text-align: left;
+    float: right;
+    display: inline-table;
+    margin: 3px 2em 0 2em;
+  }
+
+  #content {
+    width: 55vw;
+  }
+}
+
+@media only screen and (max-width: 950px) {
+  #page-header {
+    text-align: center;
+  }
+
+  #page-header ul.links {
+    float: none;
+    display: block;
+    text-align: center;
+    margin: 14px 0 0px 0;
+    font-size: 13px;
+  }
+
+  #content {
+    width: 75vw;
+  }
+}
+
+
+/* @end */
+
 /* @group Page Structure */
 
 #content {
   margin: 0 auto;
   padding: 0;
-  width: 55vw;
   padding-bottom: 3em;
 }
+
 
 #page-header {
   background: rgb(94, 81, 132);
@@ -226,7 +262,6 @@ pre {
   color: #ddd;
   padding: 0.6em 0 0.2em 0;
   position: relative;
-  text-align: left;
   font-size: 1.2em;
   margin: 0 auto;
 }

--- a/datafiles/static/hackage.css
+++ b/datafiles/static/hackage.css
@@ -64,10 +64,10 @@ a[href]:hover { text-decoration:underline; }
       http://yui.yahooapis.com/3.1.1/build/cssfonts/fonts.css
  */
 
-body {
-	font: 400 16px/1.6 'Open Sans', sans-serif;
-	*font-size:small; /* for IE */
-	*font:x-small; /* for IE in quirks mode */
+body, button {
+  font: 400 15px/1.5 'Open Sans', sans-serif;
+  *font-size:small; /* for IE */
+  *font:x-small; /* for IE in quirks mode */
 }
 
 h1 { font-size: 153.9%; /* 20px */ }
@@ -78,9 +78,9 @@ h5 { font-size: 100%;   /* 13px */ }
 h6 { font-size: 100%;   /* 13px */ }
 
 select, input, button, textarea {
-	font:99% sans-serif;
-    margin: 0.5em;
-    padding: 0.1em;
+  font-size: 1rem;
+  margin: 0.5em;
+  padding: 0.1em;
 }
 
 table {
@@ -90,13 +90,7 @@ table {
 }
 
 pre, code, kbd, samp, .src {
-	font-family:monospace;
-	*font-size:108%;
-	line-height: 1.54em;
-}
-
-#page-header .links {
-  font-size: 1rem;
+	font-family: monospace;
 }
 
 .links, .link {
@@ -196,18 +190,22 @@ ul.links li a, ul.links li form {
 }
 
 pre {
-  padding: 1rem;
-  margin: 0px;
-  background-color: rgba(0, 0, 0, .033);
+  padding: 0.5rem 1rem;
+  margin: 1em 0;
+  background-color: #f7f7f7;
   overflow: auto;
 }
 
+pre + p {
+  margin-top: 1em;
+}
+
 pre + pre {
-  margin-top: 0.4em;
+  margin-top: 0.5em;
 }
 
 .src {
-  background: #f0f0f0;
+  background: #f4f4f4;
   padding: 0.2em 0.5em;
 }
 
@@ -230,7 +228,7 @@ pre + pre {
     text-align: left;
     float: right;
     display: inline-table;
-    margin: 0.35em 2em 0 2em;
+    margin: 2px 2em 0 2em;
   }
 
   #table-of-contents {
@@ -241,9 +239,8 @@ pre + pre {
   }
 
   #content {
-    width: 55vw;
+    width: 60vw;
     max-width: 1450px;
-    min-width: 830px;
   }
 }
 
@@ -257,7 +254,6 @@ pre + pre {
     display: block;
     text-align: center;
     margin: 14px 0 0px 0;
-    font-size: 15px;
   }
 
   #content {
@@ -294,7 +290,7 @@ pre + pre {
 }
 
 #page-header .caption {
-  background: url(icons/ic_haskell_grayscale_32.svg) no-repeat 0em;
+  background: url(https://hackage.haskell.org/static/icons/ic_haskell_grayscale_32.svg) no-repeat 0em;
   color: white;
   margin: 0 2em;
   font-weight: bold;
@@ -317,7 +313,7 @@ table.info {
   border: 1px solid #ddd;
   color: rgb(78,98,114);
   background-color: #fff;
-  max-width: 40%;
+  max-width: 60%;
   border-spacing: 0;
   position: relative;
   top: -0.78em;
@@ -374,7 +370,7 @@ div#style-menu-holder {
   position: absolute;
   width: 100%;
   height: 3em;
-  margin-top: 3em;
+  margin-top: 6em;
 }
 
 /* @end */
@@ -406,7 +402,8 @@ ul.links li form button {
 #table-of-contents {
   background:  #f7f7f7;
   padding: 1em;
-  margin: 1em 0 2em 0;
+  margin: 0;
+  margin-top: 1em;
 }
 
 #table-of-contents .caption {
@@ -475,7 +472,9 @@ ul.links li form button {
 /* @end */
 
 /* @group Main Content */
-
+#interface div.top + div.top {
+  margin-top: 3em;
+}
 #interface div.top { margin: 2em 0; }
 #interface h1 + div.top,
 #interface h2 + div.top,
@@ -484,12 +483,16 @@ ul.links li form button {
 #interface h5 + div.top {
  	margin-top: 1em;
 }
-#interface p.src .link {
+
+#interface .src .link {
   float: right;
-  color: #919191;
-  border-left: 1px solid #919191;
-  background: #f0f0f0;
-  padding: 0 0.5em 0.2em;
+  color: #888;
+  padding: 0 7px;
+  -moz-user-select: none;
+  font-weight: bold;
+  line-height: 30px;
+}
+#interface .src .selflink {
   margin: 0 -0.5em 0 0.5em;
 }
 
@@ -535,8 +538,25 @@ ul.links li form button {
   margin: 0;
 }
 
+
+.subs .subs .caption {
+  margin-top: 16px !important;
+  margin-bottom: 0px !important;
+}
+
+.subs .subs .caption + .src {
+  margin: 0px;
+  margin-top: 8px;
+}
+
+.subs .subs .src + .src {
+  margin-top: 8px;
+}
+
 .top p.src {
-  border-top: 1px solid #ccc;
+  border-bottom: 3px solid #e5e5e5;
+  line-height: 2rem;
+  margin-bottom: 1em;
 }
 
 .subs, .doc {

--- a/datafiles/static/hackage.css
+++ b/datafiles/static/hackage.css
@@ -770,12 +770,16 @@ ul.directory-list {
   text-decoration: underline;
 }
 
-/* Preferred and deprecated versions */
+/* Package versions */
 
-.deprecated {
-    color:#919191 !important;
+.versions a.normal[href]:link {
+    color: #61B01E;
 }
 
-.unpreferred {
-    color:#308014 !important;
+.versions a.unpreferred[href]:link {
+    color: #FACC1F;
+}
+
+.versions a.deprecated[href]:link {
+    color: #E80C43;
 }

--- a/datafiles/static/hackage.css
+++ b/datafiles/static/hackage.css
@@ -11,7 +11,7 @@ html {
 
 body {
   background: #fefefe;
-  color: #241F33;
+  color: #221D30;
   text-align: left;
   min-height: 100%;
   position: relative;
@@ -185,7 +185,7 @@ p.caption.expander {
 pre {
   padding: 17px;
   margin: 1em 0 2em 0;
-  background-color: rgba(0, 0, 0, .025);
+  background-color: rgba(0, 0, 0, .033);
   overflow: auto;
   border-bottom: 0.25em solid white;
   /* white border adds some space below the box to compensate
@@ -207,9 +207,8 @@ pre {
 
 /* @group responsive */
 
-@media only screen and (min-width: 950px) {
+@media only screen and (min-width: 1280px) {
   #page-header {
-    text-align: left;
     text-align: left;
   }
 
@@ -223,10 +222,11 @@ pre {
 
   #content {
     width: 55vw;
+    max-width: 1200px;
   }
 }
 
-@media only screen and (max-width: 950px) {
+@media only screen and (max-width: 1280px) {
   #page-header {
     text-align: center;
   }
@@ -241,6 +241,12 @@ pre {
 
   #content {
     width: 75vw;
+  }
+}
+
+@media only screen and (max-width: 950px) {
+  #content {
+    width: 88vw;
   }
 }
 

--- a/datafiles/static/hackage.css
+++ b/datafiles/static/hackage.css
@@ -51,8 +51,8 @@ dd {
 }
 
 a { text-decoration: none; }
-a[href]:link {color: #9C5791;}
-a[href]:visited {color: #5E3558;}
+a[href]:link {color: #4C2A47;}
+a[href]:visited {color: #9C5791;}
 a[href]:hover { text-decoration:underline; }
 
 /* @end */

--- a/datafiles/static/hackage.css
+++ b/datafiles/static/hackage.css
@@ -11,7 +11,7 @@ html {
 
 body {
   background: #fefefe;
-  color: rgba(69, 59, 97, 0.95);
+  color: #241F33;
   text-align: left;
   min-height: 100%;
   position: relative;
@@ -37,8 +37,8 @@ dd {
 }
 
 a { text-decoration: none; }
-a[href]:link { color: rgb(196,69,29); }
-a[href]:visited { color: rgb(171,105,84); }
+a[href]:link {color: #9C5791;}
+a[href]:visited {color: #5E3558;}
 a[href]:hover { text-decoration:underline; }
 
 /* @end */
@@ -51,7 +51,7 @@ a[href]:hover { text-decoration:underline; }
  */
 
 body {
-	font: 400 15px/1.85 'Open Sans', sans-serif;
+	font: 400 16px/1.75 'Open Sans', sans-serif;
 	*font-size:small; /* for IE */
 	*font:x-small; /* for IE in quirks mode */
 }
@@ -236,7 +236,7 @@ pre {
     display: block;
     text-align: center;
     margin: 14px 0 0px 0;
-    font-size: 13px;
+    font-size: 15px;
   }
 
   #content {

--- a/datafiles/static/hackage.css
+++ b/datafiles/static/hackage.css
@@ -10,8 +10,8 @@ html {
 }
 
 body {
-  background: white;
-  color: black;
+  background: #fefefe;
+  color: rgba(69, 59, 97, 0.95);
   text-align: left;
   min-height: 100%;
   position: relative;
@@ -51,7 +51,7 @@ a[href]:hover { text-decoration:underline; }
  */
 
 body {
-	font:11pt/1.4 sans-serif;
+	font: 300 14px/1.85 "Merriweather Sans", sans-serif;
 	*font-size:small; /* for IE */
 	*font:x-small; /* for IE in quirks mode */
 }
@@ -78,7 +78,7 @@ table {
 pre, code, kbd, samp, .src {
 	font-family:monospace;
 	*font-size:108%;
-	line-height: 124%;
+	line-height: 1.54em;
 }
 
 .links, .link {
@@ -119,9 +119,15 @@ pre, code, kbd, samp, .src {
 
 .caption, h1, h2, h3, h4, h5, h6 {
   font-weight: bold;
-  color: rgb(78,98,114);
-  margin: 0.8em 0 0.4em;
+  color: rgb(142, 80, 132);
+  margin: 2em 0 1em 0;
 }
+
+h1:first-of-type {
+    color: rgb(94, 81, 132);
+    font-size: 2em;
+}
+
 
 * + h1, * + h2, * + h3, * + h4, * + h5, * + h6 {
   margin-top: 2em;
@@ -131,19 +137,30 @@ h1 + h2, h2 + h3, h3 + h4, h4 + h5, h5 + h6 {
   margin-top: inherit;
 }
 
+p + ul {
+  margin-top: 1em;
+}
+
+ul + p {
+  margin-top: 2em;
+}
+
 ul.links {
   list-style: none;
   text-align: left;
   float: right;
   display: inline-table;
-  margin: 0 0 0 1em;
+  margin: 0 2em 0 2em;
 }
 
 ul.links li {
   display: inline;
-  border-left: 1px solid #ddd;
   white-space: nowrap;
   padding: 0;
+}
+
+ul.links li + li:before {
+  content: '\00B7';
 }
 
 ul.links li a, ul.links li form {
@@ -173,9 +190,9 @@ p.caption.expander {
 }
 
 pre {
-  padding: 0.25em;
-  margin: 0.8em 0;
-  background: rgb(229,237,244);
+  padding: 17px;
+  margin: 1em 0 2em 0;
+  background-color: rgba(0, 0, 0, .025);
   overflow: auto;
   border-bottom: 0.25em solid white;
   /* white border adds some space below the box to compensate
@@ -198,18 +215,20 @@ pre {
 
 #content {
   margin: 0 auto;
-  padding: 0 2em 6em;
-  max-width: 60em;
+  padding: 0;
+  width: 55vw;
+  padding-bottom: 3em;
 }
 
 #page-header {
-  background: rgb(41,56,69);
-  border-top: 5px solid rgb(78,98,114);
+  background: rgb(94, 81, 132);
+  border-bottom: 5px solid rgba(69, 59, 97, 0.5);
   color: #ddd;
-  padding: 0.2em;
+  padding: 0.6em 0 0.2em 0;
   position: relative;
   text-align: left;
-  font-size: 125%;
+  font-size: 1.2em;
+  margin: 0 auto;
 }
 
 #page-header .caption {
@@ -218,14 +237,13 @@ pre {
   margin: 0 2em;
   font-weight: normal;
   font-style: normal;
-  padding-left: 2em;
+  padding-left: 2.2em;
 }
 
 #page-header a:link, #page-header a:visited { color: white; }
-#page-header li a:hover { background: rgb(78,98,114); }
 
 #module-header .caption {
-  color: rgb(78,98,114);
+  color: rgb(94, 81, 132);
   font-weight: bold;
   border-bottom: 1px solid #ddd;
 }
@@ -239,7 +257,7 @@ table.info {
   max-width: 40%;
   border-spacing: 0;
   position: relative;
-  top: -0.5em;
+  top: -0.78em;
   margin: 0 0 0 2em;
 }
 
@@ -291,9 +309,9 @@ div#style-menu-holder {
   color: #666;
   text-align: center;
   position: absolute;
-  bottom: 0;
   width: 100%;
   height: 3em;
+  margin-top: 3em;
 }
 
 /* @end */
@@ -308,7 +326,6 @@ ul.links li form input {
   padding:1px;
   margin: 0px;
 	width: 8em;
-	background: #f0f0f0; /* url('/static/search.png') no-repeat 3px 4px; */
 }
 
 ul.links li form button {
@@ -316,10 +333,7 @@ ul.links li form button {
   margin: 0px;
   cursor:pointer;
   color: white;
-  background: rgb(41,56,69);
-}
-ul.links li form button:hover {
-  background: rgb(78,98,114);
+  background-color: transparent;
 }
 
 /* @end */
@@ -337,13 +351,15 @@ ul.links li form button:hover {
 }
 
 #table-of-contents .caption {
-  text-align: center;
+  text-align: left;
   margin: 0;
 }
 
 #table-of-contents ul {
   list-style: none;
   margin: 0;
+  margin-top: 10px;
+  font-size: 95%;
 }
 
 #table-of-contents ul ul {

--- a/datafiles/templates/Html/table-interface.html.st
+++ b/datafiles/templates/Html/table-interface.html.st
@@ -13,7 +13,7 @@
         $hackagePageHeader()$
 
         <div id="content">
-            <h2>$heading$</h2>
+            <h1>$heading$</h1>
             $content$
             <table id="table" style="width:650" class="fancy row-border order-column compact">
                 <thead>

--- a/datafiles/templates/hackageCssTheme.st
+++ b/datafiles/templates/hackageCssTheme.st
@@ -1,4 +1,4 @@
 <meta name="viewport" content="width=device-width, initial-scale=1">
-<link href="https://fonts.googleapis.com/css?family=Merriweather+Sans:300,300i,400,700" rel="stylesheet">
+<link href="https://fonts.googleapis.com/css?family=Open+Sans:400,400i,700" rel="stylesheet">
 <link rel="stylesheet" href="/static/hackage.css" type="text/css" />
 <link rel="search" type="application/opensearchdescription+xml" title="Hackage" href="/packages/opensearch.xml" />

--- a/datafiles/templates/hackageCssTheme.st
+++ b/datafiles/templates/hackageCssTheme.st
@@ -1,3 +1,4 @@
 <meta name="viewport" content="width=device-width, initial-scale=1">
+<link href="https://fonts.googleapis.com/css?family=Merriweather+Sans:300,300i,400,700" rel="stylesheet">
 <link rel="stylesheet" href="/static/hackage.css" type="text/css" />
 <link rel="search" type="application/opensearchdescription+xml" title="Hackage" href="/packages/opensearch.xml" />

--- a/datafiles/templates/hackagePageHeader.st
+++ b/datafiles/templates/hackagePageHeader.st
@@ -1,5 +1,11 @@
 <div id="page-header">
 
+$if(title)$
+$title$
+$else$
+<a class="caption" href="/">Hackage : : [Package]</a>
+$endif$
+
 <ul class="links" id="page-menu">
 
     <li><a href="/">Home</a></li>
@@ -20,11 +26,5 @@
     <li><a href="/accounts">User accounts</a></li>
 
 </ul>
-
-$if(title)$
-$title$
-$else$
-<a class="caption" href="/">Hackage :: [Package]</a>
-$endif$
 
 </div>


### PR DESCRIPTION
## Motive

I work with haddock and hackage almost daily, both at work and at home, and the current theme is unfriendly. I find it very hard to read content with such a wide `#content` and spacing is not great either. 

Furthermore, I'd say many Haskell developers would appreciate the presense of the latest Haskell's logo (purple) colors in these docs. 

(Together with https://github.com/haskell/haddock/pull/721)

## Changes

- use latest Haskell's logo colours
- decrease #content width to improve readability
- use, custom nicer font: [Merriweather Sans](https://fonts.google.com/specimen/Merriweather+Sans)
- improve sizes and distances
- responsiveness (the menu is now always fully visible and good looking) 


## Preview

**EDIT 04-02-2018**: See https://github.com/haskell/hackage-server/pull/648#issuecomment-362934971
<br>

**Before:**

<img width="1280" alt="before-hackage" src="https://user-images.githubusercontent.com/7075260/34363798-887f8d80-ea7f-11e7-90c9-3c48d76254de.png">


**After:**

<img width="1280" alt="hackage-after-big" src="https://user-images.githubusercontent.com/7075260/34386391-ad7cff1a-eb28-11e7-80e7-b426aa7a075f.png">

### Smartphone

**Before - iPhone 7**

<img width="255" alt="hackage-before-iphone7" src="https://user-images.githubusercontent.com/7075260/34386254-131ce03e-eb28-11e7-88a4-83d50d1ecffa.png">

**After - iPhone 7**

<img width="266" alt="hackage-after-iphone7" src="https://user-images.githubusercontent.com/7075260/34386277-275ec698-eb28-11e7-92a4-e4685193d622.png">

### Tablet

**Before - iPad horizontal**

<img width="601" alt="hackage-before-ipad-mini" src="https://user-images.githubusercontent.com/7075260/34386297-3d13de06-eb28-11e7-8fb5-8ccfe6a2b2d5.png">

**After - iPad horizontal**

<img width="628" alt="hackage-after-ipad-mini-lay" src="https://user-images.githubusercontent.com/7075260/34386289-34c23360-eb28-11e7-91c7-9380e5cd1457.png">

**Before - iPad vertical**

<img width="337" alt="hackage-before-ipad-mini-stand" src="https://user-images.githubusercontent.com/7075260/34386476-20a77880-eb29-11e7-9e6b-ed115e5a5b6b.png">



**After - iPad vertical**

<img width="356" alt="hackage-after-ipad-mini-stand" src="https://user-images.githubusercontent.com/7075260/34386479-2428a9e8-eb29-11e7-97e1-6735c6f082b9.png">


## Edit: Responsiveness

I have made it responsive so that it looks nice and reads well on both small and large screens. See commit summary for more information.