### PR TITLE
uploader group add process improvements

### DIFF
--- a/Distribution/Server/Pages/Group.hs
+++ b/Distribution/Server/Pages/Group.hs
@@ -39,8 +39,8 @@ groupBody users baseUri (addUri, removeUri) desc =
           , toHtml "]"
           ]
       ]
-  , listGroup users (if removeUri then Just baseUri else Nothing)
   , if addUri then concatHtml $ addUser baseUri else noHtml
+  , listGroup users (if removeUri then Just baseUri else Nothing)
   ]
 
 addUser :: String -> [Html]


### PR DESCRIPTION
This does three things. First, adds trustees to those allowed to add uploaders. Second, moves the add bit to the _top_ rather than bottom of the edit group html, above rather than below existing group members. Third, gives a more informative error when uploads fail due to users not being in the uploaders group.