### PR TITLE
Remove use of mempty for compat reasons

### DIFF
--- a/Distribution/Server/Features/Core/Backup.hs
+++ b/Distribution/Server/Features/Core/Backup.hs
@@ -56,7 +56,7 @@ updatePackages accum@(PartialIndex packageMap updatelog) = RestoreBackup {
   , restoreFinalize = do
       results <- mapM partialToFullPkg (Map.toList packageMap)
       return $ PackagesState (PackageIndex.fromList results)
-                             (maybe (Left mempty) Right updatelog)
+                             (maybe (Left []) Right updatelog)
   }
 
 data PartialIndex = PartialIndex !(Map PackageId PartialPkg)


### PR DESCRIPTION
Removes `mempty` introduced by 49f1fb7f658e034f9d33bcd993156dce24138617 for compat reasons.