### PR TITLE
cache the browse page and keywordless-search results

### DIFF
--- a/Distribution/Server/Features/Html.hs
+++ b/Distribution/Server/Features/Html.hs
@@ -74,7 +74,7 @@ import qualified Data.Array as Array
 import qualified Data.Ix    as Ix
 import Data.Time.Format (formatTime)
 import Data.Time.Locale.Compat (defaultTimeLocale)
-import qualified Data.ByteString.Lazy as BS (ByteString)
+import qualified Data.ByteString.Lazy.Char8 as BS (ByteString, pack)
 import qualified Network.URI as URI
 
 import Text.XHtml.Strict
@@ -149,7 +149,7 @@ initHtmlFeature env@ServerEnv{serverTemplatesDir, serverTemplatesMode,
               reportsCore
               usersdetails -> do
       -- do rec, tie the knot
-      rec let (feature, packageIndex, packagesPage) =
+      rec let (feature, packageIndex, packagesPage, browseTable) =
                 htmlFeature env user core
                             packages upload
                             candidates versions
@@ -162,7 +162,7 @@ initHtmlFeature env@ServerEnv{serverTemplatesDir, serverTemplatesMode,
                             reportsCore
                             usersdetails
                             (htmlUtilities core tags user)
-                            mainCache namesCache
+                            mainCache namesCache browseCache
                             templates
 
           -- Index page caches
@@ -180,13 +180,21 @@ initHtmlFeature env@ServerEnv{serverTemplatesDir, serverTemplatesMode,
                             asyncCacheUpdateDelay  = serverCacheDelay,
                             asyncCacheLogVerbosity = verbosity
                           }
+          browseCache <- newAsyncCacheNF browseTable
+                          defaultAsyncCachePolicy {
+                            asyncCacheName = "browse packages",
+                            asyncCacheUpdateDelay  = serverCacheDelay,
+                            asyncCacheLogVerbosity = verbosity
+                          }
 
       registerHook itemUpdate $ \_ -> do
         prodAsyncCache mainCache  "item update"
         prodAsyncCache namesCache "item update"
+        prodAsyncCache browseCache "item update"
       registerHook packageChangeHook $ \_ -> do
         prodAsyncCache mainCache  "package change"
         prodAsyncCache namesCache "package change"
+        prodAsyncCache browseCache "package change"
 
       return feature
 
@@ -212,8 +220,9 @@ htmlFeature :: ServerEnv
             -> HtmlUtilities
             -> AsyncCache Response
             -> AsyncCache Response
+            -> AsyncCache BS.ByteString
             -> Templates
-            -> (HtmlFeature, IO Response, IO Response)
+            -> (HtmlFeature, IO Response, IO Response, IO BS.ByteString)
 
 htmlFeature env@ServerEnv{..}
             user
@@ -223,7 +232,7 @@ htmlFeature env@ServerEnv{..}
             -- [reverse index disabled] ReverseFeature{..}
             tags download
             rank
-            list@ListFeature{getAllLists}
+            list@ListFeature{getAllLists, makeItemList}
             names
             mirror distros
             docsCore docsCandidates
@@ -231,9 +240,9 @@ htmlFeature env@ServerEnv{..}
             reportsCore
             usersdetails
             utilities@HtmlUtilities{..}
-            cachePackagesPage cacheNamesPage
+            cachePackagesPage cacheNamesPage cacheBrowseTable
             templates
-  = (HtmlFeature{..}, packageIndex, packagesPage)
+  = (HtmlFeature{..}, packageIndex, packagesPage, browseTable)
   where
     htmlFeatureInterface = (emptyHackageFeature "html") {
         featureResources = htmlResources
@@ -246,6 +255,10 @@ htmlFeature env@ServerEnv{..}
          , CacheComponent {
              cacheDesc       = "packages page by name",
              getCacheMemSize = memSize <$> readAsyncCache cacheNamesPage
+           }
+         , CacheComponent {
+             cacheDesc       = "package browse page",
+             getCacheMemSize = memSize <$> readAsyncCache cacheBrowseTable
            }
          ]
       , featurePostInit = syncAsyncCache cachePackagesPage
@@ -270,8 +283,8 @@ htmlFeature env@ServerEnv{..}
                                       htmlPreferred
                                       cachePackagesPage
                                       cacheNamesPage
+                                      cacheBrowseTable
                                       templates
-                                      list
                                       names
     htmlUsers      = mkHtmlUsers      user usersdetails
     htmlUploads    = mkHtmlUploads    utilities upload
@@ -283,7 +296,7 @@ htmlFeature env@ServerEnv{..}
                                       candidates templates
     htmlPreferred  = mkHtmlPreferred  utilities core versions
     htmlTags       = mkHtmlTags       utilities core upload user list tags templates
-    htmlSearch     = mkHtmlSearch     utilities core list names templates
+    htmlSearch     = mkHtmlSearch     utilities core list names cacheBrowseTable templates
 
     htmlResources = concat [
         htmlCoreResources       htmlCore
@@ -418,6 +431,14 @@ htmlFeature env@ServerEnv{..}
                 ]
         return htmlpage
 
+    browseTable :: IO BS.ByteString
+    browseTable = do
+      pkgIndex <- queryGetPackageIndex
+      let packageNames = sortOn (map toLower . unPackageName) $ Pages.toPackageNames pkgIndex
+      pkgDetails <- makeItemList packageNames
+      let rowList = map makeRow pkgDetails
+          tabledata = "" +++ rowList +++ ""
+      return . BS.pack . showHtmlFragment $ tabledata
 
     {-
     -- Currently unused, mainly because not all web browsers use eager authentication-sending
@@ -464,14 +485,14 @@ mkHtmlCore :: ServerEnv
            -> HtmlPreferred
            -> AsyncCache Response
            -> AsyncCache Response
+           -> AsyncCache BS.ByteString
            -> Templates
-           -> ListFeature
            -> SearchFeature
            -> HtmlCore
 mkHtmlCore ServerEnv{serverBaseURI, serverBlobStore}
            utilities@HtmlUtilities{..}
            UserFeature{queryGetUserDb, checkAuthenticated}
-           CoreFeature{coreResource, queryGetPackageIndex}
+           CoreFeature{coreResource}
            VersionsFeature{ versionsResource
                           , queryGetDeprecatedFor
                           , queryGetPreferredInfo
@@ -490,8 +511,8 @@ mkHtmlCore ServerEnv{serverBaseURI, serverBlobStore}
            HtmlPreferred{..}
            cachePackagesPage
            cacheNamesPage
+           cacheBrowseTable
            templates
-           ListFeature{makeItemList}
            SearchFeature{..}
   = HtmlCore{..}
   where
@@ -537,6 +558,15 @@ mkHtmlCore ServerEnv{serverBaseURI, serverBlobStore}
             resourceGet  = [("html", serveCabalRevisionsPage)]
           }
       ]
+
+    serveBrowsePage :: DynamicPath -> ServerPartE Response
+    serveBrowsePage _dpath = do
+      template <- getTemplate templates "table-interface.html"
+      tabledata <- readAsyncCache cacheBrowseTable
+      return $ toResponse $ template
+          [ "heading"   $= "All packages"
+          , templateUnescaped "tabledata" tabledata]
+
 
     -- Currently the main package page is thrown together by querying a bunch
     -- of features about their attributes for the given package. It'll need
@@ -634,21 +664,6 @@ mkHtmlCore ServerEnv{serverBaseURI, serverBlobStore}
         [ "pkgname"  $= pkgname
         , "versions" $= map packageId pkgs
         ]
-
-    serveBrowsePage :: DynamicPath -> ServerPartE Response
-    serveBrowsePage _ = do
-      pkgIndex <- queryGetPackageIndex
-      let packageNames = sortOn (map toLower . unPackageName) $ Pages.toPackageNames pkgIndex
-      pkgDetails <- liftIO $ makeItemList packageNames
-      let rowList = map makeRow pkgDetails
-          tabledata = "" +++ rowList +++ ""
-      cacheControl [Public, maxAgeHours 1]
-                   (etagFromHash (PackageIndex.indexSize pkgIndex))
-      template <- getTemplate templates "table-interface.html"
-      return $ toResponse $ template
-        [ "heading"   $= "All packages"
-        , "content"   $= "A browsable index of all the packages"
-        , "tabledata" $= tabledata ]
 
     serveDistroMonitorPage :: DynamicPath -> ServerPartE Response
     serveDistroMonitorPage dpath = do
@@ -1675,12 +1690,14 @@ mkHtmlSearch :: HtmlUtilities
              -> CoreFeature
              -> ListFeature
              -> SearchFeature
+             -> AsyncCache BS.ByteString
              -> Templates
              -> HtmlSearch
 mkHtmlSearch HtmlUtilities{..}
              CoreFeature{..}
              ListFeature{makeItemList}
              SearchFeature{..}
+             cacheBrowseTable
              templates =
     HtmlSearch{..}
   where
@@ -1709,21 +1726,17 @@ mkHtmlSearch HtmlUtilities{..}
                 ]
 
           Just termsStr | terms <- words termsStr -> do
-            -- pkgIndex <- liftIO $ queryGetPackageIndex
-            -- currentTime <- liftIO $ getCurrentTime
-            pkgnames <- if null terms
-                        then fmap (sortOn (map toLower . unPackageName) . Pages.toPackageNames) queryGetPackageIndex
-                        else searchPackages terms
-            -- let (pageResults, moreResults) = splitAt limit (drop offset pkgnames)
-            pkgDetails <- liftIO $ makeItemList pkgnames
-
-            let rowList = map makeRow pkgDetails
-                tabledata = "" +++ rowList
+            tabledata <- if null terms
+                         then readAsyncCache cacheBrowseTable
+                         else do
+                           names <- searchPackages terms
+                           pkgDetails <- liftIO $ makeItemList names
+                           let rowList = map makeRow pkgDetails
+                           return . BS.pack . showHtmlFragment $ "" +++ rowList
             template <- getTemplate templates "table-interface.html"
             return $ toResponse $ template
               [ "heading"   $= toHtml (searchForm termsStr False)
-              , "content"   $= "A browsable index of all the packages"
-              , "tabledata" $= tabledata
+              , templateUnescaped "tabledata" tabledata
               , "footer"    $= alternativeSearchTerms termsStr]
 
           _ ->

--- a/Distribution/Server/Framework/Templating.hs
+++ b/Distribution/Server/Framework/Templating.hs
@@ -25,10 +25,12 @@ module Distribution.Server.Framework.Templating (
     templateDict,
     templateVal,
     templateEnumDesriptor,
+    templateUnescaped,
     ToSElem(..),
   ) where
 
 import Text.StringTemplate
+import Text.StringTemplate.Base
 import Text.StringTemplate.Classes
 import Happstack.Server (ToMessage(..), toResponseBS)
 
@@ -79,6 +81,10 @@ infix 0 $=
 ($=) :: ToSElem a => String -> a -> TemplateAttr
 ($=) k v = TemplateAttr (setAttribute k v)
 
+templateUnescaped :: String -> LBS.ByteString -> TemplateAttr
+templateUnescaped s x = TemplateAttr $ \st -> st {senv = envIns (SBLE (Builder.fromLazyByteString x)) (senv st)}
+   where envIns v e = e {smp = Map.insert s v (smp e)}
+
 newtype TemplateVal = TemplateVal (forall b. Stringable b => SElem b)
 
 instance ToSElem TemplateVal where
@@ -102,6 +108,7 @@ templateEnumDesriptor tostr xs x =
         , templateVal "asjson"   (JSON.encode x')
         ]
     | (i, x') <- zip [0::Int ..] xs ]
+
 
 instance ToSElem XHtml.Html where
     -- The use of SBLE here is to prevent the html being escaped


### PR DESCRIPTION
Resolves #652 

The new browse stuff wasn't using the async-cache mechanisms. This resolves that. It shares the table-element between the search page (since the search page shows all packages when no keyword is entered) and the browse page, rather than caching the whole page. But that's where all the cost is, so it should suffice...