### PR TITLE
Add 'autofocus' to Hackage's home page 'Search' field

### DIFF
--- a/datafiles/templates/hackagePageHeader.st
+++ b/datafiles/templates/hackagePageHeader.st
@@ -7,7 +7,7 @@
     <li>
       <form action="/packages/search" method="get" class="search">
         <button type="submit">Search&nbsp;</button>
-        <input type="text" name="terms" />
+        <input type="text" name="terms" autofocus />
       </form>
     </li>
 


### PR DESCRIPTION
This allows users to be able to directly search for the library
they wish when coming on the page, instead of having to click on
the Search field.