### PR TITLE
Run Haddock on package titles

### DIFF
--- a/Distribution/Server/Pages/Package.hs
+++ b/Distribution/Server/Pages/Package.hs
@@ -103,7 +103,8 @@ packagePage render headLinks top sections
     bodyTitle = case synopsis (rendOther render) of
       ""    -> h1 << pkgName
       short -> h1 << [ toHtml (pkgName ++ ": ")
-                     , small (toHtml short)
+                     , small << renderHaddock (moduleToDocUrl render docURL)
+                                              short
                      ]
 
     candidateBanner


### PR DESCRIPTION
See http://hackage.haskell.org/package/ghc-boot-th for an example of where this
matters.