### PR TITLE
Fix #866 which changed the datetime format to non iso8601

### DIFF
--- a/Distribution/Client/Mirror/Repo/Hackage2.hs
+++ b/Distribution/Client/Mirror/Repo/Hackage2.hs
@@ -113,7 +113,7 @@ uploadPackage targetRepoURI' doMirrorUploaders pkginfo locCab locTgz = do
     tgzURI  = baseURI <//> display pkgid               <.> "tar.gz"
 
     putPackageUploadTime time = do
-      let timeStr = formatTime defaultTimeLocale "%Y-%m-%dT%H:%M:%S%EZ" time
+      let timeStr = formatTime defaultTimeLocale "%Y-%m-%dT%H:%M:%SZ" time
       requestPUT (baseURI <//> "upload-time") "text/plain" (packUTF8 timeStr)
 
     putPackageUploader uname = do

--- a/Distribution/Server/Features/Core.hs
+++ b/Distribution/Server/Features/Core.hs
@@ -729,7 +729,7 @@ coreFeature ServerEnv{serverBlobStore = store} UserFeature{..}
             Object $ HashMap.fromList
               [ (Text.pack "number", Number (fromIntegral rev))
               , (Text.pack "user", String (Text.pack (display uname)))
-              , (Text.pack "time", String (Text.pack (formatTime defaultTimeLocale "%Y-%m-%dT%H:%M:%S%EZ" utime)))
+              , (Text.pack "time", String (Text.pack (formatTime defaultTimeLocale "%Y-%m-%dT%H:%M:%SZ" utime)))
               ]
           revisionsJson = Array $ Vec.imap revisionToObj revisions
       return (toResponse revisionsJson)

--- a/Distribution/Server/Features/Mirror.hs
+++ b/Distribution/Server/Features/Mirror.hs
@@ -216,7 +216,7 @@ mirrorFeature ServerEnv{serverBlobStore = store}
     uploadTimeGet :: DynamicPath -> ServerPartE Response
     uploadTimeGet dpath = do
       pkg <- packageInPath dpath >>= lookupPackageId
-      return $ toResponse $ formatTime defaultTimeLocale "%Y-%m-%dT%H:%M:%S%EZ"
+      return $ toResponse $ formatTime defaultTimeLocale "%Y-%m-%dT%H:%M:%SZ"
                                        (pkgLatestUploadTime pkg)
 
     -- curl -H 'Content-Type: text/plain' -u admin:admin -X PUT -d "Tue Oct 18 20:54:28 UTC 2010" http://localhost:8080/package/edit-distance-0.2.1/upload-time

--- a/Distribution/Server/Features/PackageFeed.hs
+++ b/Distribution/Server/Features/PackageFeed.hs
@@ -139,7 +139,7 @@ feedItems users hostURI (pkgInfo, chlog) =
           ] +++ XHtml.hr +++ chlog
         pkgName = display (pkgInfoId pkgInfo)
         (time, uploaderId) = pkgOriginalUploadInfo pkgInfo
-        timestr = formatTime defaultTimeLocale "%Y-%m-%dT%H:%M:%S%EZ" time
+        timestr = formatTime defaultTimeLocale "%Y-%m-%dT%H:%M:%SZ" time
         uploader = display $ Users.userIdToName users uploaderId
         pd = packageDescription (pkgDesc pkgInfo)
         d dt dd = XHtml.dterm (XHtml.toHtml dt) +++ XHtml.ddef (XHtml.toHtml dd)

--- a/Distribution/Server/Pages/AdminLog.hs
+++ b/Distribution/Server/Pages/AdminLog.hs
@@ -36,6 +36,6 @@ adminLogPage users entries = hackagePage "adminstrator actions log" docBody
               group,
               reason]
         nbsp = XHtml.primHtmlChar "nbsp"
-        showTime = formatTime defaultTimeLocale "%Y-%m-%dT%H:%M:%S%EZ"
+        showTime = formatTime defaultTimeLocale "%Y-%m-%dT%H:%M:%SZ"
         header = XHtml.tr << map (XHtml.th <<) ["Time ","User ","Action ","Target ","Group ","Reason "]
         fmtCell x = XHtml.td ! [XHtml.align "left"] << [XHtml.toHtml x, nbsp, nbsp]

--- a/Distribution/Server/Pages/Package.hs
+++ b/Distribution/Server/Pages/Package.hs
@@ -510,7 +510,7 @@ renderFields render = [
   where
     desc = rendOther render
     renderUploadInfo utime uinfo =
-        formatTime defaultTimeLocale "%Y-%m-%dT%H:%M:%S%EZ" utime +++ " by " +++ user
+        formatTime defaultTimeLocale "%Y-%m-%dT%H:%M:%SZ" utime +++ " by " +++ user
       where
         uname   = maybe "Unknown" (display . userName) uinfo
         uactive = maybe False (isActiveAccount . userStatus) uinfo

--- a/Distribution/Server/Pages/Recent.hs
+++ b/Distribution/Server/Pages/Recent.hs
@@ -99,7 +99,7 @@ makeRevisionRow users pkginfo =
     revlabel = [XHtml.toHtml (display pkgid), XHtml.toHtml revno]
 
 showTime :: UTCTime -> String
-showTime = formatTime defaultTimeLocale "%Y-%m-%dT%H:%M:%S%EZ"
+showTime = formatTime defaultTimeLocale "%Y-%m-%dT%H:%M:%SZ"
 
 showTimeHtml :: UTCTime -> Html
 showTimeHtml t = XHtml.thespan ! [XHtml.title $ formatTime defaultTimeLocale "%c" t ]

--- a/exes/ImportClient.hs
+++ b/exes/ImportClient.hs
@@ -940,7 +940,7 @@ formatErrorResponse (ErrorResponse uri (a,b,c) reason mBody) =
 --
 
 showUTCTime :: UTCTime -> String
-showUTCTime = formatTime defaultTimeLocale "%Y-%m-%dT%H:%M:%S%EZ"
+showUTCTime = formatTime defaultTimeLocale "%Y-%m-%dT%H:%M:%SZ"
 
 -- option utility
 reqArgFlag :: ArgPlaceHolder -> SFlags -> LFlags -> Description


### PR DESCRIPTION
Closes #933

Specifically, `%EZ` will print the timezone name ie. `UTC`, when in iso8601 the UTC timezone is represented as `Z` indicating zero offset.

The other option is to use https://hackage.haskell.org/package/time-1.11.1.2/docs/Data-Time-Format-ISO8601.html#v:iso8601Show , however I wasn't sure if there might be other implications around using it ie. `defaulteTimeLocale` is no longer explicitly being specified.

cc @gbaz @phadej 