### PR TITLE
Use ISO8601 based format for listing of recent additions

### DIFF
--- a/Distribution/Client/Mirror/Repo/Hackage2.hs
+++ b/Distribution/Client/Mirror/Repo/Hackage2.hs
@@ -113,7 +113,7 @@ uploadPackage targetRepoURI' doMirrorUploaders pkginfo locCab locTgz = do
     tgzURI  = baseURI <//> display pkgid               <.> "tar.gz"
 
     putPackageUploadTime time = do
-      let timeStr = formatTime defaultTimeLocale "%c" time
+      let timeStr = formatTime defaultTimeLocale "%Y-%m-%d %H:%M:%S%EZ" time
       requestPUT (baseURI <//> "upload-time") "text/plain" (packUTF8 timeStr)
 
     putPackageUploader uname = do

--- a/Distribution/Client/UploadLog.hs
+++ b/Distribution/Client/UploadLog.hs
@@ -52,7 +52,7 @@ data Entry = Entry UTCTime UserName PackageIdentifier
 
 instance Text Entry where
   disp (Entry time user pkgid) =
-        Disp.text (formatTime defaultTimeLocale "%c" time)
+        Disp.text (formatTime defaultTimeLocale "%Y-%m-%d %H:%M:%S%EZ" time)
     <+> disp user <+> disp pkgid
   parse = do
     time <- readPTime' "%c"

--- a/Distribution/Server/Features/Core.hs
+++ b/Distribution/Server/Features/Core.hs
@@ -713,7 +713,7 @@ coreFeature ServerEnv{serverBlobStore = store} UserFeature{..}
             Object $ HashMap.fromList
               [ (Text.pack "number", Number (fromIntegral rev))
               , (Text.pack "user", String (Text.pack (display uname)))
-              , (Text.pack "time", String (Text.pack (formatTime defaultTimeLocale "%c" utime)))
+              , (Text.pack "time", String (Text.pack (formatTime defaultTimeLocale "%Y-%m-%d %H:%M:%S%EZ" utime)))
               ]
           revisionsJson = Array $ Vec.imap revisionToObj revisions
       return (toResponse revisionsJson)

--- a/Distribution/Server/Features/Html.hs
+++ b/Distribution/Server/Features/Html.hs
@@ -711,7 +711,7 @@ mkHtmlCore ServerEnv{serverBaseURI, serverBlobStore}
            in templateDict
                 [ templateVal "number" revision
                 , templateVal "user" (display uname)
-                , templateVal "time" (formatTime defaultTimeLocale "%c" utime)
+                , templateVal "time" (formatTime defaultTimeLocale "%Y-%m-%d %H:%M:%S%EZ" utime)
                 , templateVal "posixtime" (formatTime defaultTimeLocale "%s" utime)
                 , templateVal "changes" changes
                 ]

--- a/Distribution/Server/Features/Mirror.hs
+++ b/Distribution/Server/Features/Mirror.hs
@@ -215,7 +215,7 @@ mirrorFeature ServerEnv{serverBlobStore = store}
     uploadTimeGet :: DynamicPath -> ServerPartE Response
     uploadTimeGet dpath = do
       pkg <- packageInPath dpath >>= lookupPackageId
-      return $ toResponse $ formatTime defaultTimeLocale "%c"
+      return $ toResponse $ formatTime defaultTimeLocale "%Y-%m-%d %H:%M:%S%EZ"
                                        (pkgLatestUploadTime pkg)
 
     -- curl -H 'Content-Type: text/plain' -u admin:admin -X PUT -d "Tue Oct 18 20:54:28 UTC 2010" http://localhost:8080/package/edit-distance-0.2.1/upload-time

--- a/Distribution/Server/Pages/AdminLog.hs
+++ b/Distribution/Server/Pages/AdminLog.hs
@@ -36,6 +36,6 @@ adminLogPage users entries = hackagePage "adminstrator actions log" docBody
               group,
               reason]
         nbsp = XHtml.primHtmlChar "nbsp"
-        showTime = formatTime defaultTimeLocale "%c"
+        showTime = formatTime defaultTimeLocale "%Y-%m-%d %H:%M:%S%EZ"
         header = XHtml.tr << map (XHtml.th <<) ["Time ","User ","Action ","Target ","Group ","Reason "]
         fmtCell x = XHtml.td ! [XHtml.align "left"] << [XHtml.toHtml x, nbsp, nbsp]

--- a/Distribution/Server/Pages/Package.hs
+++ b/Distribution/Server/Pages/Package.hs
@@ -501,7 +501,7 @@ renderFields render = [
   where
     desc = rendOther render
     renderUploadInfo utime uinfo =
-        formatTime defaultTimeLocale "%c" utime +++ " by " +++ user
+        formatTime defaultTimeLocale "%Y-%m-%d %H:%M:%S%EZ" utime +++ " by " +++ user
       where
         uname   = maybe "Unknown" (display . userName) uinfo
         uactive = maybe False (isActiveAccount . userStatus) uinfo

--- a/Distribution/Server/Pages/PackageFromTemplate.hs
+++ b/Distribution/Server/Pages/PackageFromTemplate.hs
@@ -220,7 +220,7 @@ packagePageTemplate render
 
     renderUploadInfo :: UTCTime -> Maybe UserInfo-> Html
     renderUploadInfo utime uinfo =
-        "by " +++ user +++ " at " +++ formatTime defaultTimeLocale "%c" utime
+        "by " +++ user +++ " at " +++ formatTime defaultTimeLocale "%Y-%m-%d %H:%M:%S%EZ" utime
       where
         uname   = maybe "Unknown" (display . userName) uinfo
         uactive = maybe False (isActiveAccount . userStatus) uinfo

--- a/Distribution/Server/Pages/Recent.hs
+++ b/Distribution/Server/Pages/Recent.hs
@@ -97,7 +97,7 @@ makeRevisionRow users pkginfo =
     pkgid = pkgInfoId pkginfo
 
 showTime :: UTCTime -> String
-showTime = formatTime defaultTimeLocale "%Y-%m-%d %H:%M:%S %Z"
+showTime = formatTime defaultTimeLocale "%Y-%m-%d %H:%M:%S%EZ"
 
 -- | URL describing a package.
 packageURL :: PackageIdentifier -> URL

--- a/Distribution/Server/Pages/Recent.hs
+++ b/Distribution/Server/Pages/Recent.hs
@@ -97,7 +97,7 @@ makeRevisionRow users pkginfo =
     pkgid = pkgInfoId pkginfo
 
 showTime :: UTCTime -> String
-showTime = formatTime defaultTimeLocale "%c"
+showTime = formatTime defaultTimeLocale "%Y-%m-%d %H:%M:%S %Z"
 
 -- | URL describing a package.
 packageURL :: PackageIdentifier -> URL

--- a/exes/ImportClient.hs
+++ b/exes/ImportClient.hs
@@ -940,7 +940,7 @@ formatErrorResponse (ErrorResponse uri (a,b,c) reason mBody) =
 --
 
 showUTCTime :: UTCTime -> String
-showUTCTime = formatTime defaultTimeLocale "%c"
+showUTCTime = formatTime defaultTimeLocale "%Y-%m-%d %H:%M:%S%EZ"
 
 -- option utility
 reqArgFlag :: ArgPlaceHolder -> SFlags -> LFlags -> Description


### PR DESCRIPTION
This will print
```
2019-10-05 09:18:07Z   barrucadu   irc-client-1.1.1.1
```
instead of
```
Sat Oct 5 09:18:07 UTC 2019   barrucadu   irc-client-1.1.1.1
```
on https://hackage.haskell.org/packages/recent

Since Hackage is an international project, it should also use the international date format as described in [ISO8601](https://en.wikipedia.org/wiki/ISO_8601).

