### PR TITLE
Fix floating overlap of sidebar

### DIFF
--- a/datafiles/static/hackage.css
+++ b/datafiles/static/hackage.css
@@ -220,9 +220,7 @@ pre + pre {
 /* @group properties */
 
 div #properties {
-    float:right;
     min-width:350px;
-    background: #fefefe;
     width:25vw;
     margin-left:15px;
     margin-bottom:15px;
@@ -302,11 +300,16 @@ table.properties td, table.properties th {
     display: inline-table;
     margin: 2px 1em 0 2em;
   }
+
+  #content {
+    flex-direction: row;
+  }
 }
 
 @media only screen and (max-width: 950px) {
   #content {
     width: 88vw;
+    flex-direction: column;
   }
 
   #page-header {
@@ -342,6 +345,7 @@ table.properties td, table.properties th {
   margin: 0 auto;
   padding: 0;
   padding-bottom: 1em;
+  display: flex
 }
 
 

--- a/datafiles/templates/Html/package-page.html.st
+++ b/datafiles/templates/Html/package-page.html.st
@@ -18,212 +18,211 @@
   $hackagePageHeader()$
 
   <div id="content">
-    <h1><a href="$baseurl$/package/$package.name$">$package.name$</a>$if(package.optional.hasSynopsis)$: <small>$package.optional.synopsis$</small>$endif$</h1>
-    <div style="font-size: small">
-      [ $tags$ ]
-      [ <a href="/package/$package.name$/tags/edit">Propose Tags </a> ]
-    </div>
-
-    $if(isDeprecated)$
-    <div id="deprecated">
-      Deprecated.
-      $deprecatedMsg$
-    </div>
-    $endif$
-
-
-
+    <div id="main">
+      <h1><a href="$baseurl$/package/$package.name$">$package.name$</a>$if(package.optional.hasSynopsis)$: <small>$package.optional.synopsis$</small>$endif$</h1>
+      <div style="font-size: small">
+        [ $tags$ ]
+        [ <a href="/package/$package.name$/tags/edit">Propose Tags </a> ]
+      </div>
+      
+      $if(isDeprecated)$
+      <div id="deprecated">
+        Deprecated.
+        $deprecatedMsg$
+      </div>
+      $endif$
+  
+      <div id="description">
+      $if(package.optional.hasDescription)$
+      $package.optional.description$
+      $endif$
+      $if(package.optional.hasReadme)$
+      <hr>
+      [<a href="#readme">Skip to Readme</a>]
+      $endif$
+      </div>
+  
+  
+      <div id="modules">
+        $moduleList$
+      </div>
+  
+      $if(hackage.hasFlags)$
+      <div id="flags">
+        $hackage.flagsSection$
+      </div>
+      $endif$
+  
+      <div id="downloads">
+        $downloadSection$
+      </div>
+  
+      <div id="maintainer-corner">
+        <h4>Maintainer's Corner</h4>
+        <p>For package maintainers and hackage trustees</p>
+        <ul>
+          <li>
+            <a href="$baseurl$/package/$package.name$/maintain">
+              edit package information
+            </a>
+          </li>
+        </ul>
+      </div>
+  
+      $if(package.optional.hasReadme)$
+      <hr />
+      <div id="readme-container">
+        <h2 id="readme">Readme for $package.name$-$package.version$</h2>
+        [<a href="#description">back to package description</a>]
+        $package.optional.readme$
+      </div>
+      $endif$
+    </div> <!-- /main -->
     <div id="properties">
-    <table class="properties">
-      <tbody>
-
-        <tr>
-          <th>Versions</th>
-          <td>$versions$</td>
-        </tr>
-
-        $if(package.optional.hasChangelog)$
-        <tr>
-          <th>Change&nbsp;log</th>
-          <td class="word-wrap">$package.optional.changelog$</td>
-        </tr>
-        $endif$
-
-        <tr>
-          <th>Dependencies</th>
-          <td>$package.buildDepends$</td>
-        </tr>
-
-        <tr>
-          <th>License</th>
-          <td>$package.license$</td>
-        </tr>
-
-        $if(package.optional.hasCopyright)$
-        <tr>
-          <th>Copyright</th>
-          <td>$package.optional.copyright$</td>
-        </tr>
-        $endif$
-
-        <tr>
-          <th>Author</th>
-          <td>$package.author$</td>
-        </tr>
-        <tr>
-          <th>Maintainer</th>
-          <td>$package.maintainer$</td>
-        </tr>
-
-        $if(hackage.hasUpdateTime)$
-        <tr>
-          <th>Revised</th>
-          <td>$hackage.updateTime$</td>
-        </tr>
-        $endif$
-
-        <!-- Obsolete/deprecated 'Stability' field hidden
-             c.f. http://stackoverflow.com/questions/3841218/conventions-for-stability-field-of-cabal-packages
-        <tr>
-          <th>Stability</th>
-          <td>$stability$</td>
-        </tr>
-        -->
-
-        $if(package.optional.hasCategories)$
-        <tr>
-          <th>Category</th>
-          <td>$package.optional.category$</td>
-        </tr>
-        $endif$
-
-        $if(package.optional.hasHomePage)$
-        <tr>
-          <th>Home page</th>
-          <td class="word-wrap">
-            <a href=$package.optional.homepage$>
-              $package.optional.homepage$
-            </a>
-          </td>
-        </tr>
-        $endif$
-
-        $if(package.optional.hasBugTracker)$
-        <tr>
-          <th>Bug&nbsp;tracker</th>
-          <td class="word-wrap">
-            <a href="$package.optional.bugTracker$">
-              $package.optional.bugTracker$
-            </a>
-          </td>
-        </tr>
-        $endif$
-
-        $if(package.optional.hasSourceRepository)$
-        <tr>
-          <th>Source&nbsp;repo</th>
-          <td class="word-wrap">$package.optional.sourceRepository$</td>
-        </tr>
-        $endif$
-
-        <tr>
-          <th>Uploaded</th>
-          <td>$hackage.uploadTime$</td>
-        </tr>
-
-
-        $if(hackage.hasDistributions)$
-        <tr>
-          <th>Distributions</th>
-          <td>$hackage.distributions$</td>
-        </tr>
-        $endif$
-
-        $if(hasexecs)$
-        <tr>
-          <th>Executables</th>
-          <td>$executables$</td>
-        </tr>
-        $endif$
-
-        <tr>
-          <th>Downloads</th>
-          <td>$totalDownloads$ total ($recentDownloads$ in the last 30 days)</td>
-        </tr>
-
-        <tr>
-          <th> Rating</th>
-	  <td>$if(hasVotes)$$score$ (votes: $votes$)$else$(no votes yet)$endif$
-	  <span style="font-size: small">[estimated by <a href="https://en.wikipedia.org/wiki/Rule_of_succession">rule of succession</a>]</span></td>
-	</tr>
-
-	<tr>
-	  <th>Your&nbsp;Rating</th>
-	  <td>
-            <ul class="star-rating">
-              <li class="star uncool" id="1">&lambda;</li>
-              <li class="star uncool" id="2">&lambda;</li>
-              <li class="star uncool" id="3">&lambda;</li>
-	    </ul>
-          $if(userRating)$
-            <input type="hidden" id="userRating" value="$userRating$">
-            [<a href="" class="clear-rating">clear rating</a>]
+      <table class="properties">
+        <tbody>
+  
+          <tr>
+            <th>Versions</th>
+            <td>$versions$</td>
+          </tr>
+  
+          $if(package.optional.hasChangelog)$
+          <tr>
+            <th>Change&nbsp;log</th>
+            <td class="word-wrap">$package.optional.changelog$</td>
+          </tr>
           $endif$
-          </td>
-        </tr>
-        <tr>
-          <th>Status</th>
-          <td>$buildStatus$</td>
-        </tr>
-      </tbody>
-    </table>
+  
+          <tr>
+            <th>Dependencies</th>
+            <td>$package.buildDepends$</td>
+          </tr>
+  
+          <tr>
+            <th>License</th>
+            <td>$package.license$</td>
+          </tr>
+  
+          $if(package.optional.hasCopyright)$
+          <tr>
+            <th>Copyright</th>
+            <td>$package.optional.copyright$</td>
+          </tr>
+          $endif$
+  
+          <tr>
+            <th>Author</th>
+            <td>$package.author$</td>
+          </tr>
+          <tr>
+            <th>Maintainer</th>
+            <td>$package.maintainer$</td>
+          </tr>
+  
+          $if(hackage.hasUpdateTime)$
+          <tr>
+            <th>Revised</th>
+            <td>$hackage.updateTime$</td>
+          </tr>
+          $endif$
+  
+          <!-- Obsolete/deprecated 'Stability' field hidden
+               c.f. http://stackoverflow.com/questions/3841218/conventions-for-stability-field-of-cabal-packages
+          <tr>
+            <th>Stability</th>
+            <td>$stability$</td>
+          </tr>
+          -->
+  
+          $if(package.optional.hasCategories)$
+          <tr>
+            <th>Category</th>
+            <td>$package.optional.category$</td>
+          </tr>
+          $endif$
+  
+          $if(package.optional.hasHomePage)$
+          <tr>
+            <th>Home page</th>
+            <td class="word-wrap">
+              <a href=$package.optional.homepage$>
+                $package.optional.homepage$
+              </a>
+            </td>
+          </tr>
+          $endif$
+  
+          $if(package.optional.hasBugTracker)$
+          <tr>
+            <th>Bug&nbsp;tracker</th>
+            <td class="word-wrap">
+              <a href="$package.optional.bugTracker$">
+                $package.optional.bugTracker$
+              </a>
+            </td>
+          </tr>
+          $endif$
+  
+          $if(package.optional.hasSourceRepository)$
+          <tr>
+            <th>Source&nbsp;repo</th>
+            <td class="word-wrap">$package.optional.sourceRepository$</td>
+          </tr>
+          $endif$
+  
+          <tr>
+            <th>Uploaded</th>
+            <td>$hackage.uploadTime$</td>
+          </tr>
+  
+  
+          $if(hackage.hasDistributions)$
+          <tr>
+            <th>Distributions</th>
+            <td>$hackage.distributions$</td>
+          </tr>
+          $endif$
+  
+          $if(hasexecs)$
+          <tr>
+            <th>Executables</th>
+            <td>$executables$</td>
+          </tr>
+          $endif$
+  
+          <tr>
+            <th>Downloads</th>
+            <td>$totalDownloads$ total ($recentDownloads$ in the last 30 days)</td>
+          </tr>
+  
+          <tr>
+            <th> Rating</th>
+  	  <td>$if(hasVotes)$$score$ (votes: $votes$)$else$(no votes yet)$endif$
+  	  <span style="font-size: small">[estimated by <a href="https://en.wikipedia.org/wiki/Rule_of_succession">rule of succession</a>]</span></td>
+  	</tr>
+  
+  	<tr>
+  	  <th>Your&nbsp;Rating</th>
+  	  <td>
+              <ul class="star-rating">
+                <li class="star uncool" id="1">&lambda;</li>
+                <li class="star uncool" id="2">&lambda;</li>
+                <li class="star uncool" id="3">&lambda;</li>
+  	    </ul>
+            $if(userRating)$
+              <input type="hidden" id="userRating" value="$userRating$">
+              [<a href="" class="clear-rating">clear rating</a>]
+            $endif$
+            </td>
+          </tr>
+          <tr>
+            <th>Status</th>
+            <td>$buildStatus$</td>
+          </tr>
+        </tbody>
+      </table>
     </div> <!-- /properties -->
-
-    <div id="description">
-    $if(package.optional.hasDescription)$
-    $package.optional.description$
-    $endif$
-    $if(package.optional.hasReadme)$
-    <hr>
-    [<a href="#readme">Skip to Readme</a>]
-    $endif$
-    </div>
-
-
-    <div id="modules">
-      $moduleList$
-    </div>
-
-    $if(hackage.hasFlags)$
-    <div id="flags">
-      $hackage.flagsSection$
-    </div>
-    $endif$
-
-    <div id="downloads">
-      $downloadSection$
-    </div>
-
-    <div id="maintainer-corner">
-      <h4>Maintainer's Corner</h4>
-      <p>For package maintainers and hackage trustees</p>
-      <ul>
-        <li>
-          <a href="$baseurl$/package/$package.name$/maintain">
-            edit package information
-          </a>
-        </li>
-      </ul>
-    </div>
-
-    $if(package.optional.hasReadme)$
-    <hr />
-    <div id="readme-container">
-      <h2 id="readme">Readme for $package.name$-$package.version$</h2>
-      [<a href="#description">back to package description</a>]
-      $package.optional.readme$
-    </div>
-    $endif$
   </div> <!-- /content -->
 
   $packagePageAssets()$

--- a/datafiles/templates/packagePageAssets.st
+++ b/datafiles/templates/packagePageAssets.st
@@ -203,18 +203,3 @@
         \$("#" + i).removeClass('cool').addClass('uncool');
   }
 </script>
-
- <script>
-    // Responsive layout change
-    \$(function()  {
-          var onResize = function() {
-              if(jQuery(window).width()<=950) {
-                 jQuery("#properties").insertAfter(jQuery("#description"));
-              } else {
-                  jQuery("#properties").insertBefore(jQuery("#description"));
-             }
-            }
-            \$(window).resize(onResize);
-            onResize();
-     });
-</script>


### PR DESCRIPTION
This PR fixes a few problems with the new package page layout. The main issue is shown in the following screenshots.

## Before
![hackage-before](https://user-images.githubusercontent.com/1002726/37689069-6ab7a5e4-2c79-11e8-8c77-61a317b7b40d.png)

## After
![hackage-after](https://user-images.githubusercontent.com/1002726/37689074-6fa0975a-2c79-11e8-8653-af848aa537e0.png)

Note that when the screen is small, the properties will appear after the main documentation. This is consistent with cargo, npm, and rubygems (I didn't check any other language's package repos).

P.S. I almost didn't contribute this change since the build instructions listed in the README did not work.