### PR TITLE
Commonmark: gfmExtensions needs to precede the defaultSyntaxSpec (#1000,#1001)

### DIFF
--- a/exes/Main.hs
+++ b/exes/Main.hs
@@ -50,8 +50,6 @@ import Data.Version
          ( showVersion )
 import Control.Monad
          ( void, unless, when, filterM )
-import Control.Applicative
-         ( (<$>) )
 import Control.Arrow
          ( second )
 import qualified Data.ByteString.Lazy as BS

--- a/hackage-server.cabal
+++ b/hackage-server.cabal
@@ -363,8 +363,10 @@ library lib-server
     , blaze-builder         ^>= 0.4
     , blaze-html            ^>= 0.9
     , cereal                ^>= 0.5
-    , commonmark	    ^>= 0.1
-    , commonmark-extensions ^>= 0.2
+    , commonmark            ^>= 0.2
+        -- commonmark-0.2 needed by commonmark-extensions-0.2.2
+    , commonmark-extensions ^>= 0.2.2
+        -- Note: 0.2.2 added footnoteSpec to gfmExtensions
     , cryptohash-md5        ^>= 0.11.100
     , cryptohash-sha256     ^>= 0.11.100
     , csv                   ^>= 0.1


### PR DESCRIPTION
Commonmark: `gfmExtensions` needs to precede the `defaultSyntaxSpec`.

- Move `gfmExtensions` before `defaultSyntaxSpec`.

- Require commonmark-extensions-0.2.2 so `footnoteSpec` is subsumed under `gfmExtensions`.
  (Note: this version bump does not exclude any GHC versions.)

- Generalize `renderMarkdown` and `renderMarkdownRel` to `renderMarkdown'`.  We use a constraint synonym to gather all the constraints on type `a`, using `LANGUAGE ConstraintKinds`.

- Haddockumentation for all functions.

- Explicit export list.

Hopefully this will fix #1000 and fix #1001, but `renderMarkdown` has no tests, so I cannot see the effect of my change locally.
