### PR TITLE
Increase visibility of note about sending an email to active accounts

### DIFF
--- a/datafiles/static/hackage.css
+++ b/datafiles/static/hackage.css
@@ -722,3 +722,8 @@ ul.directory-list {
 .unpreferred {
     color:#308014 !important;
 }
+
+p.registration-email {
+    border: 1px solid rgb(196,69,29);
+    padding: 0 1em;
+}

--- a/datafiles/templates/UserSignupReset/SignupRequest.html.st
+++ b/datafiles/templates/UserSignupReset/SignupRequest.html.st
@@ -48,15 +48,18 @@ such people choose a name (and username) that looks at home among a collection
 of real names; we will be unwilling to add Kittenlover97 to the package
 uploader group.
 
+<p class="registration-email">
+After your account is created, you cannot upload until you
+<b>contact the hackage admins</b> at admin@hackage.haskell.org and
+<b>send an email</b> requesting to be added to the uploader group.
+(This measure is unfortunately necessary to prevent spam accounts).
+</p>
+
 <p><input type="submit" value="Request account">
 
 <p>You will be sent an email containing a link to a page where you
 can set your password and activate your account.
 
-<p>After your account is created, you cannot upload until you
-<b>contact the hackage admins</b> at admin@hackage.haskell.org and
-<b>send an email</b> requesting to be added to the uploader group.
-(This measure is unfortunately necessary to prevent spam accounts).</p>
 </form>
 
 <h3>Open source licenses</h3>


### PR DESCRIPTION
I have seen multiple people complain in IRC that they are unable to upload packages over the last few days since they missed the note on the website that they need to send an email to active their accounts. Looking at the registration page, I would probably have missed it myself.

This PR tries to address this by moving the note above the registration button (nobody reads past that) and adding a red border around it. I’m sure this could be improved but in this case I think it’s more useful to address this quickly and then bikeshed the design later (iiuc this is only intended as a temporary measure anyway) than discussing the shade of red used in the border. :wink: 

Here’s a screenshot:

![screenshot-2018-3-7 register a new account hackage](https://user-images.githubusercontent.com/1313584/37106696-c31f90bc-2232-11e8-9749-ae59904cc2d2.png)
