### PR TITLE
Add Nix shell with required dependencies

### DIFF
--- a/README.md
+++ b/README.md
@@ -5,16 +5,32 @@
 
 This is the `hackage-server` code. This is what powers <http://hackage.haskell.org>, and many other private hackage instances. The `master` branch is suitable for general usage. Specific policy and documentation for the central hackage instance exists in the `central-server` branch.
 
-## Installing ICU
+## Installing dependencies
+
+`hackage-server` depends on `icu` and `zlib`.
 
 ICU stands for "International Components for Unicode". The `icu4c` is a set
 of libraries that provide Unicode and Globalization support.
 The [text-icu](https://hackage.haskell.org/package/text-icu) Haskell package
 uses the [icu4c](http://icu-project.org/apiref/icu4c/) library to build.
 
+### Nix shell
+
+If you have the Nix package manager installed, the easiest way to obtain
+`hackage-server`'s dependencies is using the Nix shell:
+
+    nix-shell
+
+### Manually
+
+You can also install dependencies manually via your operating system's package
+manager.
+
+#### ICU
+
 You'll need to do the following to get hackage-server's dependency `text-icu` to build:
 
-### Mac OS X
+##### Mac OS X
 
     brew install icu4c
     brew link icu4c --force
@@ -27,13 +43,38 @@ package text-icu
   extra-lib-dirs: /usr/local/opt/icu4c/lib
 ```
 
-### Ubuntu/Debian
+##### Ubuntu/Debian
 
     sudo apt-get update
     sudo apt-get install unzip libicu-dev
 
-### Fedora/CentOS
+##### Fedora/CentOS
+
     sudo dnf install unzip libicu-devel
+
+##### Nix/NixOS
+
+    nix-shell --packages icu
+
+#### zlib
+
+#### Mac OS X
+
+    brew install zlib
+
+#### Ubuntu/Debian
+
+    sudo apt-get update
+    sudo apt-get install zlib
+
+#### Fedora/CentOS
+
+    sudo dnf install zlib
+
+##### Nix/NixOS
+
+    nix-shell --packages zlib
+
 
 ## Setting up security infrastructure
 

--- a/shell.nix
+++ b/shell.nix
@@ -1,0 +1,21 @@
+let
+  nixpkgs = builtins.fetchTarball {
+    # master on 2021-08-02
+    url = "https://github.com/NixOS/nixpkgs/archive/70e001f35cc363eb789ea0a04eff11b86c440ba3.tar.gz";
+    sha256 = "1mrhbcfa8kkx1qnax8xh41grinqiycl56wlws5vvrli8w0pzgl1r";
+  };
+
+  pkgs = import nixpkgs { config = { }; };
+
+in
+pkgs.mkShell {
+  buildInputs = [
+    # Haskell development
+    pkgs.cabal-install
+    pkgs.ghc
+
+    # Dependencies
+    pkgs.icu
+    pkgs.zlib
+  ];
+}


### PR DESCRIPTION
Allows you to get up and running more easily if you have the Nix package
manager installed:

```bash
$ nix-shell --pure
[nix-shell]$ cabal update
[nix-shell]$ cabal build
```