### PR TITLE
Json package report try #2

### DIFF
--- a/Distribution/Server/Features.hs
+++ b/Distribution/Server/Features.hs
@@ -29,6 +29,7 @@ import Distribution.Server.Features.Distro              (initDistroFeature)
 import Distribution.Server.Features.PackageContents     (initPackageContentsFeature)
 import Distribution.Server.Features.Documentation       (initDocumentationFeature)
 import Distribution.Server.Features.BuildReports        (initBuildReportsFeature)
+import Distribution.Server.Features.PackageInfoJSON     (initPackageInfoJSONFeature)
 import Distribution.Server.Features.LegacyRedirects     (legacyRedirectsFeature)
 import Distribution.Server.Features.PreferredVersions   (initVersionsFeature)
 -- [reverse index disabled] import Distribution.Server.Features.ReverseDependencies (initReverseFeature)
@@ -149,6 +150,8 @@ initHackageFeatures env@ServerEnv{serverVerbosity = verbosity} = do
                                initAdminLogFeature env
     mkSitemapFeature        <- logStartup "sitemap" $
                                initSitemapFeature env
+    mkPackageJSONFeature    <- logStartup "package info JSON" $
+                               initPackageInfoJSONFeature env
 #endif
 
     loginfo verbosity "Initialising features, part 2"
@@ -315,6 +318,10 @@ initHackageFeatures env@ServerEnv{serverVerbosity = verbosity} = do
                         documentationCoreFeature
                         tagsFeature
 
+    packageInfoJSONFeature <- mkPackageJSONFeature
+                                coreFeature
+                                versionsFeature
+
 #endif
 
     -- The order of initialization above should be the same as
@@ -354,6 +361,7 @@ initHackageFeatures env@ServerEnv{serverVerbosity = verbosity} = do
          , getFeatureInterface votesFeature
          , getFeatureInterface adminLogFeature
          , getFeatureInterface siteMapFeature
+         , getFeatureInterface packageInfoJSONFeature
 #endif
          , staticFilesFeature
          , serverIntrospectFeature allFeatures

--- a/Distribution/Server/Features/Core.hs
+++ b/Distribution/Server/Features/Core.hs
@@ -221,6 +221,8 @@ data CoreResource = CoreResource {
     coreCabalFile       :: Resource,
     -- | A tarball for a package version.
     corePackageTarball  :: Resource,
+    -- | A Cabal file metatada revision.
+    coreCabalFileRev    :: Resource,
 
     -- Rendering resources.
     -- | URI for `corePackagesPage`, given a format (blank for none).

--- a/Distribution/Server/Features/PackageInfoJSON.hs
+++ b/Distribution/Server/Features/PackageInfoJSON.hs
@@ -1,0 +1,269 @@
+{-# LANGUAGE DeriveGeneric #-}
+{-# LANGUAGE LambdaCase #-}
+{-# LANGUAGE NamedFieldPuns #-}
+{-# LANGUAGE RankNTypes #-}
+{-# LANGUAGE RecordWildCards #-}
+{-# LANGUAGE ScopedTypeVariables #-}
+
+module Distribution.Server.Features.PackageInfoJSON (
+  PackageInfoJSONFeature(..)
+  , PackageInfoJSONResource(..)
+  , initPackageInfoJSONFeature
+
+  , PackageBasicDescription(..)
+  , PackageVersions(..)
+  ) where
+
+import Prelude ()
+import Distribution.Server.Prelude
+
+import qualified Data.Aeson                 as Aeson
+import qualified Data.ByteString.Lazy.Char8 as BS (toStrict)
+import qualified Data.Text                  as T
+import qualified Data.Vector                as Vector
+
+import           Distribution.License                         (licenseToSPDX)
+import           Distribution.Package                         (PackageIdentifier(..),
+                                                               PackageName, packageName,
+                                                               packageVersion)
+import qualified Distribution.Parsec.Common                   as Parsec
+import qualified Distribution.PackageDescription.Parsec       as PkgDescr
+import qualified Distribution.Types.GenericPackageDescription as PkgDescr
+import qualified Distribution.Types.PackageDescription        as PkgDescr
+import           Distribution.Version                         (nullVersion)
+
+import           Distribution.Server.Framework                  ((</>))
+import qualified Distribution.Server.Framework                  as Framework
+import           Distribution.Server.Features.Core              (CoreFeature(..),
+                                                                 CoreResource(..),
+                                                                 isPackageChangeAny)
+import qualified Distribution.Server.Features.PreferredVersions as Preferred
+import           Distribution.Server.Packages.Types             (CabalFileText(..), pkgMetadataRevisions)
+import           Distribution.Server.Framework.BackupRestore    (RestoreBackup(..))
+
+import           Distribution.Server.Features.PackageInfoJSON.State (PackageBasicDescription(..),
+                                                                     PackageVersions(..),
+                                                                     PackageInfoState(..),
+                                                                     GetPackageInfo(..),
+                                                                     ReplacePackageInfo(..),
+                                                                     GetDescriptionFor(..),
+                                                                     SetDescriptionFor(..),
+                                                                     GetVersionsFor(..),
+                                                                     SetVersionsFor(..),
+                                                                     initialPackageInfoState
+                                                                    )
+
+
+data PackageInfoJSONFeature = PackageInfoJSONFeature {
+    packageInfoJSONFeatureInterface :: Framework.HackageFeature
+}
+
+
+instance Framework.IsHackageFeature PackageInfoJSONFeature where
+    getFeatureInterface = packageInfoJSONFeatureInterface
+
+
+data PackageInfoJSONResource = PackageInfoJSONResource {
+    packageJSONResource        :: Framework.Resource,
+    packageVersionJSONResource :: Framework.Resource
+}
+
+
+-- | Initializing our feature involves adding JSON variants to the
+-- endpoints that serve basic information about a package-version,
+-- and a packages version deprecation status.
+-- Aditionally we set up caching for these endpoints,
+-- and attach a package change hook that invalidates the cache
+-- line for a package when in changes
+initPackageInfoJSONFeature
+  :: Framework.ServerEnv
+  -> IO (CoreFeature -> Preferred.VersionsFeature -> IO PackageInfoJSONFeature)
+initPackageInfoJSONFeature env = do
+  packageInfoState <- packageInfoStateComponent False (Framework.serverStateDir env)
+  return $ \core preferred -> do
+
+    let coreR = coreResource core
+        info = "Get basic package information"
+        vInfo = "Get basic package information at a specific metadata revision"
+
+        jsonResources = [
+          (Framework.extendResource (corePackagePage coreR)) {
+                Framework.resourceDesc = [(Framework.GET, info)]
+              , Framework.resourceGet  =
+                  [("json", servePackageBasicDescription coreR
+                            preferred packageInfoState)]
+              }
+          , (Framework.extendResource (coreCabalFileRev coreR)) {
+                Framework.resourceDesc = [(Framework.GET, vInfo)]
+              , Framework.resourceGet  =
+                  [("json", servePackageBasicDescription coreR
+                     preferred packageInfoState)]
+              }
+          ]
+
+        -- When a package is modified in any way, delet all its
+        -- PackageInfoState cache lines.
+        -- They will be recalculated next time the endpoint
+        -- is hit
+        postInit = Framework.registerHookJust
+                   (packageChangeHook core)
+                   isPackageChangeAny $ \(pkgid, _) -> do
+
+          Framework.updateState packageInfoState $
+            SetDescriptionFor (pkgid, Nothing) Nothing
+          Framework.updateState packageInfoState $
+            SetVersionsFor (packageName pkgid) Nothing
+
+    return $ PackageInfoJSONFeature {
+      packageInfoJSONFeatureInterface =
+          (Framework.emptyHackageFeature "package-info-json")
+            { Framework.featureDesc      = "Provide JSON endpoints for basic package descriptions"
+            , Framework.featureResources = jsonResources
+            , Framework.featureCaches    = []
+            , Framework.featurePostInit  = postInit
+            , Framework.featureState     =
+                [Framework.abstractAcidStateComponent packageInfoState]
+            }
+      }
+
+
+-- | Pure function for extrcacting basic package info from a Cabal file
+getBasicDescription
+  :: CabalFileText
+  -> Int
+     -- ^ Metadata revision. This will be added to the resulting
+     --   @PackageBasicDescription@
+  -> Either String PackageBasicDescription
+getBasicDescription (CabalFileText cf) metadataRev =
+  let parseResult = PkgDescr.parseGenericPackageDescription (BS.toStrict cf)
+  in case PkgDescr.runParseResult parseResult of
+    (_, Right pkg) -> let
+      pkgd                  = PkgDescr.packageDescription pkg
+      pbd_author            = T.pack $ PkgDescr.author pkgd
+      pbd_copyright         = T.pack $ PkgDescr.copyright pkgd
+      pbd_synopsis          = T.pack $ PkgDescr.synopsis pkgd
+      pbd_description       = T.pack $ PkgDescr.description pkgd
+      pbd_license           = either id licenseToSPDX $
+                                PkgDescr.licenseRaw pkgd
+      pbd_homepage          = T.pack $ PkgDescr.homepage pkgd
+      pbd_metadata_revision = metadataRev
+      in
+      return $ PackageBasicDescription {..}
+    (_, Left e) -> Left $ "Could not parse cabal file: "
+                   <> unlines (Parsec.showPError "" <$> snd e)
+
+
+-- | Get a JSON @PackageBasicDescription@ for a particular
+--   package/version/metadata-revision
+--      OR
+--   A listing of versions and their deprecation states
+servePackageBasicDescription
+  :: CoreResource
+  -> Preferred.VersionsFeature
+  -> Framework.StateComponent Framework.AcidState PackageInfoState
+  -> Framework.DynamicPath
+     -- ^ URI specifying a package and version `e.g. lens or lens-4.11`
+  -> Framework.ServerPartE Framework.Response
+servePackageBasicDescription resource preferred packageInfoState dpath = do
+
+  let metadataRev :: Maybe Int = lookup "revision" dpath >>= Framework.fromReqURI
+
+  pkgid@(PackageIdentifier name version) <- packageInPath resource dpath
+  guardValidPackageName resource name
+
+  if (version /= nullVersion)
+    then lookupOrInsertDescr pkgid metadataRev
+    else lookupOrInsertVersions name
+
+  where
+
+    lookupOrInsertDescr
+      :: PackageIdentifier
+      -> Maybe Int
+      -> Framework.ServerPartE Framework.Response
+    lookupOrInsertDescr pkgid metadataRev = do
+      cachedDescr <- Framework.queryState packageInfoState $
+                     GetDescriptionFor (pkgid, metadataRev)
+      descr :: PackageBasicDescription <- case cachedDescr of
+        Just d  -> return d
+        Nothing -> do
+          d <- getPackageDescr pkgid metadataRev
+          Framework.updateState packageInfoState $
+            SetDescriptionFor (pkgid, metadataRev) (Just d)
+          return d
+      return $ Framework.toResponse $ Aeson.toJSON descr
+
+    getPackageDescr pkgid metadataRev = do
+      guardValidPackageId resource pkgid
+      pkg <- lookupPackageId resource pkgid
+
+      let metadataRevs = fst <$> pkgMetadataRevisions pkg
+          nMetadata    = Vector.length metadataRevs
+          metadataInd  = fromMaybe (nMetadata - 1) metadataRev
+
+      when (metadataInd < 0 || metadataInd >= nMetadata)
+        (Framework.errNotFound "Revision not found"
+         [Framework.MText
+           $ "There are " <> show nMetadata <> " metadata revisions. Index "
+           <> show metadataInd <> " is out of bounds."]
+        )
+
+      let cabalFile = metadataRevs Vector.! metadataInd
+          pkgDescr  = getBasicDescription cabalFile metadataInd
+      case pkgDescr of
+        Left e  -> Framework.errInternalError [Framework.MText e]
+        Right d -> return d
+
+    lookupOrInsertVersions
+      :: PackageName
+      -> Framework.ServerPartE Framework.Response
+    lookupOrInsertVersions pkgname = do
+      cachedVersions <- Framework.queryState packageInfoState $
+                        GetVersionsFor pkgname
+      vers :: PackageVersions <- case cachedVersions of
+        Just vs  -> return vs
+        Nothing -> do
+          vs <- getVersionListing pkgname
+          Framework.updateState packageInfoState $
+            SetVersionsFor pkgname (Just vs)
+          return vs
+      return $ Framework.toResponse $ Aeson.toJSON vers
+
+    getVersionListing name = do
+      pkgs <- lookupPackageName resource name
+      prefInfo <- Preferred.queryGetPreferredInfo preferred name
+      return
+        . PackageVersions
+        . Preferred.classifyVersions prefInfo
+        $ fmap packageVersion pkgs
+
+
+-- | Our backup doesn't produce any entries, and backup restore
+--   returns an empty state. Our responses are cheap enough to
+--   compute that we would rather regenerate them by need than
+--   deal with the complexity persisting backups in
+--   yet-another-format
+packageInfoStateComponent
+  :: Bool
+  -> FilePath
+  -> IO (Framework.StateComponent Framework.AcidState PackageInfoState)
+packageInfoStateComponent freshDB stateDir = do
+  st <- Framework.openLocalStateFrom
+        (stateDir </> "db" </> "PackageInfoJSON")
+        (initialPackageInfoState freshDB)
+  return Framework.StateComponent {
+      stateDesc    = "Preferred package versions"
+    , stateHandle  = st
+    , getState     = Framework.query st GetPackageInfo
+    , putState     = Framework.update st . ReplacePackageInfo
+    , resetState   = packageInfoStateComponent True
+    , backupState  = \_ -> return []
+    , restoreState = nullRestore (initialPackageInfoState True)
+    }
+  where
+
+    nullRestore :: PackageInfoState -> RestoreBackup PackageInfoState
+    nullRestore st = RestoreBackup {
+      restoreEntry = \_ -> nullRestore <$> pure (initialPackageInfoState True)
+      , restoreFinalize = return st
+      }

--- a/Distribution/Server/Features/PackageInfoJSON/State.hs
+++ b/Distribution/Server/Features/PackageInfoJSON/State.hs
@@ -1,3 +1,4 @@
+{-# LANGUAGE BangPatterns        #-}
 {-# LANGUAGE DeriveDataTypeable  #-}
 {-# LANGUAGE DeriveGeneric       #-}
 {-# LANGUAGE LambdaCase          #-}
@@ -16,7 +17,7 @@ import qualified Data.Aeson           as Aeson
 import           Data.Aeson           ((.=), (.:))
 import           Data.Acid            (Query, Update, makeAcidic)
 import qualified Data.HashMap.Strict  as HashMap
-import qualified Data.Map             as Map
+import qualified Data.Map.Strict      as Map
 import           Data.Monoid          (Sum(..))
 import qualified Data.Text            as T
 import qualified Data.Text.Encoding   as T
@@ -45,13 +46,13 @@ import           Distribution.Server.Framework.MemSize          (MemSize,
 -- | Basic information about a package. These values are
 --   used in the `/package/:packagename` JSON endpoint
 data PackageBasicDescription = PackageBasicDescription
-  { pbd_license           :: License
-  , pbd_copyright         :: T.Text
-  , pbd_synopsis          :: T.Text
-  , pbd_description       :: T.Text
-  , pbd_author            :: T.Text
-  , pbd_homepage          :: T.Text
-  , pbd_metadata_revision :: Int
+  { pbd_license           :: !License
+  , pbd_copyright         :: !T.Text
+  , pbd_synopsis          :: !T.Text
+  , pbd_description       :: !T.Text
+  , pbd_author            :: !T.Text
+  , pbd_homepage          :: !T.Text
+  , pbd_metadata_revision :: !Int
   } deriving (Eq, Show, Generic)
 
 instance SafeCopy PackageBasicDescription where

--- a/Distribution/Server/Features/PackageInfoJSON/State.hs
+++ b/Distribution/Server/Features/PackageInfoJSON/State.hs
@@ -1,0 +1,251 @@
+{-# LANGUAGE DeriveDataTypeable  #-}
+{-# LANGUAGE DeriveGeneric       #-}
+{-# LANGUAGE LambdaCase          #-}
+{-# LANGUAGE RecordWildCards     #-}
+{-# LANGUAGE ScopedTypeVariables #-}
+{-# LANGUAGE TemplateHaskell     #-}
+{-# LANGUAGE TypeFamilies        #-}
+
+module Distribution.Server.Features.PackageInfoJSON.State where
+
+import           Control.Arrow        (first, second)
+import           Control.Applicative  ((<|>))
+import           Control.Monad.Reader (ask, asks)
+import qualified Control.Monad.State  as State
+import qualified Data.Aeson           as Aeson
+import           Data.Aeson           ((.=), (.:))
+import           Data.Acid            (Query, Update, makeAcidic)
+import qualified Data.HashMap.Strict  as HashMap
+import qualified Data.Map             as Map
+import           Data.Monoid          (Sum(..))
+import qualified Data.Text            as T
+import qualified Data.Text.Encoding   as T
+import           Data.SafeCopy        (SafeCopy(..), base, contain,
+                                       deriveSafeCopy)
+import           Data.Serialize       (Get, get, getListOf, getTwoOf, put,
+                                       putListOf, putTwoOf)
+import           Data.Typeable        (Typeable)
+import           Data.Word            (Word8)
+import           Distribution.License (licenseToSPDX)
+import           Distribution.Text    (display, simpleParse)
+import           GHC.Generics         (Generic)
+
+import           Distribution.SPDX.License (License)
+import           Distribution.Package      (PackageIdentifier, PackageName)
+import           Distribution.Version      (Version, mkVersion, versionNumbers)
+import qualified Distribution.Pretty       as Pretty
+import qualified Distribution.Parsec.Class as Parsec
+
+import qualified Distribution.Server.Features.PreferredVersions as Preferred
+import           Distribution.Server.Framework.MemSize          (MemSize,
+                                                                 memSize,
+                                                                 memSize7)
+
+
+-- | Basic information about a package. These values are
+--   used in the `/package/:packagename` JSON endpoint
+data PackageBasicDescription = PackageBasicDescription
+  { pbd_license           :: License
+  , pbd_copyright         :: T.Text
+  , pbd_synopsis          :: T.Text
+  , pbd_description       :: T.Text
+  , pbd_author            :: T.Text
+  , pbd_homepage          :: T.Text
+  , pbd_metadata_revision :: Int
+  } deriving (Eq, Show, Generic)
+
+instance SafeCopy PackageBasicDescription where
+
+  putCopy PackageBasicDescription{..} = contain $ do
+    put (Pretty.prettyShow pbd_license)
+    put $ T.encodeUtf8 pbd_copyright
+    put $ T.encodeUtf8 pbd_synopsis
+    put $ T.encodeUtf8 pbd_description
+    put $ T.encodeUtf8 pbd_author
+    put $ T.encodeUtf8 pbd_homepage
+    put pbd_metadata_revision
+
+  getCopy = contain $ do
+    licenseStr <- get
+    case Parsec.eitherParsec licenseStr of
+      Left e -> fail $ unwords ["Could not parse", licenseStr, "as license:" , e]
+      Right pbd_license -> do
+        pbd_copyright         <- T.decodeUtf8 <$> get
+        pbd_synopsis          <- T.decodeUtf8 <$> get
+        pbd_description       <- T.decodeUtf8 <$> get
+        pbd_author            <- T.decodeUtf8 <$> get
+        pbd_homepage          <- T.decodeUtf8 <$> get
+        pbd_metadata_revision <- get
+        return PackageBasicDescription{..}
+
+
+-- | Aeson instances are used for building the package-description
+--   endpoint. Any changes will impact the API endpoint.
+instance Aeson.ToJSON PackageBasicDescription where
+  toJSON PackageBasicDescription {..} =
+    Aeson.object
+      [ T.pack "license"           .= Pretty.prettyShow pbd_license
+      , T.pack "copyright"         .= pbd_copyright
+      , T.pack "synopsis"          .= pbd_synopsis
+      , T.pack "description"       .= pbd_description
+      , T.pack "author"            .= pbd_author
+      , T.pack "homepage"          .= pbd_homepage
+      , T.pack "metadata_revision" .= pbd_metadata_revision
+      ]
+
+
+instance Aeson.FromJSON PackageBasicDescription where
+  parseJSON = Aeson.withObject "PackageBasicDescription" $ \obj -> do
+    pbd_version'     <- obj .: T.pack "license"
+    let parseEitherLicense t =
+          Parsec.simpleParsec t <|> fmap licenseToSPDX (simpleParse t)
+    case parseEitherLicense pbd_version' of
+      Nothing -> fail $ concat ["Could not parse version: \"", pbd_version', "\""]
+      Just pbd_license -> do
+        pbd_copyright         <- obj .: T.pack "copyright"
+        pbd_synopsis          <- obj .: T.pack "synopsis"
+        pbd_description       <- obj .: T.pack "description"
+        pbd_author            <- obj .: T.pack "author"
+        pbd_homepage          <- obj .: T.pack "homepage"
+        pbd_metadata_revision <- obj .: T.pack "metadata_revision"
+        return $
+          PackageBasicDescription {..}
+
+-- | An index of versions for one hackage package
+--   and their preferred/deprecated status
+newtype PackageVersions = PackageVersions {
+  unPackageVersions :: [(Version, Preferred.VersionStatus)]
+  } deriving (Eq, Show)
+
+instance SafeCopy PackageVersions where
+
+  putCopy (PackageVersions vs) =
+    contain
+    $ putListOf (putTwoOf put put)
+    $ first versionNumbers . second statusTag <$> vs
+    where
+      statusTag = \case
+        Preferred.NormalVersion      -> 0 :: Word8
+        Preferred.DeprecatedVersion  -> 1
+        Preferred.UnpreferredVersion -> 2
+
+  getCopy = contain $
+    fmap PackageVersions $ getListOf $ getTwoOf getVersion getStatus
+    where
+      getVersion = mkVersion <$> getListOf get
+      getStatus  = (get :: Get Word8) >>= \case
+        0 -> return Preferred.NormalVersion
+        1 -> return Preferred.DeprecatedVersion
+        2 -> return Preferred.UnpreferredVersion
+        n -> fail $ "Unsupported tag for VersionStatus: " ++ show n
+
+
+-- | This encoding of @PackageVersions@ is used in the
+-- `/package/$package` endpoint (when the URI doesn't specify)
+-- a version. Any change here is an API change.
+instance Aeson.ToJSON PackageVersions where
+  toJSON (PackageVersions p) =
+    Aeson.toJSON
+    $ Map.mapKeys display
+    $ fmap encodeStatus
+    $ Map.fromList p
+    where
+      encodeStatus = \case
+        Preferred.NormalVersion      -> "normal"
+        Preferred.DeprecatedVersion  -> "deprecated"
+        Preferred.UnpreferredVersion -> "unpreferred"
+
+
+instance Aeson.FromJSON PackageVersions where
+  parseJSON = Aeson.withObject "PackageVersions" $ \obj ->
+    fmap PackageVersions
+    $ traverse (parsePair)
+    $ HashMap.toList obj
+    where
+      parsePair (vStr, vStatus) =
+        (,) <$> parseVersion vStr <*> parseStatus vStatus
+
+      parseVersion verText =
+        let verString = T.unpack verText
+        in case simpleParse verString of
+             Just ver -> return ver
+             Nothing  -> fail $ concat ["Could not parse \""
+                                       , verString ++ "\" as Version. "
+                                       , "expected \"a.b.c\" form"]
+
+      parseStatus (Aeson.String s) = case T.unpack s of
+        "normal"      -> return Preferred.NormalVersion
+        "deprecated"  -> return Preferred.DeprecatedVersion
+        "unpreferred" -> return Preferred.UnpreferredVersion
+        other         -> fail $ concat ["Could not parse \"" ++ other
+                         ++ "\" as status. Expected \"normal\""
+                         ++ "\"deprecated\" or \"unpreferred\""]
+      parseStatus _   = fail "Expected a string"
+
+data PackageInfoState = PackageInfoState {
+    descriptions          :: !(Map.Map (PackageIdentifier, Maybe Int) PackageBasicDescription)
+  , versions              :: !(Map.Map PackageName PackageVersions)
+  , migratedEphemeralData :: Bool
+  } deriving (Show, Typeable, Eq)
+
+getDescriptionFor
+  :: (PackageIdentifier, Maybe Int)
+  -> Query PackageInfoState (Maybe PackageBasicDescription)
+getDescriptionFor pkgId = asks $ Map.lookup pkgId . descriptions
+
+getVersionsFor
+  :: PackageName
+  -> Query PackageInfoState (Maybe PackageVersions)
+getVersionsFor pkgName = asks $ Map.lookup pkgName . versions
+
+setDescriptionFor
+  :: (PackageIdentifier, Maybe Int)
+  -> Maybe PackageBasicDescription
+  -> Update PackageInfoState ()
+setDescriptionFor  pkgId descr = State.modify $ \p ->
+  case descr of
+    Just d  -> p {descriptions = Map.alter (const (Just d)) pkgId (descriptions p)}
+    Nothing -> p {descriptions = Map.filterWithKey (\pkgId' _ -> fst pkgId' /= fst pkgId) (descriptions p)}
+
+setVersionsFor
+  :: PackageName
+  -> Maybe PackageVersions
+  -> Update PackageInfoState ()
+setVersionsFor  pkgName vs = State.modify $ \p ->
+  p { versions = Map.alter (const vs) pkgName (versions p) }
+
+getPackageInfo :: Query PackageInfoState PackageInfoState
+getPackageInfo = ask
+
+replacePackageInfo :: PackageInfoState -> Update PackageInfoState ()
+replacePackageInfo = State.put
+
+makeAcidic ''PackageInfoState ['getDescriptionFor
+                              ,'getVersionsFor
+                              ,'setDescriptionFor
+                              ,'setVersionsFor
+                              ,'getPackageInfo
+                              ,'replacePackageInfo
+                              ]
+
+deriveSafeCopy 0 'base ''PackageInfoState
+
+instance MemSize PackageBasicDescription where
+  memSize PackageBasicDescription{..} =
+    memSize7 (Pretty.prettyShow pbd_license) pbd_copyright pbd_synopsis
+             pbd_description pbd_author pbd_homepage pbd_metadata_revision
+
+instance MemSize PackageVersions where
+  memSize (PackageVersions ps) = getSum $
+    foldMap (\(v,_) -> Sum (memSize v) `mappend` Sum (memSize (0 :: Word))) ps
+
+instance MemSize PackageInfoState where
+  memSize (PackageInfoState {..}) = memSize descriptions + memSize versions
+
+
+initialPackageInfoState :: Bool -> PackageInfoState
+initialPackageInfoState freshDB = PackageInfoState
+  { descriptions          = mempty
+  , versions              = mempty
+  , migratedEphemeralData = freshDB
+  }

--- a/hackage-server.cabal
+++ b/hackage-server.cabal
@@ -288,6 +288,8 @@ library lib-server
       Distribution.Server.Features.PackageCandidates.Types
       Distribution.Server.Features.PackageCandidates.State
       Distribution.Server.Features.PackageCandidates.Backup
+      Distribution.Server.Features.PackageInfoJSON
+      Distribution.Server.Features.PackageInfoJSON.State
       Distribution.Server.Features.PackageList
       Distribution.Server.Features.Distro
       Distribution.Server.Features.Distro.Distributions

--- a/tests/HighLevelTest.hs
+++ b/tests/HighLevelTest.hs
@@ -189,13 +189,24 @@ runPackageTests = do
     do info "Getting package index with etag"
        validateETagHandling "/packages/index.tar.gz"
     do info "Getting testpackage info"
-       xs <- validate NoAuth "/package/testpackage"
+       xs <- validate NoAuth "/package/testpackage.html"
        unless (">testpackage</a>: <small>test package testpackage</small></h1>" `isInfixOf` xs) $
            die ("Bad package info: " ++ show xs)
     do info "Getting testpackage-1.0.0.0 info"
-       xs <- validate NoAuth "/package/testpackage-1.0.0.0"
+       xs <- validate NoAuth "/package/testpackage-1.0.0.0.html"
        unless (">testpackage</a>: <small>test package testpackage</small></h1>" `isInfixOf` xs) $
            die ("Bad package info: " ++ show xs)
+
+    do info "Getting testpackage-1.0.0.0 info (JSON)"
+       xs <- validate NoAuth "/package/testpackage-1.0.0.0.json"
+       unless ("\"synopsis\":\"test package testpackage\"" `isInfixOf` xs) $
+           die ("Bad package info: " ++ show xs)
+
+    do info "Getting testpackage version info (JSON)"
+       xs <- validate NoAuth "/package/testpackage.json"
+       unless ("\"1.0.0.0\":\"normal\"" `isInfixOf` xs) $
+           die ("Bad package version info: " ++ show xs)
+
     do info "Getting testpackage Cabal file"
        cabalFile <- getUrl NoAuth "/package/testpackage-1.0.0.0/testpackage.cabal"
        unless (cabalFile == testpackageCabalFile) $


### PR DESCRIPTION
Replacement for #399 

Add two endpoints, which reuse existing URLs but use the requested content type to choose a JSON response instead of HTML. The new endpoints provide basic information about a package (author, description, license), and a listing of available versions for a package, along with each version's deprecation status.

For example:

`/package/avro-0.4.1.2`
```
{
    "author": "Thomas M. DuBuisson", 
    "description": "Avro serialization and deserialization support for Haskell", 
    "license": "BSD-3-Clause", 
    "metadata_revision": 0
}
```

`/package/avro`
```
{
    "0.4.1.1": "normal", 
    "0.4.1.2": "deprecated", 
    "0.4.1.4": "normal"
}
```

For the first (single-version) view, the URL can specify a metadata revision:
`/packages/avro-0.4.1.1/revision/1`
```
{
    "author": "Thomas M. DuBuisson", 
    "description": "Avro serialization and deserialization support!", 
    "license": "BSD-3-Clause", 
    "metadata_revision": 1
}
```
(when no revision is specified, the most recent one is used)

NOTE: There is no caching implemented for these endpoints. Is it Ok to assume that the computations being done (parsing several cabal files per request) are cheap enough to justify not adding some AcidState caching?

There is no dependencies data in this PR. I'm thinking of adding that in a second PR, after talking with @hvr about his ideas for formatting there.

/cc @hvr @alexcmcdaniel @gbaz 