### PR TITLE
Add deauthentication

### DIFF
--- a/Distribution/Server/Features/Core.hs
+++ b/Distribution/Server/Features/Core.hs
@@ -399,6 +399,9 @@ coreFeature ServerEnv{serverBlobStore = store} UserFeature{..}
           , coreCabalFile
           , coreCabalFileRevs
           , coreCabalFileRev
+          , coreUserDeauth
+          , coreAdminDeauth
+          , corePackUserDeauth
           ]
       , featureState    = [abstractAcidStateComponent packagesState]
       , featureCaches   = [
@@ -448,6 +451,19 @@ coreFeature ServerEnv{serverBlobStore = store} UserFeature{..}
     coreCabalFileRev = (resourceAt "/package/:package/revision/:revision.:format") {
         resourceDesc = [(GET, "Get package .cabal file revision")]
       , resourceGet  = [("cabal", serveCabalFileRevision)]
+      }
+
+    coreUserDeauth = (resourceAt "/packages/deauth") {
+        resourceDesc = [(GET,  "Deauth Package user")]
+      , resourceGet  = [("", deauth)]
+      }
+    coreAdminDeauth = (resourceAt "/admin/deauth") {
+        resourceDesc = [(GET,  "Deauth Admin")]
+      , resourceGet  = [("", deauth)]
+      }
+    corePackUserDeauth = (resourceAt "/user/:user/deauth") {
+        resourceDesc = [(GET,  "Deauth User")]
+      , resourceGet  = [("", deauth)]
       }
     indexPackageUri = \format ->
       renderResource corePackagesPage [format]
@@ -729,6 +745,14 @@ coreFeature ServerEnv{serverBlobStore = store} UserFeature{..}
             cabalfile = Resource.CabalFile (cabalFileByteString fileRev) utime
         Nothing -> errNotFound "Package revision not found"
                      [MText "Cannot parse revision, or revision out of range."]
+    
+    
+    deauth :: DynamicPath -> ServerPartE Response
+    deauth _ = do
+      return $ (toResponse ("<script>window.location='/'</script>"::String)) { 
+          rsCode = 401 
+        , rsHeaders   = mkHeaders ([("Content-Type",  "text/html")])
+      }
 
 packageExists, packageIdExists :: (Package pkg, Package pkg') => PackageIndex pkg -> pkg' -> Bool
 -- | Whether a package exists in the given package index.

--- a/Distribution/Server/Features/Html.hs
+++ b/Distribution/Server/Features/Html.hs
@@ -885,6 +885,7 @@ mkHtmlUploads HtmlUtilities{..} UploadFeature{..} = HtmlUploads{..}
                 [ input ! [thetype "file", name "package"]
                 , input ! [thetype "submit", value "Upload package"]
                 ]
+          , paragraph << [toHtml "If you want to deauthenticate first, ", anchor ! [href "/packages/deauth"] << "click here", toHtml "."]
           ]
 
     serveUploadResult :: DynamicPath -> ServerPartE Response

--- a/datafiles/templates/AdminFrontend/admin.html.st
+++ b/datafiles/templates/AdminFrontend/admin.html.st
@@ -6,7 +6,7 @@ $hackageCssTheme()$
 </head>
 
 <body>
-$hackagePageHeader()$
+$hackagePageHeader(deauthAdmin="1")$
 
 <div id="content">
 <h1>Admin front-end</h1>

--- a/datafiles/templates/Users/manage.html.st
+++ b/datafiles/templates/Users/manage.html.st
@@ -6,7 +6,7 @@ $hackageCssTheme()$
 </head>
 
 <body>
-$hackagePageHeader()$
+$hackagePageHeader(deauthUser="1")$
 
 <div id="content">
 <h2>Manage user account $username$</h2>

--- a/datafiles/templates/hackagePageHeader.st
+++ b/datafiles/templates/hackagePageHeader.st
@@ -18,6 +18,13 @@
     <li><a href="/upload">Upload</a></li>
 
     <li><a href="/accounts">User accounts</a></li>
+    $if(deauthPack)$
+      <li><a title="If authenticated" href="/packages/deauth">Logout</a></li>
+    $elseif(deauthAdmin)$
+      <li><a title="If authenticated" href="/admin/deauth">Logout</a></li>
+    $elseif(deauthUser)$
+      <li><a title="If authenticated" href="./deauth">Logout</a></li>
+    $endif$
 
 </ul>
 


### PR DESCRIPTION
Hackage deauthenticates a session only when browser closes which is definitely not an option for most of the time. 
Hackage uses three authentications at `/admin`, `/packages`, `/user/USERNAME` and all these three can't be deauthenticated with a single route.

This PR adds a logout feature. Logout feature is available at
* `/user/USERNAME/manage`
* `/packages/upload`
* `/admin`

There isn't any straight forward way for the template to know if the user is authenticated, thus logout button is not dynamic and I picked locations where to show.