### PR TITLE
Hide documentation banner when package only contains an executable

### DIFF
--- a/Distribution/Server/Features/Html.hs
+++ b/Distribution/Server/Features/Html.hs
@@ -78,6 +78,8 @@ import qualified Network.URI as URI
 import Text.XHtml.Strict
 import qualified Text.XHtml.Strict as XHtml
 import Text.XHtml.Table (simpleTable)
+import Distribution.PackageDescription (hasLibs)
+import Distribution.PackageDescription.Configuration (flattenPackageDescription)
 
 
 -- TODO: move more of the below to Distribution.Server.Pages.*, it's getting
@@ -589,6 +591,7 @@ mkHtmlCore ServerEnv{serverBaseURI, serverBlobStore}
             pkgname = packageName realpkg
             docURL  = packageDocsContentUri docs realpkg
             execs   = rendExecNames render
+            pkgdesc = flattenPackageDescription $ pkgDesc pkg
 
         prefInfo      <- queryGetPreferredInfo pkgname
         distributions <- queryPackageStatus pkgname
@@ -643,6 +646,7 @@ mkHtmlCore ServerEnv{serverBaseURI, serverBlobStore}
           , "recentDownloads"   $= recentDown
           , "votes"             $= pkgVotes
           , "hasVotes"          $= pkgVotes > 0
+          , "hasExecOnly"       $= (not . hasLibs) pkgdesc && (not . null) execs
           , "userRating"        $= userRating
           , "score"             $= pkgScore
           , "buildStatus"       $= buildStatus

--- a/datafiles/templates/Html/package-page.html.st
+++ b/datafiles/templates/Html/package-page.html.st
@@ -192,7 +192,7 @@
         $if(install.0)$<img src="https://img.shields.io/static/v1?label=Build&message=$install.2$&color=$install.1$" />$endif$
         $if(test.0)$<img src="https://img.shields.io/static/v1?label=Tests&message=$test.2$&color=$test.1$" />$endif$
         $if(covg.0)$<img src="https://img.shields.io/static/v1?label=Coverage&message=$covg.2$%&color=$covg.1$" />$endif$
-        <img src="https://img.shields.io/static/v1?label=Documentation&message=$if(hasDocs)$Available$else$Unavailable$endif$&color=$if(hasDocs)$success$else$critical$endif$" />
+        $if(!hasExecOnly)$<img src="https://img.shields.io/static/v1?label=Documentation&message=$if(hasDocs)$Available$else$Unavailable$endif$&color=$if(hasDocs)$success$else$critical$endif$" />$endif$
     </div>
 
     <div id="modules">


### PR DESCRIPTION
Closes #945 