### PR TITLE
switch to commonmark for uniformity and more extensions

### DIFF
--- a/Distribution/Server/Features/PackageContents.hs
+++ b/Distribution/Server/Features/PackageContents.hs
@@ -17,22 +17,18 @@ import Distribution.Server.Packages.Types
 import Distribution.Server.Packages.Render
 import Distribution.Server.Features.Users
 import Distribution.Server.Util.ServeTarball
+import Distribution.Server.Util.Markdown (renderMarkdown, supposedToBeMarkdown)
 import Distribution.Server.Pages.Template (hackagePage)
 
 import Distribution.Text
 import Distribution.Package
 
-import qualified Cheapskate      as Markdown (markdown, Options(..))
-import qualified Cheapskate.Html as Markdown (renderDoc)
-import qualified Text.Blaze.Html.Renderer.Pretty as Blaze (renderHtml)
 import qualified Data.Text                as T
 import qualified Data.Text.Encoding       as T
 import qualified Data.Text.Encoding.Error as T
 import qualified Data.ByteString.Lazy as BS (ByteString, toStrict)
-import qualified Data.ByteString.Char8 as C8
 import qualified Text.XHtml.Strict as XHtml
 import           Text.XHtml.Strict ((<<), (!))
-import System.FilePath.Posix (takeExtension)
 
 
 data PackageContentsFeature = PackageContentsFeature {
@@ -152,7 +148,7 @@ packageContentsFeature CoreFeature{ coreResource = CoreResource{
                  [ XHtml.h2 << title2
                  , XHtml.thediv ! [XHtml.theclass "embedded-author-content"]
                                << if supposedToBeMarkdown filename
-                                    then renderMarkdown contents
+                                    then renderMarkdown filename contents
                                     else XHtml.thediv ! [XHtml.theclass "preformatted"]
                                                      << unpackUtf8 contents
                  ]
@@ -186,7 +182,7 @@ packageContentsFeature CoreFeature{ coreResource = CoreResource{
               [ XHtml.h2 << title
               , XHtml.thediv ! [XHtml.theclass "embedded-author-content"]
                             << if supposedToBeMarkdown filename
-                                 then renderMarkdown contents
+                                 then renderMarkdown filename contents
                                  else XHtml.thediv ! [XHtml.theclass "preformatted"]
                                                   << unpackUtf8 contents
               ]
@@ -203,25 +199,6 @@ packageContentsFeature CoreFeature{ coreResource = CoreResource{
           serveTarball (display (packageId pkg) ++ " source tarball")
                        [] (display (packageId pkg)) fp index
                        [Public, maxAgeDays 30] etag
-
-renderMarkdown :: BS.ByteString -> XHtml.Html
-renderMarkdown = XHtml.primHtml . Blaze.renderHtml
-               . Markdown.renderDoc . Markdown.markdown opts
-               . T.decodeUtf8With T.lenientDecode . convertNewLine . BS.toStrict
-  where
-    opts =
-      Markdown.Options
-        { Markdown.sanitize           = True
-        , Markdown.allowRawHtml       = False
-        , Markdown.preserveHardBreaks = False
-        , Markdown.debug              = False
-        }
-
-convertNewLine :: C8.ByteString -> C8.ByteString
-convertNewLine = C8.filter (/= '\r')
-
-supposedToBeMarkdown :: FilePath -> Bool
-supposedToBeMarkdown fname = takeExtension fname `elem` [".md", ".markdown"]
 
 unpackUtf8 :: BS.ByteString -> String
 unpackUtf8 = T.unpack

--- a/Distribution/Server/Pages/Package.hs
+++ b/Distribution/Server/Pages/Package.hs
@@ -20,7 +20,6 @@ module Distribution.Server.Pages.Package
   , maintainerSection
   , downloadSection
   , moduleToDocUrl
-  , renderMarkdown
   ) where
 
 import Distribution.Server.Features.PreferredVersions
@@ -31,6 +30,7 @@ import Distribution.Server.Pages.Package.HaddockHtml
 import Distribution.Server.Packages.ModuleForest
 import Distribution.Server.Packages.Render
 import Distribution.Server.Users.Types (userStatus, userName, isActiveAccount)
+import Distribution.Server.Util.Markdown (renderMarkdownRel, supposedToBeMarkdown)
 import Data.TarIndex (TarIndex)
 import qualified Data.TarIndex as Tar
 
@@ -51,15 +51,9 @@ import Control.Arrow            (second)
 import System.FilePath.Posix    ((</>), (<.>), takeFileName)
 import Data.Time.Locale.Compat  (defaultTimeLocale)
 import Data.Time.Format         (formatTime)
-import System.FilePath.Posix    (takeExtension)
-import Network.URI              (isRelativeReference)
-
-import qualified Cheapskate      as Markdown (markdown, Options(..), Inline(Link), walk)
-import qualified Cheapskate.Html as Markdown (renderDoc)
 
 import qualified Documentation.Haddock.Markup as Haddock
 
-import qualified Text.Blaze.Html.Renderer.Pretty as Blaze (renderHtml)
 import qualified Data.Text                as T
 import qualified Data.Text.Encoding       as T
 import qualified Data.Text.Encoding.Error as T (lenientDecode)
@@ -170,37 +164,12 @@ readmeSection PackageRender { rendReadme = Just (_, _etag, _, filename)
     , toHtml "]"
     , thediv ! [theclass "embedded-author-content"]
             << if supposedToBeMarkdown filename
-                 then renderMarkdown (T.pack name) content
+                 then renderMarkdownRel name content
                  else pre << unpackUtf8 content
     ] where
       name = display pkgid
 readmeSection _ _ = []
 
-updateRelativeLinks :: T.Text -> Markdown.Inline -> Markdown.Inline
-updateRelativeLinks name (Markdown.Link inls url title) =
-  Markdown.Link inls url' title
-  where url' = if isRelativeReference $ T.unpack url then name <> T.pack "/src" <> url else url
-updateRelativeLinks _ x = x
-
-renderMarkdown :: T.Text -> BS.ByteString -> Html
-renderMarkdown name = primHtml . Blaze.renderHtml
-               . Markdown.renderDoc . Markdown.walk (updateRelativeLinks name)
-               . Markdown.markdown opts
-                 -- workaround for https://github.com/jgm/cheapskate/issues/25
-               . T.replace (T.pack "\r\n") (T.pack "\n")
-               . T.decodeUtf8With T.lenientDecode
-               . BS.toStrict
-  where
-    opts =
-      Markdown.Options
-        { Markdown.sanitize           = True
-        , Markdown.allowRawHtml       = False
-        , Markdown.preserveHardBreaks = False
-        , Markdown.debug              = False
-        }
-
-supposedToBeMarkdown :: FilePath -> Bool
-supposedToBeMarkdown fname = takeExtension fname `elem` [".md", ".markdown"]
 
 unpackUtf8 :: BS.ByteString -> String
 unpackUtf8 = T.unpack

--- a/Distribution/Server/Pages/PackageFromTemplate.hs
+++ b/Distribution/Server/Pages/PackageFromTemplate.hs
@@ -18,6 +18,7 @@ import Distribution.Server.Packages.PackageIndex (PackageIndex)
 import Distribution.Server.Packages.Types
 import Distribution.Server.Features.PackageCandidates
 import Distribution.Server.Users.Types (userStatus, userName, isActiveAccount)
+import Distribution.Server.Util.Markdown (renderMarkdown, supposedToBeMarkdown)
 import Data.TarIndex (TarIndex)
 import Distribution.Server.Features.Distro.Types
 
@@ -33,7 +34,6 @@ import Data.List                (intersperse)
 import System.FilePath.Posix    ((</>), takeFileName, dropTrailingPathSeparator)
 import Data.Time.Locale.Compat  (defaultTimeLocale)
 import Data.Time.Format         (formatTime)
-import System.FilePath.Posix    (takeExtension)
 
 import qualified Data.Text                as T
 import qualified Data.Text.Encoding       as T
@@ -115,7 +115,7 @@ packagePageTemplate render
     ]
   where
     -- Access via "$hackage.varName$"
-    hackageFieldsTemplate = 
+    hackageFieldsTemplate =
       if isCandidate
         then templateDict $
         [ templateVal "uploadTime"
@@ -131,7 +131,7 @@ packagePageTemplate render
         , templateVal "flagsSection"
             (Old.renderPackageFlags render docURL)
         ]
-        else templateDict $ 
+        else templateDict $
         [ templateVal "uploadTime"
             (uncurry renderUploadInfo $ rendUploadInfo render)
         ] ++
@@ -140,7 +140,7 @@ packagePageTemplate render
             (case rendUpdateInfo render of Nothing -> False; _ -> True)
         , templateVal "updateTime" [ renderUpdateInfo revisionNo utime uinfo
             | (revisionNo, utime, uinfo) <- maybeToList (rendUpdateInfo render) ]
-        ] ++        
+        ] ++
         [ templateVal "hasDistributions"
             True
             {-(if distributions == [] then False else True)-}
@@ -491,13 +491,11 @@ readmeSection PackageRender { rendReadme = Just (_, _etag, _, filename), rendPkg
               (Just content) =
     [ thediv ! [theclass "embedded-author-content"]
             << if supposedToBeMarkdown filename
-                 then Old.renderMarkdown (T.pack $ display pkgid) content
+                 then renderMarkdown (display pkgid) content
                  else pre << unpackUtf8 content
     ]
 readmeSection _ _ = []
 
-supposedToBeMarkdown :: FilePath -> Bool
-supposedToBeMarkdown fname = takeExtension fname `elem` [".md", ".markdown"]
 
 unpackUtf8 :: BS.ByteString -> String
 unpackUtf8 = T.unpack

--- a/Distribution/Server/Pages/Template.hs
+++ b/Distribution/Server/Pages/Template.hs
@@ -36,6 +36,7 @@ hackagePageWith headExtra docTitle docSubtitle docContent bodyExtra =
                             , thetype "image/png"] << noHtml
                 , meta ! [ name "viewport"
                          , content "width=device-width, initial-scale=1"]
+                , (script noHtml) ! [ src "https://cdn.jsdelivr.net/npm/mathjax@3/es5/tex-chtml-full.js", thetype "text/javascript"]
                 -- if Search is enabled
                 , thelink ! [ rel "search", href "/packages/opensearch.xml"
                             , thetype "application/opensearchdescription+xml"

--- a/Distribution/Server/Util/Markdown.hs
+++ b/Distribution/Server/Util/Markdown.hs
@@ -14,6 +14,7 @@ import qualified Data.Text as T
 import qualified Data.Text.Encoding       as T
 import qualified Data.Text.Encoding.Error as T (lenientDecode)
 import qualified Data.Text.Lazy as TL
+import Data.Semigroup
 import Network.URI (isRelativeReference)
 import Control.Monad.Identity
 import Text.HTML.SanitizeXSS as XSS

--- a/Distribution/Server/Util/Markdown.hs
+++ b/Distribution/Server/Util/Markdown.hs
@@ -1,0 +1,120 @@
+{-# LANGUAGE MultiParamTypeClasses #-}
+{-# LANGUAGE OverloadedStrings #-}
+{-# LANGUAGE FlexibleInstances #-}
+{-# LANGUAGE FlexibleContexts #-}
+{-# LANGUAGE GeneralizedNewtypeDeriving #-}
+{-# LANGUAGE UndecidableInstances       #-}
+module Distribution.Server.Util.Markdown where
+
+import Commonmark
+import Commonmark.Extensions
+import Commonmark.Extensions.Footnote()
+import Commonmark.Extensions.Math()
+import qualified Data.Text as T
+import qualified Data.Text.Encoding       as T
+import qualified Data.Text.Encoding.Error as T (lenientDecode)
+import qualified Data.Text.Lazy as TL
+import Network.URI (isRelativeReference)
+import Control.Monad.Identity
+import Text.HTML.SanitizeXSS as XSS
+import System.FilePath.Posix  (takeExtension)
+import qualified Data.ByteString.Lazy as BS (ByteString, toStrict)
+import qualified Text.XHtml.Strict as XHtml
+
+-- HHtml wraps Html, and mostly behaves the same, except that
+-- relative links in images and urls have "src/" prepended.
+newtype HHtml a = HHtml { unHHtml :: Html a }
+  deriving (Show, Semigroup, Monoid)
+
+instance HasAttributes (HHtml a) where
+  addAttributes attrs (HHtml x) = HHtml (addAttributes attrs x)
+
+instance ToPlainText (HHtml a) where
+  toPlainText (HHtml x) = toPlainText x
+
+instance Rangeable (Html a) => Rangeable (HHtml a) where
+  ranged sr (HHtml x) = (HHtml $ ranged sr x)
+
+instance (Rangeable (Html a), Rangeable (HHtml a)) => IsInline (HHtml a) where
+  lineBreak = HHtml lineBreak
+  softBreak = HHtml softBreak
+  str t = HHtml (str t)
+  entity t = HHtml (entity t)
+  escapedChar c = HHtml (escapedChar c)
+  emph ils = HHtml (emph $ unHHtml ils)
+  strong ils = HHtml (strong $ unHHtml ils)
+  link target title ils = HHtml $
+    link (adjustRelativeLink target) title (unHHtml ils)
+  image target title ils = HHtml $
+    image (adjustRelativeLink target) title (unHHtml ils)
+  code t = HHtml $ code t
+  rawInline f t = HHtml (rawInline f t)
+
+instance (Rangeable (Html a), IsInline (HHtml a))
+     => IsBlock (HHtml a) (HHtml a) where
+  paragraph ils = HHtml $ paragraph $ unHHtml ils
+  plain ils = HHtml $ plain $ unHHtml ils
+  thematicBreak = HHtml thematicBreak
+  blockQuote bs = HHtml $ blockQuote $ unHHtml bs
+  codeBlock info t = HHtml $ codeBlock info t
+  heading level ils = HHtml $ heading level $ unHHtml ils
+  rawBlock f t = HHtml $ rawBlock f t
+  referenceLinkDefinition x y = HHtml $ referenceLinkDefinition x y
+  list lType lSpacing items =
+    HHtml $ list lType lSpacing $ map unHHtml items
+
+instance HasEmoji (HHtml a) where
+  emoji kw cs = HHtml $ emoji kw cs
+
+instance HasStrikethrough (HHtml a) where
+  strikethrough ils = HHtml $ strikethrough $ unHHtml ils
+
+instance HasPipeTable (HHtml a) (HHtml a) where
+  pipeTable aligns heads rows =
+    HHtml $ pipeTable aligns (map unHHtml heads) (map (map unHHtml) rows)
+
+instance (Rangeable (Html a), Rangeable (HHtml a))
+         => HasTaskList (HHtml a) (HHtml a) where
+  taskList ltype lspacing items =
+    HHtml $ taskList ltype lspacing
+          $ map (\(done, bl) -> (done, unHHtml bl)) items
+
+instance HasMath (HHtml a) where
+  inlineMath t = HHtml $ inlineMath t
+  displayMath t = HHtml $ displayMath t
+
+
+instance Rangeable (Html a) => HasFootnote (HHtml a) (HHtml a) where
+  footnote x y (HHtml t) = HHtml (footnote x y t)
+  footnoteList xs = HHtml $ footnoteList (map unHHtml xs)
+  footnoteRef x y (HHtml t) = HHtml (footnoteRef x y t)
+
+adjustRelativeLink :: T.Text -> T.Text
+adjustRelativeLink url
+  | isRelativeReference (T.unpack url) &&
+    not ("/" `T.isPrefixOf` url)
+              = "src/" <> url
+  | otherwise = url
+
+
+renderHHtml :: HHtml () -> TL.Text
+renderHHtml (HHtml x) = renderHtml x
+
+renderMarkdown :: String -> BS.ByteString -> XHtml.Html
+renderMarkdown name md =
+     either (const $ XHtml.pre XHtml.<< T.unpack txt) (XHtml.primHtml . T.unpack . sanitizeBalance . TL.toStrict . (renderHtml :: Html () -> TL.Text)) $
+         runIdentity (commonmarkWith (mathSpec <> footnoteSpec <> defaultSyntaxSpec <> gfmExtensions)
+                     name
+                     txt)
+  where txt = T.decodeUtf8With T.lenientDecode . BS.toStrict $ md
+
+renderMarkdownRel :: String -> BS.ByteString -> XHtml.Html
+renderMarkdownRel name md =
+     either (const $ XHtml.pre XHtml.<< T.unpack txt) (XHtml.primHtml . T.unpack . sanitizeBalance . TL.toStrict . renderHHtml) $
+         runIdentity (commonmarkWith (mathSpec <> footnoteSpec <> defaultSyntaxSpec <> gfmExtensions)
+                     name
+                     txt)
+  where txt = T.decodeUtf8With T.lenientDecode . BS.toStrict $ md
+
+supposedToBeMarkdown :: FilePath -> Bool
+supposedToBeMarkdown fname = takeExtension fname `elem` [".md", ".markdown"]

--- a/datafiles/templates/Html/package-page.html.st
+++ b/datafiles/templates/Html/package-page.html.st
@@ -10,7 +10,7 @@
   </title>
   <link rel="canonical" href="$sbaseurl$/package/$package.name$" />
   <script src="/static/jquery.min.js"></script>
-  <script src="https://cdnjs.cloudflare.com/ajax/libs/mathjax/2.7.0/MathJax.js?config=TeX-AMS-MML_HTMLorMML" type="text/javascript"></script>
+  <script src="https://cdn.jsdelivr.net/npm/mathjax@3/es5/tex-chtml-full.js" type="text/javascript"></script>
   <base href="$baseurl$/package/$package.name$-$package.version$/" />
 </head>
 

--- a/hackage-server.cabal
+++ b/hackage-server.cabal
@@ -245,6 +245,7 @@ library lib-server
     Distribution.Server.Util.Nonce
     Distribution.Server.Util.Merge
     Distribution.Server.Util.ParseSpecVer
+    Distribution.Server.Util.Markdown
 
     Distribution.Server.Features
     Distribution.Server.Features.Core
@@ -359,6 +360,9 @@ library lib-server
     , blaze-builder         ^>= 0.4
     , blaze-html            ^>= 0.9
     , cereal                ^>= 0.5
+    , commonmark	    ^>= 0.1
+    , commonmark-extensions ^>= 0.2
+    -- TODO delete
     , cheapskate            ^>= 0.1
     , cryptohash-md5        ^>= 0.11.100
     , cryptohash-sha256     ^>= 0.11.100
@@ -382,6 +386,7 @@ library lib-server
     , time-locale-compat    ^>= 0.1.0.1
     , xhtml                 ^>= 3000.2
     , xmlgen                ^>= 0.6
+    , xss-sanitize          ^>= 0.3.6
 
   if !flag(minimal)
     build-depends: snowball ^>= 1.0
@@ -551,4 +556,3 @@ test-suite HashTests
       -- component-specific dependencies
     , tasty       ^>= 1.2.1
     , tasty-hunit ^>= 0.10
-

--- a/hackage-server.cabal
+++ b/hackage-server.cabal
@@ -362,8 +362,6 @@ library lib-server
     , cereal                ^>= 0.5
     , commonmark	    ^>= 0.1
     , commonmark-extensions ^>= 0.2
-    -- TODO delete
-    , cheapskate            ^>= 0.1
     , cryptohash-md5        ^>= 0.11.100
     , cryptohash-sha256     ^>= 0.11.100
     , csv                   ^>= 0.1


### PR DESCRIPTION
resolves #565
resolves #825
resolves #477
resolves #650 
resolves #567 

For math we still need to include the following

- [x] `<script src="https://cdn.jsdelivr.net/npm/mathjax@3/es5/tex-chtml-full.js" type="text/javascript"></script>`
