### PR TITLE
Enhancement: direct link to list of maintainers

### DIFF
--- a/Distribution/Server/Pages/PackageFromTemplate.hs
+++ b/Distribution/Server/Pages/PackageFromTemplate.hs
@@ -167,6 +167,8 @@ packagePageTemplate render
       , templateVal "license"       (Old.rendLicense render)
       , templateVal "author"        (toHtml $ author desc)
       , templateVal "maintainer"    (Old.maintainField $ rendMaintainer render)
+      , templateVal "maintainerURL" (toHtml $
+        anchor ! [href $ "/package" </> pkgName </> "maintainers" ] << "package maintainers")
       , templateVal "buildDepends"  (snd (Old.renderDependencies render))
       , templateVal "optional"      optionalPackageInfoTemplate
       , templateVal "candidateBanner" candidateBanner

--- a/README.md
+++ b/README.md
@@ -150,7 +150,7 @@ By default the server runs on port `8080` with the following settings:
 
 To specify something different, see `hackage-server init --help` for details.
 
-The http://127.0.0.1:8080/packages/uploaders/edit is usel to add users
+The http://127.0.0.1:8080/packages/uploaders/edit is used to add users
 (e.g. `admin`) to *Uploaders* group.
 
 The server can be stopped by using `Control-C`.

--- a/datafiles/templates/Html/package-page.html.st
+++ b/datafiles/templates/Html/package-page.html.st
@@ -221,7 +221,7 @@
 
     <div id="maintainer-corner">
       <h4>Maintainer's Corner</h4>
-      <p>For package maintainers and hackage trustees</p>
+      <p>For $package.maintainerURL$ and hackage trustees</p>
       <ul>
         <li>
           <a href="$baseurl$/package/$package.name$/maintain">


### PR DESCRIPTION
This is my first issue to hackage-server. ;)

This pull request is responding to the issue #918. Attached is the changes on the user interface.
![Screenshot 2021-08-14 at 4 57 11 PM](https://user-images.githubusercontent.com/1331557/129440851-2b41bc99-e3b3-4bd6-bb41-6e800935eb19.png)
Mind the **Maintainer's Corner** section, the `package maintainer` has became a clickable url according to the issue #918 

And I also fixed the typo in README.