### PR TITLE
Use flexbox instead of float

### DIFF
--- a/datafiles/static/hackage.css
+++ b/datafiles/static/hackage.css
@@ -312,6 +312,7 @@ table.properties td, table.properties th {
 
 @media only screen and (min-width: 1920px) {
   #content {
+    /* keep this in sync with #left-pane children */
     width: 60vw;
   }
 }
@@ -375,18 +376,28 @@ table.properties td, table.properties th {
       margin-bottom: 2em;
   }
 
-  #left-pane {
-      margin-right: 2em;
-      /* The margin is subtracted. Without this line, a narrow left-pane would
-       * leave a narrow properties pane with space on the right. So we make the
-       * left-pane take the space that the properties pane is not allotted.
-       * That leaves no space on the right. */
-      width: calc(60% - 2em);
+  #left-pane > * {
+      /*   (100% - (width of properties)) * (width of #content) - gap
+       * = (100% - 40%                  ) * 60vw                - 2em
+       * = 60%                            * 60vw                - 2em
+       * = 36vw - 2em
+       */
+      width: calc(36vw - 2em);
+  }
+
+  #left-pane > #modules {
+      /* This overrides the width in the previous block. We want a long module
+       * name to make the left-pane wide, so that it will push down
+       * #properties.
+       */
+      width: fit-content;
   }
 
   #flex-container {
       display: flex;
       flex-wrap: wrap;
+      justify-content: space-between;
+      gap: 2em; /* keep this in sync with calculation above */
   }
 }
 
@@ -843,10 +854,6 @@ ul.links li form button {
 
 #index td + td {
   padding-left: 1em;
-}
-
-#module-list {
-  overflow-x: auto;
 }
 
 #module-list ul {

--- a/datafiles/static/hackage.css
+++ b/datafiles/static/hackage.css
@@ -381,7 +381,7 @@ table.properties td, table.properties th {
        * leave a narrow properties pane with space on the right. So we make the
        * left-pane take the space that the properties pane is not allotted.
        * That leaves no space on the right. */
-      max-width: calc(60% - 2em);
+      width: calc(60% - 2em);
   }
 
   #flex-container {
@@ -845,19 +845,13 @@ ul.links li form button {
   padding-left: 1em;
 }
 
+#module-list {
+  overflow-x: auto;
+}
+
 #module-list ul {
   list-style: none;
   margin: 0 0 0 20px;
-
-     /* Warning: Needed for oldIE support, but words are broken up letter-by-letter */
-    -ms-word-break: break-all;
-    word-break: break-all;
-    /* Non standard for webkit */
-    word-break: break-word;
-    -webkit-hyphens: auto;
-    -moz-hyphens: auto;
-    -ms-hyphens: auto;
-    hyphens: auto;
 }
 
 /* Disable identation for the top level modules */

--- a/datafiles/static/hackage.css
+++ b/datafiles/static/hackage.css
@@ -381,7 +381,7 @@ table.properties td, table.properties th {
        * leave a narrow properties pane with space on the right. So we make the
        * left-pane take the space that the properties pane is not allotted.
        * That leaves no space on the right. */
-      min-width: calc(60% - 2em);
+      max-width: calc(60% - 2em);
   }
 
   #flex-container {

--- a/datafiles/static/hackage.css
+++ b/datafiles/static/hackage.css
@@ -315,11 +315,29 @@ table.properties td, table.properties th {
     /* keep this in sync with #left-pane children */
     width: 60vw;
   }
+
+  #left-pane > * {
+      /*   (100% - (width of properties)) * (width of #content) - gap
+       * = (100% - 40%                  ) * 60vw                - 2em
+       * = 60%                            * 60vw                - 2em
+       * = 36vw - 2em
+       */
+      width: calc(36vw - 2em);
+  }
 }
 
 @media only screen and (min-width: 1280px) and (max-width: 1919px) {
   #content {
     width: 65vw;
+  }
+
+  #left-pane > * {
+      /*   (100% - (width of properties)) * (width of #content) - gap
+       * = (100% - 40%                  ) * 65vw                - 2em
+       * = 60%                            * 65vw                - 2em
+       * = 39vw - 2em
+       */
+      width: calc(39vw - 2em);
   }
 }
 
@@ -344,6 +362,15 @@ table.properties td, table.properties th {
 
   #content {
     width: 75vw;
+  }
+
+  #left-pane > * {
+      /*   (100% - (width of properties)) * (width of #content) - gap
+       * = (100% - 40%                  ) * 75vw                - 2em
+       * = 60%                            * 75vw                - 2em
+       * = 45vw - 2em
+       */
+      width: calc(45vw - 2em);
   }
 }
 
@@ -376,23 +403,6 @@ table.properties td, table.properties th {
       margin-bottom: 2em;
   }
 
-  #left-pane > * {
-      /*   (100% - (width of properties)) * (width of #content) - gap
-       * = (100% - 40%                  ) * 60vw                - 2em
-       * = 60%                            * 60vw                - 2em
-       * = 36vw - 2em
-       */
-      width: calc(36vw - 2em);
-  }
-
-  #left-pane > #modules {
-      /* This overrides the width in the previous block. We want a long module
-       * name to make the left-pane wide, so that it will push down
-       * #properties.
-       */
-      width: fit-content;
-  }
-
   #flex-container {
       display: flex;
       flex-wrap: wrap;
@@ -404,6 +414,10 @@ table.properties td, table.properties th {
 @media only screen and (max-width: 949px) {
   #content {
     width: 88vw;
+  }
+
+  #left-pane > * {
+      width: fit-content;
   }
 
   #page-header {
@@ -460,6 +474,14 @@ table.properties td, table.properties th {
 /* @end */
 
 /* @group Page Structure */
+
+#left-pane > #modules {
+    /* This overrides the width in width-dependent blocks. We want a long
+     * module name to make the left-pane wide, so that it will push down
+     * #properties.
+     */
+    width: fit-content;
+}
 
 #content {
   margin: 0 auto;

--- a/datafiles/static/hackage.css
+++ b/datafiles/static/hackage.css
@@ -370,11 +370,23 @@ table.properties td, table.properties th {
   }
 
   div #properties {
-      float:right;
       background: #fefefe;
       width: 40%;
-      margin-left: 2em;
       margin-bottom: 2em;
+  }
+
+  #left-pane {
+      margin-right: 2em;
+      /* The margin is subtracted. Without this line, a narrow left-pane would
+       * leave a narrow properties pane with space on the right. So we make the
+       * left-pane take the space that the properties pane is not allotted.
+       * That leaves no space on the right. */
+      min-width: calc(60% - 2em);
+  }
+
+  #flex-container {
+      display: flex;
+      flex-wrap: wrap;
   }
 }
 

--- a/datafiles/templates/Html/package-page.html.st
+++ b/datafiles/templates/Html/package-page.html.st
@@ -41,201 +41,208 @@
     </div>
     $endif$
 
-    <div id="description">
-    $if(package.optional.hasDescription)$
-    $package.optional.description$
-    $endif$
-    $if(package.optional.hasReadme)$
-    <hr>
-    [<a href="#readme">Skip to Readme</a>]
-    $endif$
-    </div>
+    <div id="flex-container">
 
+      <div id="left-pane">
 
-    <div id="properties">
-    <table class="properties">
-      <tbody>
-
-        <tr>
-          <th>Versions <span style="font-weight:normal;font-size: small;">[<a href="/package/$package.name$.rss">RSS</a>]</span></th>
-          <td>$versions$</td>
-        </tr>
-
-        $if(package.optional.hasChangelog)$
-        <tr>
-          <th>Change&nbsp;log</th>
-          <td class="word-wrap">$package.optional.changelog$</td>
-        </tr>
-        $endif$
-
-        <tr>
-          <th>Dependencies</th>
-          <td>$package.buildDepends$</td>
-        </tr>
-
-        <tr>
-          <th>License</th>
-          <td class="word-wrap">$package.license$</td>
-        </tr>
-
-        $if(package.optional.hasCopyright)$
-        <tr>
-          <th>Copyright</th>
-          <td class="word-wrap">$package.optional.copyright$</td>
-        </tr>
-        $endif$
-
-        <tr>
-          <th>Author</th>
-          <td class="word-wrap">$package.author$</td>
-        </tr>
-        <tr>
-          <th>Maintainer</th>
-          <td class="word-wrap">$package.maintainer$</td>
-        </tr>
-
-        $if(hackage.hasUpdateTime)$
-        <tr>
-          <th>Revised</th>
-          <td>$hackage.updateTime$</td>
-        </tr>
-        $endif$
-
-        <!-- Obsolete/deprecated 'Stability' field hidden
-             c.f. http://stackoverflow.com/questions/3841218/conventions-for-stability-field-of-cabal-packages
-        <tr>
-          <th>Stability</th>
-          <td>$stability$</td>
-        </tr>
-        -->
-
-        $if(package.optional.hasCategories)$
-        <tr>
-          <th>Category</th>
-          <td>$package.optional.category$</td>
-        </tr>
-        $endif$
-
-        $if(package.optional.hasHomePage)$
-        <tr>
-          <th>Home page</th>
-          <td class="word-wrap">
-            <a href=$package.optional.homepage$>
-              $package.optional.homepage$
-            </a>
-          </td>
-        </tr>
-        $endif$
-
-        $if(package.optional.hasBugTracker)$
-        <tr>
-          <th>Bug&nbsp;tracker</th>
-          <td class="word-wrap">
-            <a href="$package.optional.bugTracker$">
-              $package.optional.bugTracker$
-            </a>
-          </td>
-        </tr>
-        $endif$
-
-        $if(package.optional.hasSourceRepository)$
-        <tr>
-          <th>Source&nbsp;repo</th>
-          <td class="word-wrap">$package.optional.sourceRepository$</td>
-        </tr>
-        $endif$
-
-        <tr>
-          <th>Uploaded</th>
-          <td>$hackage.uploadTime$</td>
-        </tr>
-
-
-        $if(hackage.hasDistributions)$
-        <tr>
-          <th>Distributions</th>
-          <td>$hackage.distributions$</td>
-        </tr>
-        $endif$
-
-        $if(hasexecs)$
-        <tr>
-          <th>Executables</th>
-          <td>$executables$</td>
-        </tr>
-        $endif$
-
-        <tr>
-          <th>Downloads</th>
-          <td>$totalDownloads$ total ($recentDownloads$ in the last 30 days)</td>
-        </tr>
-
-        <tr>
-          <th> Rating</th>
-          <td>$if(hasVotes)$$score$ (votes: $votes$)$else$(no votes yet)$endif$
-          <span style="font-size: small">[estimated by <a href="https://en.wikipedia.org/wiki/Bayesian_average">Bayesian average</a>]</span></td>
-        </tr>
-
-        <tr>
-          <th>Your&nbsp;Rating</th>
-          <td>
-            <ul class="star-rating">
-              <li class="star uncool" id="1">&lambda;</li>
-              <li class="star uncool" id="2">&lambda;</li>
-              <li class="star uncool" id="3">&lambda;</li>
-            </ul>
-          $if(userRating)$
-            <input type="hidden" id="userRating" value="$userRating$">
-            [<a href="" class="clear-rating">clear rating</a>]
+        <div id="description">
+          $if(package.optional.hasDescription)$
+          $package.optional.description$
           $endif$
-          </td>
-        </tr>
-        <tr>
-          <th>Status</th>
-          <td>$buildStatus$</td>
-        </tr>
-      </tbody>
-    </table>
-    </div> <!-- /properties -->
+          $if(package.optional.hasReadme)$
+          <hr>
+          [<a href="#readme">Skip to Readme</a>]
+          $endif$
+        </div>
 
-    <div id="badges" style="margin-top: 20px;">
-        $if(install.0)$<img src="https://img.shields.io/static/v1?label=Build&message=$install.2$&color=$install.1$" />$endif$
-        $if(test.0)$<img src="https://img.shields.io/static/v1?label=Tests&message=$test.2$&color=$test.1$" />$endif$
-        $if(covg.0)$<img src="https://img.shields.io/static/v1?label=Coverage&message=$covg.2$%&color=$covg.1$" />$endif$
-        $if(!hasExecOnly)$<img src="https://img.shields.io/static/v1?label=Documentation&message=$if(hasDocs)$Available$else$Unavailable$endif$&color=$if(hasDocs)$success$else$critical$endif$" />$endif$
-    </div>
+        <div id="badges" style="margin-top: 20px;">
+            $if(install.0)$<img src="https://img.shields.io/static/v1?label=Build&message=$install.2$&color=$install.1$" />$endif$
+            $if(test.0)$<img src="https://img.shields.io/static/v1?label=Tests&message=$test.2$&color=$test.1$" />$endif$
+            $if(covg.0)$<img src="https://img.shields.io/static/v1?label=Coverage&message=$covg.2$%&color=$covg.1$" />$endif$
+            $if(!hasExecOnly)$<img src="https://img.shields.io/static/v1?label=Documentation&message=$if(hasDocs)$Available$else$Unavailable$endif$&color=$if(hasDocs)$success$else$critical$endif$" />$endif$
+        </div>
 
-    <div id="modules">
-      $moduleList$
-    </div>
+        <div id="modules">
+          $moduleList$
+        </div>
 
-    $if(hackage.hasFlags)$
-    <div id="flags">
-      $hackage.flagsSection$
-    </div>
-    $endif$
+        $if(hackage.hasFlags)$
+        <div id="flags">
+          $hackage.flagsSection$
+        </div>
+        $endif$
 
-    <div id="downloads">
-      $downloadSection$
-    </div>
+        <div id="downloads">
+          $downloadSection$
+        </div>
 
-    <div id="maintainer-corner">
-      <h4>Maintainer's Corner</h4>
-      <p>For $package.maintainerURL$ and hackage trustees</p>
-      <ul>
-        <li>
-          <a href="$baseurl$/package/$package.name$/maintain">
-            edit package information
-          </a>
-        </li>
-      </ul>
-      <p>Candidates</p>
-      <ul>
-        <li>
-          $candidates$
-        </li>
-      </ul>
-    </div>
+        <div id="maintainer-corner">
+          <h4>Maintainer's Corner</h4>
+          <p>For $package.maintainerURL$ and hackage trustees</p>
+          <ul>
+            <li>
+              <a href="$baseurl$/package/$package.name$/maintain">
+                edit package information
+              </a>
+            </li>
+          </ul>
+          <p>Candidates</p>
+          <ul>
+            <li>
+              $candidates$
+            </li>
+          </ul>
+        </div>
+
+      </div><!-- /left-pane -->
+
+
+      <div id="properties">
+        <table class="properties">
+          <tbody>
+
+            <tr>
+              <th>Versions <span style="font-weight:normal;font-size: small;">[<a href="/package/$package.name$.rss">RSS</a>]</span></th>
+              <td>$versions$</td>
+            </tr>
+
+            $if(package.optional.hasChangelog)$
+            <tr>
+              <th>Change&nbsp;log</th>
+              <td class="word-wrap">$package.optional.changelog$</td>
+            </tr>
+            $endif$
+
+            <tr>
+              <th>Dependencies</th>
+              <td>$package.buildDepends$</td>
+            </tr>
+
+            <tr>
+              <th>License</th>
+              <td class="word-wrap">$package.license$</td>
+            </tr>
+
+            $if(package.optional.hasCopyright)$
+            <tr>
+              <th>Copyright</th>
+              <td class="word-wrap">$package.optional.copyright$</td>
+            </tr>
+            $endif$
+
+            <tr>
+              <th>Author</th>
+              <td class="word-wrap">$package.author$</td>
+            </tr>
+            <tr>
+              <th>Maintainer</th>
+              <td class="word-wrap">$package.maintainer$</td>
+            </tr>
+
+            $if(hackage.hasUpdateTime)$
+            <tr>
+              <th>Revised</th>
+              <td>$hackage.updateTime$</td>
+            </tr>
+            $endif$
+
+            <!-- Obsolete/deprecated 'Stability' field hidden
+                 c.f. http://stackoverflow.com/questions/3841218/conventions-for-stability-field-of-cabal-packages
+            <tr>
+              <th>Stability</th>
+              <td>$stability$</td>
+            </tr>
+            -->
+
+            $if(package.optional.hasCategories)$
+            <tr>
+              <th>Category</th>
+              <td>$package.optional.category$</td>
+            </tr>
+            $endif$
+
+            $if(package.optional.hasHomePage)$
+            <tr>
+              <th>Home page</th>
+              <td class="word-wrap">
+                <a href=$package.optional.homepage$>
+                  $package.optional.homepage$
+                </a>
+              </td>
+            </tr>
+            $endif$
+
+            $if(package.optional.hasBugTracker)$
+            <tr>
+              <th>Bug&nbsp;tracker</th>
+              <td class="word-wrap">
+                <a href="$package.optional.bugTracker$">
+                  $package.optional.bugTracker$
+                </a>
+              </td>
+            </tr>
+            $endif$
+
+            $if(package.optional.hasSourceRepository)$
+            <tr>
+              <th>Source&nbsp;repo</th>
+              <td class="word-wrap">$package.optional.sourceRepository$</td>
+            </tr>
+            $endif$
+
+            <tr>
+              <th>Uploaded</th>
+              <td>$hackage.uploadTime$</td>
+            </tr>
+
+
+            $if(hackage.hasDistributions)$
+            <tr>
+              <th>Distributions</th>
+              <td>$hackage.distributions$</td>
+            </tr>
+            $endif$
+
+            $if(hasexecs)$
+            <tr>
+              <th>Executables</th>
+              <td>$executables$</td>
+            </tr>
+            $endif$
+
+            <tr>
+              <th>Downloads</th>
+              <td>$totalDownloads$ total ($recentDownloads$ in the last 30 days)</td>
+            </tr>
+
+            <tr>
+              <th> Rating</th>
+              <td>$if(hasVotes)$$score$ (votes: $votes$)$else$(no votes yet)$endif$
+              <span style="font-size: small">[estimated by <a href="https://en.wikipedia.org/wiki/Bayesian_average">Bayesian average</a>]</span></td>
+            </tr>
+
+            <tr>
+              <th>Your&nbsp;Rating</th>
+              <td>
+                <ul class="star-rating">
+                  <li class="star uncool" id="1">&lambda;</li>
+                  <li class="star uncool" id="2">&lambda;</li>
+                  <li class="star uncool" id="3">&lambda;</li>
+                </ul>
+              $if(userRating)$
+                <input type="hidden" id="userRating" value="$userRating$">
+                [<a href="" class="clear-rating">clear rating</a>]
+              $endif$
+              </td>
+            </tr>
+            <tr>
+              <th>Status</th>
+              <td>$buildStatus$</td>
+            </tr>
+          </tbody>
+        </table>
+      </div> <!-- /properties -->
+    </div><!-- /flex-container -->
 
     $if(package.optional.hasReadme)$
     <hr />

--- a/datafiles/templates/packagePageAssets.st
+++ b/datafiles/templates/packagePageAssets.st
@@ -203,18 +203,3 @@
         \$("#" + i).removeClass('cool').addClass('uncool');
   }
 </script>
-
- <script>
-    // Responsive layout change
-    \$(function()  {
-          var onResize = function() {
-              if(jQuery(window).width()<=950) {
-                 jQuery("#properties").insertAfter(jQuery("#description"));
-              } else {
-                  jQuery("#properties").insertBefore(jQuery("#description"));
-             }
-            }
-            \$(window).resize(onResize);
-            onResize();
-     });
-</script>


### PR DESCRIPTION
Fixes #928.

Instead of using `float: right`, which is designed for content that can be divided in the middle (e.g. floating an image as on Wikipedia), this PR uses flexbox to fit the columns next to each other if possible, but otherwise lets the properties pane go down below if either of description/badges/modules/flags/downloads/maintainer-corner are too wide.

This makes it such that very long module paths will leave the properties pane with no space, and it will be sent down.

I note that the issue #928 is named after narrow screens, but in fact really narrow screens won't exhibit the problem, since they won't have any "float" applied. The issue is with the float, which is what this PR replaces. The floating removed in this PR was only applied on screens with a certain *minimum* screen width.

To test this PR, I'd recommend opening up any package page and using the inspector to make a module name longer. Before this PR, you'd get the weird behavior screenshotted in the linked issue. But with this PR, that doesn't happen.

Note that the diff is much smaller if you ignore white-space! There is a Github setting for that: Click on the cog right below the "Files changed" tab, while being on that tab.

The reason for putting all of these sections in the new `left-pane` is because the README marks the end of tools and Hackage metadata, and it therefore is a good dividing line. There are many small packages with a properties page that is much taller than all of the sections in the `left-pane` put together, as shown in this screenshot (showing behaviour with this PR applied):
![image](https://user-images.githubusercontent.com/284023/155192490-501fd726-0f83-45d4-9265-817656d46d27.png)

If the sections were not in the left pane, the white space shown in the screenshot would be even taller.

Tested on Firefox 91 and Chrome 98.

Tagging @noughtmare