### PR TITLE
README: Update macOS instructions for icu4c

### DIFF
--- a/README.md
+++ b/README.md
@@ -13,10 +13,15 @@ uses the [icu4c](http://icu-project.org/apiref/icu4c/) library to build.
 
 You'll need to do the following to get hackage-server's dependency `text-icu` to build:
 
-### Mac OS X
+### macOS
 
     brew install icu4c
-    brew link icu4c --force
+
+Then create a `cabal.project.local` with
+
+    package text-icu
+      extra-include-dirs: /usr/local/opt/icu4c/include
+      extra-lib-dirs: /usr/local/opt/icu4c/lib
 
 ### Ubuntu/Debian
 


### PR DESCRIPTION
Running `brew link icu4c --force` resulted in:

    Warning: Refusing to link macOS-provided software: icu4c
    If you need to have icu4c first in your PATH run:
      echo 'export PATH="/usr/local/opt/icu4c/bin:$PATH"' >> ~/.bash_profile
      echo 'export PATH="/usr/local/opt/icu4c/sbin:$PATH"' >> ~/.bash_profile

    For compilers to find icu4c you may need to set:
      export LDFLAGS="-L/usr/local/opt/icu4c/lib"
      export CPPFLAGS="-I/usr/local/opt/icu4c/include"

    For pkg-config to find icu4c you may need to set:
      export PKG_CONFIG_PATH="/usr/local/opt/icu4c/lib/pkgconfig"

and doing that didn't allow hackage-server to build (`cabal build`).

Using `cabal v2-build --extra-lib-dirs=/usr/local/opt/icu4c/lib/
--extra-include-dirs=/usr/local/opt/icu4c/include` also didn't work.