### PR TITLE
table tooltips

### DIFF
--- a/datafiles/templates/Html/table-interface.html.st
+++ b/datafiles/templates/Html/table-interface.html.st
@@ -19,8 +19,8 @@
                 <thead>
                     <tr>
                         <th><div style="width:100px">Name</div></th>
-                        <th><div style="width:40px">DLs</div></th>
-                        <th><div style="width:50px">Rating</div></th>
+                        <th><div style="width:50px"><span title="(30 days)">DLs</span></div></th>
+                        <th><div style="width:50px"><span title="(0-3)">Rating</span></div></th>
                         <th><div style="width:160px">Description</div></th>
 			<th><div style="width:140px">Tags</div></th>
 			<th><div style="width:80px">Last U/L</th>


### PR DESCRIPTION
sort of resolves #642 

Adding "(30 days)" after "DLs" makes the table header unwieldy, so I addyed it as a tooltip. But that's really non-obvious to find. While I was at it I also added a tooltip to indicate ratings are 0-3.

But it would be better to have either A) better tooltips (via fancy css, I guess) or B) bite the bullet and go to 2-row headers or C) something else, I'm not sure what.

This certainly improves things slightly, but I'm not sure if it is enough :-/