### PR TITLE
Fix: Accept space seperated flags in Build Report

### DIFF
--- a/Distribution/Server/Features/BuildReports/BuildReport.hs
+++ b/Distribution/Server/Features/BuildReports/BuildReport.hs
@@ -253,7 +253,7 @@ fieldDescrs =
     <*> uniqueField       "compiler"           compilerL
     <*> uniqueField       "client"             clientL
     <*> (map unpack <$>
-        monoidalFieldAla  "flags"              (alaList CommaFSep) flagAssignmentL')
+        monoidalFieldAla  "flags"              (alaList FSep) flagAssignmentL')
     <*> monoidalFieldAla  "dependencies"       (alaList VCat) dependenciesL
     <*> uniqueField       "install-outcome"    installOutcomeL
     <*> uniqueField       "docs-outcome"       docsOutcomeL


### PR DESCRIPTION
Hackage have a parser that parses Build Report. Currently, the parser only accepts comma-separated flags whereas builder sends flags as space-separated.
So when I send a report that has
```
flags: -examples integer-gmp sse2 -sse41
```
The request fails with the error message:
```
Error submitting report: 
unexpected 'i'
expecting space, comma, white space or end of input
```
It starts to fail since [this](https://github.com/haskell/hackage-server/commit/780744ebcbec93a9e764f5484047b9f3348141b3#diff-0251fd4f91872f46f89c3c26c76750b2) change I guess as I can see some build reports (like [this](http://hackage.haskell.org/package/hashable-1.3.0.0/reports/) one) have space-separated flags whereas Hackage returns an error now.

This PR fixes this issue by using [FSep](https://hackage.haskell.org/package/Cabal-3.2.0.0/docs/Distribution-Parsec-Newtypes.html#t:FSep) instead of [CommaFSep](https://hackage.haskell.org/package/Cabal-3.2.0.0/docs/Distribution-Parsec-Newtypes.html#t:CommaFSep). 
Hackage now accepts reports with space-separated flags without any error.