### PR TITLE
Two Column Layout for Package Pages [Do Not Merge]

### DIFF
--- a/datafiles/static/hackage.css
+++ b/datafiles/static/hackage.css
@@ -579,7 +579,7 @@ ul.links li form button:hover {
 }
 
 #module-list li {
-  clear: right;
+/*  clear: right; */
 }
 
 #module-list span.collapser,
@@ -655,6 +655,13 @@ p.tip {
 
 table.simpletable th, table.simpletable td {
   padding: 0.2em 1em;
+}
+
+div #properties {
+    float:right;
+    min-width:200px;
+    width:20%;
+    margin-left:12px;
 }
 
 table.properties td, table.properties th {

--- a/datafiles/templates/Html/package-page.html.st
+++ b/datafiles/templates/Html/package-page.html.st
@@ -35,19 +35,8 @@
     </div>
     $endif$
 
-    <div id="description">
-    $if(package.optional.hasDescription)$
-    $package.optional.description$
-    $endif$
-    </div>
-
-    $if(package.optional.hasReadme)$
-    <hr>
-    [<a href="#readme">Skip to Readme</a>]
-    $endif$
-
     <div id="properties">
-    <h2>Properties</h2>
+<!--    <h2>Properties</h2> -->
     <table class="properties">
       <tbody>
 
@@ -191,6 +180,18 @@
       </tbody>
     </table>
     </div> <!-- /properties -->
+
+
+    <div id="description">
+    $if(package.optional.hasDescription)$
+    $package.optional.description$
+    $endif$
+    </div>
+
+    $if(package.optional.hasReadme)$
+    <hr>
+    [<a href="#readme">Skip to Readme</a>]
+    $endif$
 
     <div id="modules">
       $moduleList$


### PR DESCRIPTION
This implements a two-column layout for package pages, pushing the description information to the right hand column, as suggested in #667 

It is independent of the broader redesign (#648) but I think would be merged after it, as complimentary, and so we can evaluate how it looks in the context of the redesign. Some screenshots follow:

![image](https://user-images.githubusercontent.com/1125849/37548740-50a2b85a-2950-11e8-8ff3-28f7e04470cf.png)

![image](https://user-images.githubusercontent.com/1125849/37548747-5c8fbfbe-2950-11e8-9237-ecb610394b0a.png)

![image](https://user-images.githubusercontent.com/1125849/37548762-84630244-2950-11e8-93ea-23865fb2bd68.png)

Note that for lens, the image has to be resized or it causes problems. My hope is with the more percentage-based widths of the redesign we can avoid this -- otherwise a hack will be necessary.