### PR TITLE
Remove link to Hayoo API search in search results

### DIFF
--- a/Distribution/Server/Features/Html.hs
+++ b/Distribution/Server/Features/Html.hs
@@ -1881,20 +1881,14 @@ mkHtmlSearch HtmlUtilities{..}
         alternativeSearch =
           paragraph <<
             [ toHtml "Alternatively, if you are looking for a particular function then try "
-            , anchor ! [href hayooBaseLink] << "Hayoo"
-            , toHtml " or "
             , anchor ! [href hoogleBaseLink] << "Hoogle"
             ]
         alternativeSearchTerms termsStr =
           paragraph <<
             [ toHtml "Alternatively, if you are looking for a particular function then try "
-            , anchor ! [href (hayooLink termsStr)] << "Hayoo"
-            , toHtml " or "
             , anchor ! [href (hoogleLink termsStr)] << "Hoogle"
             ]
-        hayooBaseLink  = "http://holumbus.fh-wedel.de/hayoo/hayoo.html"
         hoogleBaseLink = "http://www.haskell.org/hoogle/"
-        hayooLink termsStr  = "http://hayoo.fh-wedel.de/?query=" <> termsStr
         hoogleLink termsStr = "http://www.haskell.org/hoogle/?hoogle=" <> termsStr
 
         explainResults :: (Maybe PackageName, [(Search.Explanation PkgDocField PkgDocFeatures T.Text, PackageName)]) -> [Html]


### PR DESCRIPTION
Hayoo, the haskell api search engine, has been down for about 2 years.
Instead of pointing the user to a dead link, we should just direct them
to Hoogle instead.

Should address #919