### PR TITLE
Use schemaless base URI on package page

### DIFF
--- a/Distribution/Server/Features/Html.hs
+++ b/Distribution/Server/Features/Html.hs
@@ -75,6 +75,7 @@ import qualified Data.Ix    as Ix
 import Data.Time.Format (formatTime)
 import Data.Time.Locale.Compat (defaultTimeLocale)
 import qualified Data.ByteString.Lazy as BS (ByteString)
+import qualified Network.URI as URI
 
 import Text.XHtml.Strict
 import qualified Text.XHtml.Strict as XHtml
@@ -593,7 +594,7 @@ mkHtmlCore ServerEnv{serverBaseURI, serverBlobStore}
 
         return $ toResponse . template $
           -- IO-related items
-          [ "baseurl"           $= show (serverBaseURI)
+          [ "baseurl"           $= show (serverBaseURI { URI.uriScheme = "" })
           , "cabalVersion"      $= display cabalVersion
           , "tags"              $= (renderTags tags)
           , "versions"          $= (PagesNew.renderVersion realpkg


### PR DESCRIPTION
Currently the base URI on the package page differs from the one requested:

Visiting http://hackage.haskell.org/package/Cabal-2.0.1.1/ leads to this base URI `<base href="https://hackage.haskell.org/package/Cabal-2.0.1.1/">`. Note the different protocol.

This leads to violations of the Same-Origin-Policy when requesting `doc-index.json` for the QuickJump feature: 

![bildschirmfoto 2018-01-16 um 07 48 07](https://user-images.githubusercontent.com/1876617/34975327-a3113c4e-fa91-11e7-827d-4c2b8def1a25.png)

With this patch we use a schemaless base URI to mitigate the problem.