### PR TITLE
Use non-breaking-space in package metadata table

### DIFF
--- a/datafiles/templates/Html/package-page.html.st
+++ b/datafiles/templates/Html/package-page.html.st
@@ -58,7 +58,7 @@
 
         $if(package.optional.hasChangelog)$
         <tr>
-          <th>Change log</th>
+          <th>Change&nbsp;log</th>
           <td>$package.optional.changelog$</td>
         </tr>
         $endif$
@@ -117,7 +117,7 @@
 
         $if(package.optional.hasBugTracker)$
         <tr>
-          <th>Bug tracker</th>
+          <th>Bug&nbsp;tracker</th>
           <td>
             <a href="$package.optional.bugTracker$">
               $package.optional.bugTracker$
@@ -128,7 +128,7 @@
 
         $if(package.optional.hasSourceRepository)$
         <tr>
-          <th>Source repository</th>
+          <th>Source&nbsp;repo</th>
           <td>$package.optional.sourceRepository$</td>
         </tr>
         $endif$
@@ -171,7 +171,7 @@
 	</tr>
 
 	<tr>
-	  <th>Your Rating</th>
+	  <th>Your&nbsp;Rating</th>
 	  <td>
             <ul class="star-rating">
               <li class="star uncool" id="1">&lambda;</li>


### PR DESCRIPTION
Source repository is currently split on two lines making table look "wrong". The name is long, but maybe this is till better:

![screenshot from 2018-02-11 17-05-06](https://user-images.githubusercontent.com/51087/36074807-2d8fbe42-0f4e-11e8-847a-aadeeb954870.png)