### PR TITLE
Doc tests using `doctest-parallel`

### DIFF
--- a/hackage-server.cabal
+++ b/hackage-server.cabal
@@ -564,3 +564,12 @@ test-suite HashTests
     , tasty       ^>= 1.4
     , tasty-hunit ^>= 0.10
 
+test-suite DocTests
+  import:         test-defaults
+
+  type:           exitcode-stdio-1.0
+  main-is:        DocTestMain.hs
+
+  build-depends:
+    , lib-server
+    , doctest-parallel ^>= 0.2.1

--- a/hackage-server.cabal
+++ b/hackage-server.cabal
@@ -572,4 +572,5 @@ test-suite DocTests
 
   build-depends:
     , lib-server
-    , doctest-parallel ^>= 0.2.1
+    , doctest-parallel ^>= 0.2.2
+        -- doctest-parallel-0.2.2 is the first to filter out autogen-modules

--- a/tests/DocTestMain.hs
+++ b/tests/DocTestMain.hs
@@ -1,0 +1,27 @@
+-- | `doctest-parallel` runner for `hackage-server` library.
+module Main where
+
+import Data.List
+         ( isPrefixOf )
+import System.Environment
+         ( getArgs )
+
+import Distribution.ModuleName
+         ( components )
+
+import Test.DocTest
+         ( mainFromLibrary )
+import Test.DocTest.Helpers
+         ( Library(..), extractSpecificCabalLibrary, findCabalPackage )
+
+-- | Doctest @hackage-server:lib-server@.
+main :: IO ()
+main = do
+  args <- getArgs
+  pkg  <- findCabalPackage "hackage-server"
+  -- Need to give the library name, otherwise the parser does not find it.
+  lib  <- extractSpecificCabalLibrary (Just "lib-server") pkg
+  -- Need to filter out the @Paths_*@ modules, as they are not found by doctest-parallel.
+  let f    = not . ("Paths_" `isPrefixOf`) . head . components
+  let lib' = lib{ libModules = filter f $ libModules lib }
+  mainFromLibrary lib' args

--- a/tests/DocTestMain.hs
+++ b/tests/DocTestMain.hs
@@ -1,18 +1,12 @@
 -- | `doctest-parallel` runner for `hackage-server` library.
 module Main where
 
-import Data.List
-         ( isPrefixOf )
 import System.Environment
          ( getArgs )
-
-import Distribution.ModuleName
-         ( components )
-
 import Test.DocTest
          ( mainFromLibrary )
 import Test.DocTest.Helpers
-         ( Library(..), extractSpecificCabalLibrary, findCabalPackage )
+         ( extractSpecificCabalLibrary, findCabalPackage )
 
 -- | Doctest @hackage-server:lib-server@.
 main :: IO ()
@@ -21,7 +15,4 @@ main = do
   pkg  <- findCabalPackage "hackage-server"
   -- Need to give the library name, otherwise the parser does not find it.
   lib  <- extractSpecificCabalLibrary (Just "lib-server") pkg
-  -- Need to filter out the @Paths_*@ modules, as they are not found by doctest-parallel.
-  let f    = not . ("Paths_" `isPrefixOf`) . head . components
-  let lib' = lib{ libModules = filter f $ libModules lib }
-  mainFromLibrary lib' args
+  mainFromLibrary lib args


### PR DESCRIPTION
This is an alternative to #1013, ~~but it does not work (yet?).~~

~~Potential~~ advantages:
- `doctest-parallel` is faster
- ~~no need to move library to `src/`~~

UPDATE: moving library sources into `src/` made this variant work.  It is faster than plain `doctest` (#1013), so I think I will settle for this alternative.