### PR TITLE
Use HTTPS in canonical links

### DIFF
--- a/Distribution/Server/Features/Html.hs
+++ b/Distribution/Server/Features/Html.hs
@@ -627,6 +627,7 @@ mkHtmlCore ServerEnv{serverBaseURI, serverBlobStore}
         return $ toResponse . template $
           -- IO-related items
           [ "baseurl"           $= show (serverBaseURI { URI.uriScheme = "" })
+          , "sbaseurl"          $= show (serverBaseURI { URI.uriScheme = "https:" })
           , "cabalVersion"      $= display cabalVersion
           , "tags"              $= (renderTags tags)
           , "versions"          $= (PagesNew.renderVersion realpkg

--- a/Distribution/Server/Features/StaticFiles.hs
+++ b/Distribution/Server/Features/StaticFiles.hs
@@ -9,6 +9,7 @@ import Distribution.Server.Framework.Templating
 import Text.XHtml.Strict (Html, toHtml, anchor, (<<), (!), href, paragraph)
 
 import Data.List hiding (find)
+import qualified Network.URI as URI
 import System.FilePath
 import System.Directory (getDirectoryContents)
 
@@ -37,7 +38,7 @@ find p dirPath = do
   return (filter p contents)
 
 staticFilesFeature :: ServerEnv -> Templates -> [FilePath] -> HackageFeature
-staticFilesFeature ServerEnv{serverStaticDir, serverTemplatesMode}
+staticFilesFeature ServerEnv{serverStaticDir, serverTemplatesMode, serverBaseURI}
                    templates staticFiles =
   (emptyHackageFeature "static-files") {
     featureResources =
@@ -101,7 +102,9 @@ staticFilesFeature ServerEnv{serverStaticDir, serverTemplatesMode}
         Nothing       -> mzero
         Just template -> do
           cacheControlWithoutETag staticResourceCacheControls
-          ok $ toResponse $ template []
+          ok $ toResponse $ template [
+            "sbaseurl" $= show (serverBaseURI { URI.uriScheme = "https:" })
+            ]
 
     textErrorPage (ErrorResponse errCode hdrs errTitle message) = do
         template <- getTemplate templates "hackageErrorPage.txt"

--- a/datafiles/templates/Html/package-page.html.st
+++ b/datafiles/templates/Html/package-page.html.st
@@ -8,7 +8,7 @@
   <title>
     $package.name$$if(package.optional.hasSynopsis)$: $package.optional.synopsis$$endif$
   </title>
-  <link rel="canonical" href="$baseurl$/package/$package.name$" />
+  <link rel="canonical" href="$sbaseurl$/package/$package.name$" />
   <script src="/static/jquery.min.js"></script>
   <script src="https://cdnjs.cloudflare.com/ajax/libs/mathjax/2.7.0/MathJax.js?config=TeX-AMS-MML_HTMLorMML" type="text/javascript"></script>
   <base href="$baseurl$/package/$package.name$-$package.version$/" />

--- a/datafiles/templates/index.html.st
+++ b/datafiles/templates/index.html.st
@@ -3,6 +3,7 @@
 <head>
 $hackageCssTheme()$
 <title>Introduction | Hackage</title>
+<link rel="canonical" href="$sbaseurl$" />
 </head>
 
 <body>


### PR DESCRIPTION
Stemming from a discussion on #haskell-infrastructure this is an attempt to steer search engines towards the HTTPS version of hackage using `<link rel="canonical" href="https://...">`, because for some reason they prefer HTTP now.

My first goal is to have the canonical links on package pages and the index page, because I believe them to be searched for the most, but I'm happy to add them to more pages when suggested. If the change is acceptable, I will file another pull request against the `central-server` branch containing changes to the templates there.
