### PR TITLE
account-management redirect page

### DIFF
--- a/Distribution/Server/Features/Users.hs
+++ b/Distribution/Server/Features/Users.hs
@@ -161,6 +161,8 @@ data UserResource = UserResource {
     adminResource :: GroupResource,
     -- | Manage a user
     manageUserResource :: Resource,
+    -- | Redirect users to their management page
+    redirectUserResource :: Resource,
 
     -- | URI for `userList` given a format.
     userListUri :: String -> String,
@@ -293,6 +295,7 @@ userFeature templates usersState adminsState
             , passwordResource
             , enabledResource
             , manageUserResource
+            , redirectUserResource
             ]
           ++ [
               groupResource adminResource
@@ -331,6 +334,13 @@ userFeature templates usersState adminsState
                       ]
               , resourceGet  = [ ("", serveUserManagementGet) ]
               , resourcePost = [ ("", serveUserManagementPost) ]
+              }
+      , redirectUserResource =
+              (resourceAt "/users/account-management.:format")
+              { resourceDesc =
+                      [ (GET, "user's personal account management page")
+                      ]
+              , resourceGet  = [ ("", const redirectUserManagement) ]
               }
       , passwordResource = resourceAt "/user/:username/password.:format"
                            --TODO: PUT
@@ -551,6 +561,12 @@ userFeature templates usersState adminsState
           errBadRequest "User deleted"
             [MText "Cannot disable account, it has already been deleted"]
 
+    redirectUserManagement :: ServerPartE Response
+    redirectUserManagement = do
+      uid <- guardAuthenticated
+      uinfo <- lookupUserInfo uid
+      tempRedirect ("/user/"++show (userName uinfo)++"/manage") (toResponse ())
+
     serveUserManagementGet :: DynamicPath -> ServerPartE Response
     serveUserManagementGet dpath = do
       (uid, uinfo)  <- lookupUserNameFull =<< userNameInPath dpath
@@ -560,7 +576,7 @@ userFeature templates usersState adminsState
       ok $ toResponse $
         template
           [ "username" $= display (userName uinfo)
-          , "tokens"   $= 
+          , "tokens"   $=
               [ templateDict
                   [ templateVal "hash" (display authtok)
                   , templateVal "description" desc

--- a/Distribution/Server/Features/Users.hs
+++ b/Distribution/Server/Features/Users.hs
@@ -340,7 +340,7 @@ userFeature templates usersState adminsState
               { resourceDesc =
                       [ (GET, "user's personal account management page")
                       ]
-              , resourceGet  = [ ("", const redirectUserManagement) ]
+              , resourceGet  = [ ("", const (redirectUserManagement r)) ]
               }
       , passwordResource = resourceAt "/user/:username/password.:format"
                            --TODO: PUT
@@ -561,11 +561,11 @@ userFeature templates usersState adminsState
           errBadRequest "User deleted"
             [MText "Cannot disable account, it has already been deleted"]
 
-    redirectUserManagement :: ServerPartE Response
-    redirectUserManagement = do
+    redirectUserManagement :: UserResource -> ServerPartE Response
+    redirectUserManagement r = do
       uid <- guardAuthenticated
       uinfo <- lookupUserInfo uid
-      tempRedirect ("/user/"++show (userName uinfo)++"/manage") (toResponse ())
+      tempRedirect (manageUserUri r "" (userName uinfo)) (toResponse ())
 
     serveUserManagementGet :: DynamicPath -> ServerPartE Response
     serveUserManagementGet dpath = do

--- a/datafiles/templates/accounts.html.st
+++ b/datafiles/templates/accounts.html.st
@@ -27,7 +27,8 @@ maintainer group.</p>
 <h2>Account Management</h2>
 You can modify various settings for your account, including changing
   the email address and password, as well as creating authentication
-  tokens, at the <a href="/users/account-management">page</a>.
+  tokens, at the <a href="/users/account-management">account
+  management page</a>.
 
 <p>If you forget your password you can <a href="/users/password-reset">reset it</a>
 so long as you know your user login name and the email address you

--- a/datafiles/templates/accounts.html.st
+++ b/datafiles/templates/accounts.html.st
@@ -10,16 +10,24 @@ $hackagePageHeader()$
 
 <div id="content">
 <h2>User accounts</h2>
-<p>Most of the functions of the Hackage web interface
-(including browsing and checking packages) are available to all.
-However, uploading packages requires a Hackage username and password.
-</p>
+<h2>Create an account</h2>
 
-<p>So, you can <a href="/users/register-request">register a new user account</a>.</p>
+<p>Fill in the <a href="/users/register-request">registation form</a> to get
+a new user account for yourself.</p>
 
-<p>You can also peruse the <a href="/users/">list of users</a>.</p>
+<p>Once you have your account you can upload packages with <em>new</em> names,
+but not other existing packages.</p>
+
+<p>If you want to upload a new version for a package uploaded by another user,
+you should contact that user and request to be added to the package's
+maintainer group.</p>
 
 <p>Passwords are <b>not</b> stored, just the digest.</p>
+
+<h2>Account Management</h2>
+You can modify various settings for your account, including changing
+  the email address and password, as well as creating authentication
+  tokens, at the <a href="/users/account-management">page</a>.
 
 <p>If you forget your password you can <a href="/users/password-reset">reset it</a>
 so long as you know your user login name and the email address you


### PR DESCRIPTION
This just tosses in a redirect page so that if a user hits /users/account-management it asks them to login, and then directs them to their own personal account management page.

It also updates the "user accounts" page (we'll need to update it separately for the central-server branch) to point to this page.

So that gives a two-click process to get to user-specific settings from anywhere else on the site.

This is relevant to https://github.com/haskell/hackage-server/issues/167 and https://github.com/haskell/hackage-server/pull/622