### PR TITLE
New mirror client flag: skip existing packages

### DIFF
--- a/Distribution/Client/Mirror/CmdLine.hs
+++ b/Distribution/Client/Mirror/CmdLine.hs
@@ -24,7 +24,8 @@ data MirrorOpts = MirrorOpts {
                     selectedPkgs    :: [PackageId],
                     continuous      :: Maybe Int, -- if so, interval in minutes
                     mo_keepGoing    :: Bool,
-                    mirrorUploaders :: Bool
+                    mirrorUploaders :: Bool,
+                    skipExists      :: Bool
                   }
 
 data MirrorFlags = MirrorFlags {
@@ -33,6 +34,7 @@ data MirrorFlags = MirrorFlags {
     flagInterval        :: Maybe String,
     flagKeepGoing       :: Bool,
     flagMirrorUploaders :: Bool,
+    flagSkipExists      :: Bool,
     flagVerbosity       :: Verbosity,
     flagHelp            :: Bool
 }
@@ -44,6 +46,7 @@ defaultMirrorFlags = MirrorFlags
   , flagInterval        = Nothing
   , flagKeepGoing       = True
   , flagMirrorUploaders = False
+  , flagSkipExists      = False
   , flagVerbosity       = normal
   , flagHelp            = False
   }
@@ -77,6 +80,10 @@ mirrorFlagDescrs =
   , Option [] ["mirror-uploaders"]
       (NoArg (\opts -> opts { flagMirrorUploaders = True }))
       "Mirror the original uploaders which requires that they are already registered on the target hackage."
+
+  , Option [] ["skip-exists"]
+      (NoArg (\opts -> opts { flagSkipExists = True }))
+      "Skip already mirrored packages (only works for local repos)"
   ]
 
 validateOpts :: [String] -> IO (Verbosity, MirrorOpts)
@@ -104,7 +111,8 @@ validateOpts args = do
                                     then Just interval
                                     else Nothing,
                    mo_keepGoing = flagKeepGoing flags,
-                   mirrorUploaders = flagMirrorUploaders flags
+                   mirrorUploaders = flagMirrorUploaders flags,
+                   skipExists   = flagSkipExists flags
                  })
           where
             mpkgs     = validatePackageIds pkgstrs

--- a/Distribution/Client/Mirror/Repo.hs
+++ b/Distribution/Client/Mirror/Repo.hs
@@ -13,6 +13,7 @@ module Distribution.Client.Mirror.Repo (
   , readCachedTargetIndex
   , authenticate
   , uploadPackage
+  , packageExists
     -- ** Finalizing a mirror
   , finalizeMirror
   , cacheTargetIndex
@@ -175,6 +176,19 @@ uploadPackage targetRepo doMirrorUploaders pkgInfo locCab locTgz =
          Local.uploadPackage targetRepoPath
                              pkgInfo
                              locTgz
+
+-- | Check if a package already exists
+--
+-- Currently always returns 'False' for remote repos.
+packageExists :: TargetRepo
+              -> PkgIndexInfo
+              -> MirrorSession Bool
+packageExists targetRepo pkgInfo =
+     case targetRepo of
+       TargetHackage2{} ->
+         return False
+       TargetLocal{..} ->
+         Local.packageExists targetRepoPath pkgInfo
 
 {-------------------------------------------------------------------------------
   Finalizing

--- a/Distribution/Client/Mirror/Repo/Local.hs
+++ b/Distribution/Client/Mirror/Repo/Local.hs
@@ -2,6 +2,7 @@ module Distribution.Client.Mirror.Repo.Local (
     withTargetRepo
   , downloadIndex
   , uploadPackage
+  , packageExists
   ) where
 
 -- stdlib
@@ -63,3 +64,16 @@ uploadPackage targetRepoPath' pkginfo locTgz = liftIO $ do
     pkgFile = pkgDir   </> display pkgid <.> "tar.gz"
 
     PkgIndexInfo pkgid _ _ _ = pkginfo
+
+-- | Check if a package already exists
+packageExists :: FilePath
+              -> PkgIndexInfo
+              -> MirrorSession Bool
+packageExists targetRepoPath' pkginfo = liftIO $
+    doesFileExist pkgFile
+  where
+    pkgDir  = targetRepoPath' </> "package"
+    pkgFile = pkgDir   </> display pkgid <.> "tar.gz"
+
+    PkgIndexInfo pkgid _ _ _ = pkginfo
+

--- a/Distribution/Client/Mirror/Session.hs
+++ b/Distribution/Client/Mirror/Session.hs
@@ -324,6 +324,7 @@ data MirrorEvent =
   | GetPackageFailed GetError PackageId
   | PutPackageOk
   | PutPackageFailed ErrorResponse PackageId
+  | PackageSkipped
 
 notifyResponse :: MirrorEvent -> MirrorSession ()
 notifyResponse e = do
@@ -333,18 +334,20 @@ notifyResponse e = do
     put st'
   where
     handleEvent _ False st = case e of
-      GetIndexOk   -> return st
-      GetPackageOk -> return st
-      PutPackageOk -> return st
+      GetIndexOk     -> return st
+      GetPackageOk   -> return st
+      PutPackageOk   -> return st
+      PackageSkipped -> return st
       GetPackageFailed rsp pkgid ->
         mirrorError (GetEntityError (EntityPackage pkgid) rsp)
       PutPackageFailed rsp pkgid ->
         mirrorError (PutPackageError pkgid rsp)
 
     handleEvent verbosity True st = case e of
-      GetIndexOk   -> return st
-      GetPackageOk -> return st
-      PutPackageOk -> return st
+      GetIndexOk     -> return st
+      GetPackageOk   -> return st
+      PutPackageOk   -> return st
+      PackageSkipped -> return st
       GetPackageFailed rsp pkgid ->
         if getFailedPermanent rsp
           then do


### PR DESCRIPTION
When mirroring to a local repo, using the `--skip-exists` command line flag will now check if the local file for a package already exists, and if so, skip downloading this package. It does not work for remote repos nor does it check checksums or hashes or anything like that. Nonetheless, I am finding it useful, as I was having trouble creating a full mirror of hackage using the mirror client; it would stop for some reason or other somewhere halfway, not have a local index yet, and start over entirely.

Probably the mirror client needs some love, but until somebody has time for that, this is probably an improvement. Feel free to ignore this PR of course if you feel it's not the right thing to do; just sharing in case it's useful.