### PR TITLE
tests/Util: remove `die`

### DIFF
--- a/tests/CreateUserTest.hs
+++ b/tests/CreateUserTest.hs
@@ -20,6 +20,7 @@ import Control.Monad
 import Data.List (isInfixOf)
 import Data.String ()
 import System.Directory
+import System.Exit (die)
 import System.FilePath
 import System.IO
 import System.Random
@@ -94,8 +95,7 @@ runUserTests = do
            die ("Bad user account kind: " ++ show (accountKind uainf))
        unless ("self-registration" `isInfixOf` accountNotes uainf) $
            die ("Bad user notes: " ++ accountNotes uainf)
-       
+
   where
     mkTestEmail :: Int -> String
     mkTestEmail n = "HackageTestUser" ++ show n
-

--- a/tests/Distribution/Server/Packages/UnpackTest.hs
+++ b/tests/Distribution/Server/Packages/UnpackTest.hs
@@ -24,5 +24,5 @@ testPermissions :: FilePath ->  -- ^ .tar.gz file to test
 testPermissions tarPath mangler = do
     entries <- return . Tar.read . GZip.decompress =<< BL.readFile tarPath
     let mappedEntries = Tar.foldEntries Tar.Next Tar.Done (Tar.Fail . FormatError) entries
-    when ((checkEntries mangler mappedEntries) /= checkUselessPermissions mappedEntries) $
+    when (checkEntries mangler mappedEntries /= checkUselessPermissions mappedEntries) $
         assertFailure ("Permissions check did not match expected for: " ++ tarPath)

--- a/tests/HackageClientUtils.hs
+++ b/tests/HackageClientUtils.hs
@@ -15,7 +15,7 @@ import Data.Version (showVersion)
 import Network.HTTP hiding (user)
 import Network.URI
 import System.Directory
-import System.Exit (ExitCode(..))
+import System.Exit (ExitCode(..), die)
 import System.FilePath
 import System.IO
 import System.IO.Error
@@ -330,4 +330,3 @@ validate auth url = do
             forM_ (zip [1..] errs) $ \(i, err) ->
               putStrLn $ show (i :: Int) ++ ".\t" ++ err
   return body
-

--- a/tests/HighLevelTest.hs
+++ b/tests/HighLevelTest.hs
@@ -19,7 +19,7 @@ import qualified Data.ByteString.Lazy.Char8 as LBS
 import Data.List (isInfixOf)
 import Data.String ()
 import System.Directory
-import System.Exit (ExitCode(..))
+import System.Exit (ExitCode(..), die)
 import System.FilePath
 import System.IO
 
@@ -222,4 +222,3 @@ runPackageTests = do
 
 testpackage :: (FilePath, String, FilePath, String, FilePath, String)
 testpackage = mkPackage "testpackage"
-

--- a/tests/HttpUtils.hs
+++ b/tests/HttpUtils.hs
@@ -28,6 +28,7 @@ import Data.Maybe
 import Network.HTTP hiding (user)
 import Network.HTTP.Auth
 import Data.Aeson (Result(..), Value(..), FromJSON(..), (.:), fromJSON, json')
+import System.Exit (die)
 
 import qualified Network.Http.Client as HC
 import qualified System.IO.Streams as Streams

--- a/tests/MailUtils.hs
+++ b/tests/MailUtils.hs
@@ -22,6 +22,8 @@ import Network.HTTP hiding (user)
 
 import qualified Text.XML.Light as XML
 
+import System.Exit (die)
+
 import HttpUtils
 import Util
 

--- a/tests/Run.hs
+++ b/tests/Run.hs
@@ -63,5 +63,4 @@ killProcessGroup pid = do
               checkReallyDead (n - 1)
 
 ignoreIOExceptions :: IO () -> IO ()
-ignoreIOExceptions io = io `catchIOError` ((\_ -> return ()))
-
+ignoreIOExceptions io = io `catchIOError` (\_ -> return ())

--- a/tests/Util.hs
+++ b/tests/Util.hs
@@ -3,15 +3,12 @@
 module Util (
     explode
   , trim
-  , die
   , info
   , decodeJSON
   ) where
 
 import Data.Char
 import Data.Aeson
-import System.IO
-import System.Exit (exitFailure)
 
 import qualified Data.ByteString.Lazy.Char8 as LBS
 
@@ -28,10 +25,6 @@ trim = reverse . dropWhile isSpace
 
 info :: String -> IO ()
 info str = putStrLn ("= " ++ str)
-
-die :: String -> IO a
-die err = do hPutStrLn stderr err
-             exitFailure
 
 decodeJSON :: FromJSON a => String -> IO a
 decodeJSON str =


### PR DESCRIPTION
`die` is verbatim in `System.Exit` since sufficiently long (all GHC 8.x).