### PR TITLE
MirrorClient: Set keep-going by default

### DIFF
--- a/Distribution/Client/Mirror/CmdLine.hs
+++ b/Distribution/Client/Mirror/CmdLine.hs
@@ -42,7 +42,7 @@ defaultMirrorFlags = MirrorFlags
   { flagCacheDir        = Nothing
   , flagContinuous      = False
   , flagInterval        = Nothing
-  , flagKeepGoing       = False
+  , flagKeepGoing       = True
   , flagMirrorUploaders = False
   , flagVerbosity       = normal
   , flagHelp            = False
@@ -70,9 +70,9 @@ mirrorFlagDescrs =
       (ReqArg (\int opts -> opts { flagInterval = Just int }) "MIN")
       "Set the mirroring interval in minutes (default 30)"
 
-  , Option [] ["keep-going"]
-      (NoArg (\opts -> opts { flagKeepGoing = True }))
-      "Don't fail on mirroring errors, keep going."
+  , Option [] ["fail-on-error"]
+      (NoArg (\opts -> opts { flagKeepGoing = False }))
+      "Fail on mirroring errors."
 
   , Option [] ["mirror-uploaders"]
       (NoArg (\opts -> opts { flagMirrorUploaders = True }))


### PR DESCRIPTION
By default, mirror client fails on error. In most of the cases, this is not required behaviour. This PR inverts keep-going flag and change it to fail-on-error.
The client now fails only if the fail-on-error flag is set.

![image](https://user-images.githubusercontent.com/31537546/83235113-03017f80-a1af-11ea-96d3-125de5cc9694.png)
