### PR TITLE
move doc index link 

### DIFF
--- a/Distribution/Server/Pages/Package.hs
+++ b/Distribution/Server/Pages/Package.hs
@@ -32,6 +32,7 @@ import Distribution.Server.Packages.ModuleForest
 import Distribution.Server.Packages.Render
 import Distribution.Server.Users.Types (userStatus, userName, isActiveAccount)
 import Data.TarIndex (TarIndex)
+import qualified Data.TarIndex as Tar
 
 import qualified Distribution.ModuleName as Module
 import Distribution.ModuleName (ModuleName)
@@ -317,15 +318,16 @@ moduleSection render mdocIndex docURL quickNav =
                      [renderDocIndexLink] ++
                      [renderModuleForest docURL m ]
                 else [])
-        renderDocIndexLink
-          | isJust mdocIndex =
-            let docIndexURL = docURL </> "doc-index.html"
+        renderDocIndexLink = case mdocIndex of
+          Just tindex ->
+            let docIndexURL | isJust (Tar.lookup tindex "doc-index-All.html") = docURL </> "doc-index-All.html"
+                            | otherwise = docURL </> "doc-index.html"
             in  paragraph ! [thestyle "font-size: small"]
                   << ("[" +++ anchor ! [href docIndexURL] << "Index" +++ "]" +++
                       (if quickNav
                        then " [" +++ anchor ! [identifier "quickjump-trigger", href "#"] << "Quick Jump" +++ "]"
                        else mempty))
-          | otherwise = mempty
+          Nothing -> mempty
 
 propertySection :: [(String, Html)] -> [Html]
 propertySection sections =

--- a/Distribution/Server/Pages/Package.hs
+++ b/Distribution/Server/Pages/Package.hs
@@ -319,7 +319,7 @@ moduleSection render mdocIndex docURL quickNav =
                 else [])
         renderDocIndexLink
           | isJust mdocIndex =
-            let docIndexURL = docURL </> "doc-index-All.html"
+            let docIndexURL = docURL </> "doc-index.html"
             in  paragraph ! [thestyle "font-size: small"]
                   << ("[" +++ anchor ! [href docIndexURL] << "Index" +++ "]" +++
                       (if quickNav

--- a/Distribution/Server/Pages/Package.hs
+++ b/Distribution/Server/Pages/Package.hs
@@ -313,13 +313,13 @@ moduleSection render mdocIndex docURL quickNav =
                      , renderModuleForest docURL s ]
                 else []) ++
             (if not (null m)
-                then [ h2 << "Modules"
-                     , renderModuleForest docURL m ]
-                else []) ++
-            [renderDocIndexLink]
+                then [ h2 << "Modules"] ++
+                     [renderDocIndexLink] ++
+                     [renderModuleForest docURL m ]
+                else [])
         renderDocIndexLink
           | isJust mdocIndex =
-            let docIndexURL = docURL </> "doc-index.html"
+            let docIndexURL = docURL </> "doc-index-All.html"
             in  paragraph ! [thestyle "font-size: small"]
                   << ("[" +++ anchor ! [href docIndexURL] << "Index" +++ "]" +++
                       (if quickNav


### PR DESCRIPTION
Resolves #400

Under this change, the link will be right under `Modules` like this:

![image](https://user-images.githubusercontent.com/1125849/37642210-b74afbea-2bf2-11e8-92d5-b7b992cac63c.png)
