### PR TITLE
Add blockquote styling

### DIFF
--- a/datafiles/static/hackage.css
+++ b/datafiles/static/hackage.css
@@ -209,6 +209,13 @@ pre + pre {
   margin-top: 0.5em;
 }
 
+blockquote {
+  border-left: 3px solid #c7a5d3;
+  background: #eee4f1;
+  margin: 0.5em;
+  padding: 0.0005em 0.3em 0.5em 0.5em;
+}
+
 .src {
   background: #f4f4f4;
   padding: 0.2em 0.5em;

--- a/datafiles/static/hackage.css
+++ b/datafiles/static/hackage.css
@@ -211,7 +211,7 @@ pre + pre {
 
 blockquote {
   border-left: 3px solid #c7a5d3;
-  background: #eee4f1;
+  background-color: #eee4f1;
   margin: 0.5em;
   padding: 0.0005em 0.3em 0.5em 0.5em;
 }


### PR DESCRIPTION
Fixes #775

I guessed at a border color that fit with the purple theme and selected a lighter tint for the background.
As you can probably see from the padding rule I'm not very familiar with css, I'm not sure why the top padding was so hard to change but it was always much larger than the bottom padding. I also took a guess at the right padding so as to make it symmetrical with the left padding.

Feel free to suggest better colors or padding.