### PR TITLE
Prevent new package uploads which case-clash with existing

### DIFF
--- a/Distribution/Server/Features/Upload.hs
+++ b/Distribution/Server/Features/Upload.hs
@@ -353,7 +353,7 @@ uploadFeature ServerEnv{serverBlobStore = store}
            -> case (packageExists state pkg, PackageIndex.searchByName state (unPackageName . pkgName $ pkg)) of
                 (False,PackageIndex.Unambiguous (mp:_)) -> do
                       group <- (queryUserGroup . maintainersGroup . packageName) mp
-                      if uid `Group.member` group
+                      if not $ uid `Group.member` group
                          then uploadError (caseClash [mp])
                          else return Nothing
 
@@ -394,9 +394,9 @@ uploadFeature ServerEnv{serverBlobStore = store}
                      ++ "maintainers of the existing package."
                      ]
         caseClash pkgs = [MText $
-                         "Package(s) with the same name as this package, modulo case already exist:"
-                      ++ intercalate ", " (map (display . packageName) pkgs) ++ "."
-                      ++ "You may only upload new packages which case-clash with existing packages"
+                         "Package(s) with the same name as this package, modulo case, already exist:"
+                      ++ intercalate ", " (map (display . packageName) pkgs) ++ ". "
+                      ++ "You may only upload new packages which case-clash with existing packages "
                       ++ "if you are a maintainer of one of the existing packages. Please pick another name."]
 
     -- This function generically extracts a package, useful for uploading, checking,

--- a/Distribution/Server/Features/Upload.hs
+++ b/Distribution/Server/Features/Upload.hs
@@ -26,7 +26,7 @@ import Distribution.Server.Packages.PackageIndex (PackageIndex)
 import qualified Distribution.Server.Packages.PackageIndex as PackageIndex
 
 import Data.Maybe (fromMaybe)
-import Data.List (dropWhileEnd)
+import Data.List (dropWhileEnd, intercalate)
 import Data.Time.Clock (getCurrentTime)
 import Data.Function (fix)
 import Data.ByteString.Lazy (ByteString)
@@ -349,7 +349,22 @@ uploadFeature ServerEnv{serverBlobStore = store}
            -> uploadError normVerExists
 
             | otherwise
-           -> return Nothing
+              -- check for new packages that case-clash with existing ones
+           -> case (packageExists state pkg, PackageIndex.searchByName state (unPackageName . pkgName $ pkg)) of
+                (False,PackageIndex.Unambiguous (mp:_)) -> do
+                      group <- (queryUserGroup . maintainersGroup . packageName) mp
+                      if uid `Group.member` group
+                         then uploadError (caseClash [mp])
+                         else return Nothing
+
+                (False,PackageIndex.Ambiguous mps) -> do
+                      let matchingPackages = concat . map (take 1) $ mps
+                      groups <- mapM (queryUserGroup . maintainersGroup . packageName) matchingPackages
+                      if not . any (uid `Group.member`) $ groups
+                         then uploadError (caseClash matchingPackages)
+                         else return Nothing
+
+                _ -> return Nothing
       where
         uploadError = return . Just . ErrorResponse 403 [] "Upload failed"
         versionExists = [ MText $
@@ -378,6 +393,11 @@ uploadFeature ServerEnv{serverBlobStore = store}
                      ++ "this is a package name clash, please pick another name or talk to the "
                      ++ "maintainers of the existing package."
                      ]
+        caseClash pkgs = [MText $
+                         "Package(s) with the same name as this package, modulo case already exist:"
+                      ++ intercalate ", " (map (display . packageName) pkgs) ++ "."
+                      ++ "You may only upload new packages which case-clash with existing packages"
+                      ++ "if you are a maintainer of one of the existing packages. Please pick another name."]
 
     -- This function generically extracts a package, useful for uploading, checking,
     -- and anything else in the standard user-upload pipeline.
@@ -442,4 +462,3 @@ packageIdExistsModuloNormalisedVersion pkgs pkg =
         n vs' = case dropWhileEnd (== 0) vs' of
             []   -> [0]
             vs'' -> vs''
-


### PR DESCRIPTION
Resolves #352 

Includes logic to allow uploads of existing packages, and also to allow uploads of new packages if the maintainer is a maintainer of an existing packages (so, e.g., people can migrate the capitalization of their own packages).