### PR TITLE
Handle HTTP 451 error code in mirror client

### DIFF
--- a/Distribution/Client/Mirror/Session.hs
+++ b/Distribution/Client/Mirror/Session.hs
@@ -376,11 +376,13 @@ notifyResponse e = do
        case resp of
          ErrorResponse _ (4,0,4)    _ _ -> True
          ErrorResponse _ (4,1,0)    _ _ -> True
+         ErrorResponse _ (4,5,1)    _ _ -> True
          ErrorResponse _ _otherCode _ _ -> False
     getFailedPermanent (GetRemoteError (Sec.SomeRemoteError theError)) =
        case cast theError of
          Just (Sec.HTTP.UnexpectedResponse _ (4,0,4)) -> True
          Just (Sec.HTTP.UnexpectedResponse _ (4,1,0)) -> True
+         Just (Sec.HTTP.UnexpectedResponse _ (4,5,1)) -> True
          _otherwise                                   -> False
     getFailedPermanent (GetVerificationError _) = False
     getFailedPermanent (GetInvalidPackage _)    = True


### PR DESCRIPTION
There are some packages for which Hackage returns a 451 "Unavailable for Legal Reasons". At the moment the mirror client chokes on these and exits; we should treat this the same as a 404.