### PR TITLE
Show ISO8601 and SHA256 of revisions

### DIFF
--- a/Distribution/Server/Features/Html.hs
+++ b/Distribution/Server/Features/Html.hs
@@ -34,6 +34,7 @@ import Distribution.Server.Features.TarIndexCache
 import Distribution.Server.Features.UserDetails
 import Distribution.Server.Features.EditCabalFiles
 import Distribution.Server.Features.Html.HtmlUtilities
+import Distribution.Server.Features.Security.SHA256
 
 import Distribution.Server.Users.Types
 import qualified Distribution.Server.Users.Group as Group
@@ -687,12 +688,22 @@ mkHtmlCore ServerEnv{serverBaseURI, serverBlobStore}
           pkgname      = packageName pkginfo
           revisions    = reverse $ Vec.toList (pkgMetadataRevisions pkginfo)
           numRevisions = pkgNumRevisions pkginfo
-          revchanges   = [ case diffCabalRevisionsByteString
-                                  (cabalFileByteString old)
-                                  (cabalFileByteString new)
-                           of Left _err     -> []
-                              Right changes -> changes
-                         | ((new, _), (old, _)) <- zip revisions (tail revisions) ]
+
+          revchanges   :: [(SHA256Digest, [Change])]
+          revchanges   = start revisions where
+            start []          = []
+            start (curr:rest) = go curr rest
+
+            go curr [] = [(sha256 (cabalFileByteString (fst curr)), [])]
+            go curr (prev:rest) =
+                ( sha256 (cabalFileByteString (fst curr))
+                , changes curr prev )
+                : go prev rest
+
+            changes curr prev = either (const []) id $
+              diffCabalRevisionsByteString
+                (cabalFileByteString (fst prev))
+                (cabalFileByteString (fst curr))
 
       cacheControl [NoCache] (etagFromHash numRevisions)
       template <- getTemplate templates "revisions.html"
@@ -702,18 +713,21 @@ mkHtmlCore ServerEnv{serverBaseURI, serverBlobStore}
         , "revisions" $= zipWith3 (revisionToTemplate users)
                                   (map snd revisions)
                                   [numRevisions-1, numRevisions-2..]
-                                  (revchanges ++ [[]])
+                                  revchanges
         ]
       where
-        revisionToTemplate :: Users.Users -> UploadInfo -> Int -> [Change]
+        revisionToTemplate :: Users.Users -> UploadInfo -> Int
+                           -> (SHA256Digest, [Change])
                            -> TemplateVal
-        revisionToTemplate users (utime, uid) revision changes =
+        revisionToTemplate users (utime, uid) revision (sha256hash, changes) =
           let uname = Users.userIdToName users uid
            in templateDict
                 [ templateVal "number" revision
+                , templateVal "sha256" (show sha256hash)
                 , templateVal "user" (display uname)
                 , templateVal "time" (formatTime defaultTimeLocale "%c" utime)
                 , templateVal "posixtime" (formatTime defaultTimeLocale "%s" utime)
+                , templateVal "iso8601" (formatTime defaultTimeLocale "%Y-%m-%dT%H:%M:%SZ" utime)
                 , templateVal "changes" changes
                 ]
 

--- a/datafiles/templates/Html/revisions.html.st
+++ b/datafiles/templates/Html/revisions.html.st
@@ -21,14 +21,18 @@ stored separately.
     <th>No.</th>
     <th>Time</th>
     <th>User</th>
-    <th>Changes</th>
+    <th>SHA256</th>
   </tr>
   $revisions:{revision|
     <tr>
       <td valign="top"><a href="/package/$pkgid$/revision/$revision.number$.cabal">#$revision.number$</a></td>
-      <td valign="top">$revision.time$</td>
+      <td valign="top" title="$revision.time$">$revision.iso8601$</td>
       <td valign="top"><a href="/user/$revision.user$">$revision.user$</td>
-      <td>
+      <td valign="top">$revision.sha256$</th>
+    </tr>
+    <tr>
+      <td valign="top"></td>
+      <td colspan="3">
         <ul>
         $revision.changes:{change|<li><p>$change.what$
                          $if(change.from)$ $if(change.to)$from$endif$ <pre>$change.from$</pre>$endif$


### PR DESCRIPTION
The rendered table is ugly,
but this information is needed
(and extracting SHA256 is tricky).

![Screenshot from 2020-03-22 16-47-14](https://user-images.githubusercontent.com/51087/77252540-19de9f80-6c5d-11ea-9c0b-5d6668b392c3.png)
