### PR TITLE
Fix search bugs

### DIFF
--- a/Distribution/Server/Features/Search/ExtractDescriptionTerms.hs
+++ b/Distribution/Server/Features/Search/ExtractDescriptionTerms.hs
@@ -16,6 +16,7 @@ import Data.Char
 import qualified NLP.Tokenize as NLP
 import qualified NLP.Snowball as NLP
 import qualified Data.Foldable as F
+import Data.List (intercalate)
 
 import qualified Documentation.Haddock.Markup as Haddock
 import Documentation.Haddock.Types
@@ -23,7 +24,7 @@ import Documentation.Haddock.Types
 import qualified Distribution.Server.Pages.Package.HaddockParse as Haddock (parse)
 
 extraStems :: [Text] -> Text -> [Text]
-extraStems ss x = x : mapMaybe (x `T.stripSuffix`) ss
+extraStems ss x = x : mapMaybe (`T.stripSuffix` x) ss
 
 extractSynopsisTerms :: [Text] -> Set Text -> String -> [Text]
 extractSynopsisTerms ss stopWords =
@@ -63,7 +64,7 @@ extractDescriptionTerms ss stopWords =
         [] --TODO: something here
         (  filter (not . ignoreTok)
          . NLP.tokenize
-         . concat . Haddock.markup termsMarkup)
+         . intercalate " " . Haddock.markup termsMarkup)
     . Haddock.parse
 
 termsMarkup :: DocMarkupH () String [String]


### PR DESCRIPTION
This fixes two bugs in search -- first by not concating component strings of markdown, but instead joining them with whitespace (pre-tokenization). Second a stupid order-of-arguments error that meant the extra stemming added in https://github.com/haskell/hackage-server/pull/633 wasn't working properly. This should go a fair way to addressing https://github.com/haskell/hackage-server/issues/615