### PR TITLE
break before dots in module names

### DIFF
--- a/Distribution/Server/Pages/Package.hs
+++ b/Distribution/Server/Pages/Package.hs
@@ -625,7 +625,10 @@ renderModuleForest docUrl forest =
           thespan ! [theclass "module"] << modName path
       moduleEntry True path =
           thespan ! [theclass "module"] << linkedName path
-      modName path = toHtml (intercalate "." path)
+      modName path = mconcat (intersperse (itag "wbr") (map toHtml (mapTail ('.':) path)))
+        where
+          mapTail f (x:xs) = x : map f xs
+          mapTail _ xs = xs
       linkedName path = anchor ! [href modUrl] << modName path
           where
             modUrl = docUrl ++ "/" ++ intercalate "-" path ++ ".html"


### PR DESCRIPTION
See #928.

Now the module list of `prettyprinter` looks like this:

![image](https://user-images.githubusercontent.com/2665074/122957587-9c2ea580-d371-11eb-89dd-98cc93792a91.png)
