### PR TITLE
Ask new uploaders to name the package they want to upload

### DIFF
--- a/datafiles/templates/UserSignupReset/SignupConfirmation.email.st
+++ b/datafiles/templates/UserSignupReset/SignupConfirmation.email.st
@@ -6,10 +6,14 @@ this link:
 
   $confirmlink$
 
-After your account is created, you cannot upload until you
-contact the hackage trustees at hackage-trustees@haskell.org and
-send an email (including your login username) requesting to be added to the uploader group.
-(This measure is unfortunately necessary to prevent spam accounts).
+After your account is created, you will need to email the Hackage
+Trustees at hackage-trustees@haskell.org requesting to be added to the
+uploader group. In this email, please include your Hackage username
+and a package that you'd like to upload. (This measure is
+unfortunately necessary to prevent spam accounts.)
+
+For storage and bandwidth reasons, we ask uploaders to only upload
+packages they believe will be useful and that they intend to maintain.
 
 If you were not expecting this email, our apologies,
 please ignore it.
@@ -21,4 +25,3 @@ ______________________________________________
 Please do not reply to this email. This email
 address is used only for sending email so you
 will not receive a response.
-

--- a/datafiles/templates/UserSignupReset/SignupConfirmation.email.st
+++ b/datafiles/templates/UserSignupReset/SignupConfirmation.email.st
@@ -13,7 +13,7 @@ and a package that you'd like to upload. (This measure is
 unfortunately necessary to prevent spam accounts.)
 
 For storage and bandwidth reasons, we ask uploaders to only upload
-packages they believe will be useful and that they intend to maintain.
+packages they believe will be useful to others and that they intend to maintain.
 
 If you were not expecting this email, our apologies,
 please ignore it.


### PR DESCRIPTION
(And to only upload packages they believe will be useful and intend
to maintain.)

Hopefully this will remove one email round-trip from most Hackage uploader requests, and discourage submission of toy packages.

I will email this PR to the Trustees list, so they get a chance to weigh in before merge.