### PR TITLE
fix postfix apt installation & remove ** usage so cabal copy works.

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -26,7 +26,7 @@ RUN apt-get update
 RUN DEBIAN_FRONTEND=noninteractive apt-get install -yy unzip libicu-dev postfix
 RUN apt-get install -y ghc-8.2.2 cabal-install-2.4
 ENV PATH /opt/ghc/bin:$PATH
-RUN cabal update
+RUN cabal v2-update
 
 # Required Header files
 RUN apt-get install -y zlib1g-dev libssl-dev
@@ -35,13 +35,11 @@ RUN apt-get install -y zlib1g-dev libssl-dev
 RUN mkdir /build
 WORKDIR /build
 ADD ./hackage-server.cabal ./hackage-server.cabal
-RUN cabal sandbox init
-# TODO: Switch to Nix-style cabal new-install
-RUN cabal install --only-dependencies --enable-tests -j --force-reinstalls
-ENV PATH /build/.cabal-sandbox/bin:$PATH
+RUN cabal v2-install -j --force-reinstalls
+ENV PATH /root/.cabal/bin:$PATH
 
 # needed for creating TUF keys
-RUN cabal install hackage-repo-tool
+RUN cabal v2-install hackage-repo-tool
 
 # add code
 # note: this must come after installing the dependencies, such that
@@ -56,13 +54,13 @@ RUN hackage-repo-tool create-root --keys keys -o datafiles/TUF/root.json
 RUN hackage-repo-tool create-mirrors --keys keys -o datafiles/TUF/mirrors.json
 
 # build & test & install hackage
-RUN cabal configure -f-build-hackage-mirror --enable-tests
-RUN cabal build
+RUN cabal v2-configure -f-build-hackage-mirror --enable-tests
+RUN cabal v2-build
 # tests currently don't pass: the hackage-security work introduced some
 # backup/restore errors (though they look harmless)
 # see https://github.com/haskell/hackage-server/issues/425
 #RUN cabal test
-RUN cabal copy && cabal register
+RUN cabal v2-install all
 
 # setup server runtime environment
 RUN mkdir /runtime

--- a/Dockerfile
+++ b/Dockerfile
@@ -23,8 +23,8 @@ RUN apt-add-repository ppa:hvr/ghc
 RUN apt-get update
 
 # Dependencies
-RUN apt-get install -yy unzip libicu-dev postfix
-RUN apt-get install -y ghc-8.2.1 cabal-install-2.0
+RUN DEBIAN_FRONTEND=noninteractive apt-get install -yy unzip libicu-dev postfix
+RUN apt-get install -y ghc-8.2.2 cabal-install-2.4
 ENV PATH /opt/ghc/bin:$PATH
 RUN cabal update
 

--- a/README.md
+++ b/README.md
@@ -69,7 +69,7 @@ you can find these as the file names of the files created in
 `signed.roles.root.keyids`). An example `cabal` client configuration might look
 something like
 
-    remote-repo my-private-hackage
+    repository my-private-hackage
       url: http://example.com:8080/
       secure: True
       root-keys: 865cc6ce84231ccc990885b1addc92646b7377dd8bb920bdfe3be4d20c707796

--- a/hackage-server.cabal
+++ b/hackage-server.cabal
@@ -31,13 +31,19 @@ tested-with: GHC ==8.4.4 || ==8.2.2 || ==8.0.2 || ==7.10.3 || ==7.8.4 || ==7.6.3
 
 data-dir: datafiles
 data-files:
-  templates/**/*.st
+  templates/AdminFrontend/*.st
+  templates/EditCabalFile/*.st
+  templates/Html/*.st
+  templates/LegacyPasswds/*.st
+  templates/Search/*.st
+  templates/UserSignupReset/*.st
+  templates/Users/*.st
 
-  static/**/*.css
-  static/**/*.js
-  static/**/*.svg
-  static/**/*.png
-  static/**/*.ico
+  static/datatables/*.css
+  static/datatables/*.js
+  static/icons/*.svg
+  static/images/*.png
+  static/*.ico
 
   TUF/README.md
   TUF/mirrors.json


### PR DESCRIPTION
Minimum changes I needed to have `docker build .` work.

* `ghc-8.2.1` is no longer available in `ppa:hvr/ghc`
* The `**` glob didn't work so I flattened the `data-files` section
* `cabal-install-2.4` was also needed
* `postfix` refuses to obey `-y`, but a noninteractive frontend for `apt-get` works.