### PR TITLE
MirrorClient: Skip setting cache if pkgs selected

### DIFF
--- a/exes/MirrorClient.hs
+++ b/exes/MirrorClient.hs
@@ -137,7 +137,10 @@ mirrorOnce verbosity opts
 
               mirrorPackages verbosity opts sourceRepo targetRepo pkgsToMirror'
               finalizeMirror   sourceRepo targetRepo
-              cacheTargetIndex sourceRepo targetRepo
+
+              case length (selectedPkgs opts) of
+                0 ->  cacheTargetIndex sourceRepo targetRepo
+                _ ->  return ()
 
               case mirrorPostHook (mirrorConfig opts) of
                 Nothing       -> return ()


### PR DESCRIPTION
Skips setting the cache if mirror client runs against selected packages. This resolves #874 