### PR TITLE
Add package links to "changelog not found" page

### DIFF
--- a/Distribution/Server/Features/PackageContents.hs
+++ b/Distribution/Server/Features/PackageContents.hs
@@ -21,6 +21,7 @@ import Distribution.Server.Pages.Template (hackagePage)
 
 import Distribution.Text
 import Distribution.Package
+import Distribution.PackageDescription
 
 import qualified Cheapskate      as Markdown (markdown, Options(..))
 import qualified Cheapskate.Html as Markdown (renderDoc)
@@ -31,6 +32,7 @@ import qualified Data.Text.Encoding.Error as T
 import qualified Data.ByteString.Lazy as BS (ByteString, toStrict)
 import qualified Data.ByteString.Char8 as C8
 import qualified Text.XHtml.Strict as XHtml
+import qualified Distribution.Utils.ShortText as ST
 import           Text.XHtml.Strict ((<<), (!))
 import System.FilePath.Posix (takeExtension)
 
@@ -134,20 +136,28 @@ packageContentsFeature CoreFeature{ coreResource = CoreResource{
 
     serveChangeLogHtml :: DynamicPath -> ServerPartE Response
     serveChangeLogHtml dpath = do
-      pkg     <- packageInPath dpath >>= lookupPackageId
-      mReadme <- liftIO $ findToplevelFile pkg isChangeLogFile
-      case mReadme of
-        Left err ->
-          errNotFound "Changelog not found" [MText err]
+      pkg        <- packageInPath dpath >>= lookupPackageId
+      mChangeLog <- liftIO $ findToplevelFile pkg isChangeLogFile
+      let pkgId   = packageId pkg
+      let url     = packageURL pkgId
+      let pkgName = display pkgId
+      case mChangeLog of
+        Left _ -> do
+          let message = [MText "Package ", MLink pkgName url, MText " has no changelog file in source distribution. "]
+          let home = homepage $ packageDescription $ pkgDesc pkg
+          if ST.null home then 
+            errNotFound "Changelog not found" message
+          else 
+            let homeUrl = ST.fromShortText home in
+            errNotFound "Changelog not found" (message ++ [MText "You may find one at the package home page: ", MLink homeUrl homeUrl])
         Right (tarfile, etag, offset, filename) -> do
           contents <- either (\err -> errInternalError [MText err])
                              (return . snd)
                   =<< liftIO (loadTarEntry tarfile offset)
           cacheControl [Public, maxAgeDays 30] etag
           return $ toResponse $ Resource.XHtml $
-            let title  = "Changelog for " ++ display pkgId
-                title2 = "Changelog for " XHtml.+++ (XHtml.anchor ! [XHtml.href (packageURL pkgId)] << display pkgId)
-                pkgId  = packageId pkg
+            let title  = "Changelog for " ++ pkgName
+                title2 = "Changelog for " XHtml.+++ (XHtml.anchor ! [XHtml.href url] << pkgName)
             in hackagePage title
                  [ XHtml.h2 << title2
                  , XHtml.thediv ! [XHtml.theclass "embedded-author-content"]


### PR DESCRIPTION
One link to its hackage page and another one to package home, if available.