### PR TITLE
add redirect on package.tar.gz download

### DIFF
--- a/Distribution/Server/Features/Core.hs
+++ b/Distribution/Server/Features/Core.hs
@@ -677,21 +677,28 @@ coreFeature ServerEnv{serverBlobStore = store} UserFeature{..}
       return . toResponse $ Array (Vec.fromList json)
 
     -- result: tarball or not-found error
+    -- note: this has a redirect gimmick so that we can cache the real
+    -- tarball in the CDN and also hit the redirect to trigger the download hook
     servePackageTarball :: DynamicPath -> ServerPartE Response
     servePackageTarball dpath = do
       pkgid <- packageTarballInPath dpath
       guard (pkgVersion pkgid /= nullVersion)
       pkg <- lookupPackageId pkgid
+      rq <- askRq
       case pkgLatestTarball pkg of
-        Nothing -> errNotFound "Tarball not found"
-                     [MText "No tarball exists for this package version."]
-        Just (tarball, (uploadtime, _uid), _revNo) -> do
-          let blobId = blobInfoId $ pkgTarballGz tarball
-          cacheControl [Public, NoTransform, maxAgeDays 30]
-                       (BlobStorage.blobETag blobId)
-          file <- liftIO $ BlobStorage.fetch store blobId
-          runHook_ packageDownloadHook pkgid
-          return $ toResponse $ Resource.PackageTarball file blobId uploadtime
+         Nothing -> errNotFound "Tarball not found"
+                    [MText "No tarball exists for this package version."]
+         Just (tarball, (uploadtime, _uid), _revNo) ->
+           if not (isJust . lookup "real" . rqInputsQuery $ rq)
+             then do
+               runHook_ packageDownloadHook pkgid
+               seeOther (rqUri rq ++ "?real=true")  $ toResponse ()
+             else do
+               let blobId = blobInfoId $ pkgTarballGz tarball
+               cacheControl [Public, NoTransform, maxAgeDays 30]
+                            (BlobStorage.blobETag blobId)
+               file <- liftIO $ BlobStorage.fetch store blobId
+               return $ toResponse $ Resource.PackageTarball file blobId uploadtime
 
     -- result: cabal file or not-found error
     serveCabalFile :: DynamicPath -> ServerPartE Response


### PR DESCRIPTION
Resolves #659

The approach here is different than in that ticket. We just check if there is a "?real=true" at the end of the .tar.gz url. If there isn't, we bump the download count and redirect to a url that does have the path. If there is, then we just return the .tar.gz.

That way the cdn can cache the real url, and everything works as is.