### PR TITLE
GHC 9.0 and Cabal 3.4 (fix #1016)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -17,6 +17,8 @@ jobs:
       fail-fast: false
       matrix:
         versions:
+          - ghc: '9.0.2'
+            cabal: '3.6'
           - ghc: '8.10.7'
             cabal: '3.6'
           - ghc: '8.8.4'

--- a/hackage-server.cabal
+++ b/hackage-server.cabal
@@ -113,7 +113,7 @@ common defaults
   -- other dependencies shared by most components
   build-depends:
     , aeson                 ^>= 1.5
-    , Cabal                 ^>= 3.2.1.0
+    , Cabal                 ^>= 3.4.1.0
     , fail                  ^>= 4.9.0
       -- we use Control.Monad.Except, introduced in mtl-2.2.1
     , network               >=  3 && < 3.2

--- a/src/Data/TarIndex.hs
+++ b/src/Data/TarIndex.hs
@@ -69,8 +69,8 @@ newtype PathComponentId = PathComponentId Int
 
 type TarEntryOffset = Int
 
-$(deriveSafeCopy 0 'base ''TarIndex)
 $(deriveSafeCopy 0 'base ''PathComponentId)
+$(deriveSafeCopy 0 'base ''TarIndex)
 $(deriveSafeCopy 0 'base ''TarIndexEntry)
 
 instance MemSize TarIndex where

--- a/src/Distribution/Server/Features/BuildReports/BuildReport.hs
+++ b/src/Distribution/Server/Features/BuildReports/BuildReport.hs
@@ -473,17 +473,6 @@ instance Pretty BuildStatus where
   pretty (BuildFailCnt a)  = Disp.text "BuildFailCnt " Disp.<+> pretty a
   pretty BuildOK    = Disp.text "BuildOK"
 
--------------------
--- SafeCopy instances
---
-
-deriveSafeCopy 0 'base      ''Outcome
-deriveSafeCopy 1 'extension ''InstallOutcome
-deriveSafeCopy 3 'extension ''BuildReport
-deriveSafeCopy 1 'base      ''BuildStatus
-deriveSafeCopy 1 'base      ''BooleanCovg
-deriveSafeCopy 1 'base      ''BuildCovg
-
 
 -------------------
 -- Old SafeCopy versions
@@ -550,6 +539,8 @@ data InstallOutcome_v0
    | V0_BuildFailed
    | V0_InstallFailed
    | V0_InstallOk
+
+deriveSafeCopy 0 'base      ''Outcome
 
 deriveSafeCopy 0 'base      ''InstallOutcome_v0
 deriveSafeCopy 2 'extension ''BuildReport_v1
@@ -636,3 +627,13 @@ instance Data.Aeson.FromJSON PkgDetails where
       parseVersion :: Maybe String -> Maybe Version
       parseVersion Nothing = Nothing
       parseVersion (Just k) = P.simpleParsec k
+
+-------------------
+-- SafeCopy instances
+--
+
+deriveSafeCopy 1 'extension ''InstallOutcome
+deriveSafeCopy 3 'extension ''BuildReport
+deriveSafeCopy 1 'base      ''BuildStatus
+deriveSafeCopy 1 'base      ''BooleanCovg
+deriveSafeCopy 1 'base      ''BuildCovg

--- a/src/Distribution/Server/Features/Distro/Types.hs
+++ b/src/Distribution/Server/Features/Distro/Types.hs
@@ -62,8 +62,8 @@ data DistroPackageInfo
 
 $(deriveSafeCopy 0 'base ''DistroName)
 $(deriveSafeCopy 0 'base ''Distributions)
-$(deriveSafeCopy 0 'base ''DistroVersions)
 $(deriveSafeCopy 0 'base ''DistroPackageInfo)
+$(deriveSafeCopy 0 'base ''DistroVersions)
 
 instance MemSize Distributions where
     memSize (Distributions a) = memSize1 a

--- a/src/Distribution/Server/Features/DownloadCount/State.hs
+++ b/src/Distribution/Server/Features/DownloadCount/State.hs
@@ -198,6 +198,9 @@ instance MemSize InMemStats where
   Serializing on-disk stats
 ------------------------------------------------------------------------------}
 
+deriveSafeCopy 0 'base ''InMemStats
+deriveSafeCopy 0 'base ''OnDiskPerPkg
+
 readOnDiskStats :: FilePath -> IO OnDiskStats
 readOnDiskStats stateDir = do
     createDirectoryIfMissing True stateDir
@@ -241,9 +244,6 @@ reconstructLog stateDir onDisk =
 {------------------------------------------------------------------------------
   ACID stuff
 ------------------------------------------------------------------------------}
-
-deriveSafeCopy 0 'base ''InMemStats
-deriveSafeCopy 0 'base ''OnDiskPerPkg
 
 getInMemStats :: Query InMemStats InMemStats
 getInMemStats = ask

--- a/src/Distribution/Server/Features/Html/HtmlUtilities.hs
+++ b/src/Distribution/Server/Features/Html/HtmlUtilities.hs
@@ -91,7 +91,7 @@ htmlUtilities CoreFeature{coreResource}
         in
             [ big $ bold $ toHtml $ display pkgname
             , disp
-            , anchor ![href "tags/edit" ] << "Propose a tag?", toHtml " or "
+            , anchor ! [href "tags/edit" ] << "Propose a tag?", toHtml " or "
             , toHtml "return to ", packageNameLink pkgname, br
             ]
 

--- a/src/Distribution/Server/Features/PackageCandidates.hs
+++ b/src/Distribution/Server/Features/PackageCandidates.hs
@@ -222,6 +222,11 @@ candidatesFeature ServerEnv{serverBlobStore = store}
             resourceDesc = [(GET, "Candidate tarball")]
           , resourceGet  = [("tarball", serveCandidateTarball)]
           }
+      -- dummy null resource for revisions, since candidates don't have revisions
+      , coreCabalFileRev = (resourceAt "/package/:package/candidate/revisions/") {
+          resourceDesc = []
+        , resourceGet  = []
+      }
       , indexPackageUri = \format ->
           renderResource (corePackagesPage r) [format]
       , corePackageIdUri = \format pkgid ->

--- a/src/Distribution/Server/Features/PackageCandidates/State.hs
+++ b/src/Distribution/Server/Features/PackageCandidates/State.hs
@@ -30,12 +30,13 @@ data CandidatePackages_v0 = CandidatePackages_v0 {
     candidateList_v0 :: !(PackageIndex.PackageIndex CandPkgInfo)
   } deriving (Typeable, Show, Eq)
 
-deriveSafeCopy 1 'extension ''CandidatePackages
 deriveSafeCopy 0 'base ''CandidatePackages_v0
 
 instance Migrate CandidatePackages where
   type MigrateFrom CandidatePackages = CandidatePackages_v0
   migrate (CandidatePackages_v0 cs) = CandidatePackages cs False
+
+deriveSafeCopy 1 'extension ''CandidatePackages
 
 instance MemSize CandidatePackages where
     memSize (CandidatePackages a b) = memSize2 a b

--- a/src/Distribution/Server/Features/PackageInfoJSON/State.hs
+++ b/src/Distribution/Server/Features/PackageInfoJSON/State.hs
@@ -221,14 +221,6 @@ getPackageInfo = ask
 replacePackageInfo :: PackageInfoState -> Update PackageInfoState ()
 replacePackageInfo = State.put
 
-makeAcidic ''PackageInfoState ['getDescriptionFor
-                              ,'getVersionsFor
-                              ,'setDescriptionFor
-                              ,'setVersionsFor
-                              ,'getPackageInfo
-                              ,'replacePackageInfo
-                              ]
-
 deriveSafeCopy 0 'base ''PackageInfoState
 
 instance MemSize PackageBasicDescription where
@@ -250,3 +242,12 @@ initialPackageInfoState freshDB = PackageInfoState
   , versions              = mempty
   , migratedEphemeralData = freshDB
   }
+
+makeAcidic ''PackageInfoState
+  [ 'getDescriptionFor
+  , 'getVersionsFor
+  , 'setDescriptionFor
+  , 'setVersionsFor
+  , 'getPackageInfo
+  , 'replacePackageInfo
+  ]

--- a/src/Distribution/Server/Features/PreferredVersions.hs
+++ b/src/Distribution/Server/Features/PreferredVersions.hs
@@ -27,7 +27,6 @@ import Distribution.Server.Packages.Types
 import Distribution.Package
 import Distribution.Version
 import Distribution.Text
-import Distribution.Types.LibraryName (LibraryName(LMainLibName))
 
 import Data.Function (fix)
 import Data.List (intercalate, find)
@@ -36,7 +35,6 @@ import Data.Time.Clock (getCurrentTime)
 import Control.Arrow (second)
 import Control.Applicative (optional)
 import qualified Data.Map as Map
-import qualified Data.Set as Set
 import qualified Data.ByteString.Lazy.Char8 as BS (pack) -- Only used for ASCII data
 import Data.Aeson (Value(..))
 import qualified Data.HashMap.Strict as HashMap
@@ -380,7 +378,7 @@ versionsFeature ServerEnv{ serverVerbosity = verbosity }
 
     formatSinglePreferredVersions :: PackageName -> PreferredInfo -> Maybe String
     formatSinglePreferredVersions pkgname pref =
-      display . (\vr -> Dependency pkgname vr (Set.singleton LMainLibName)) <$> sumRange pref
+      display . (\vr -> Dependency pkgname vr mainLibSet) <$> sumRange pref
 
     formatGlobalPreferredVersions :: [(PackageName, PreferredInfo)] -> String
     formatGlobalPreferredVersions =

--- a/src/Distribution/Server/Features/Security/FileInfo.hs
+++ b/src/Distribution/Server/Features/Security/FileInfo.hs
@@ -43,6 +43,19 @@ data FileInfo = FileInfo {
   }
   deriving (Typeable, Show, Eq)
 
+data FileInfo_v0 = FileInfo_v0 Sec.Int54 SHA256Digest
+
+deriveSafeCopy 0 'base ''FileInfo_v0
+
+instance Migrate FileInfo where
+    type MigrateFrom FileInfo = FileInfo_v0
+    migrate (FileInfo_v0 len s256) =
+      FileInfo {
+        fileInfoLength = len,
+        fileInfoSHA256 = s256,
+        fileInfoMD5    = Nothing
+      }
+
 deriveSafeCopy 1 'extension ''FileInfo
 
 instance MemSize FileInfo where
@@ -60,19 +73,6 @@ instance HasFileInfo TarballCompressed where
 instance HasFileInfo BlobInfo where
   fileInfo bi@BlobInfo{..} = FileInfo (fromIntegral blobInfoLength) blobInfoHashSHA256 (Just $ blobInfoHashMD5 bi)
 
-
-data FileInfo_v0 = FileInfo_v0 Sec.Int54 SHA256Digest
-
-deriveSafeCopy 0 'base ''FileInfo_v0
-
-instance Migrate FileInfo where
-    type MigrateFrom FileInfo = FileInfo_v0
-    migrate (FileInfo_v0 len s256) =
-      FileInfo {
-        fileInfoLength = len,
-        fileInfoSHA256 = s256,
-        fileInfoMD5    = Nothing
-      }
 
 {-------------------------------------------------------------------------------
   Auxiliary

--- a/src/Distribution/Server/Features/Security/State.hs
+++ b/src/Distribution/Server/Features/Security/State.hs
@@ -66,7 +66,6 @@ data SecurityStateFiles =
      }
   deriving (Typeable, Show, Eq)
 
-deriveSafeCopy 2 'extension ''SecurityState
 deriveSafeCopy 0 'base      ''SecurityStateFiles
 
 instance MemSize SecurityState where
@@ -364,20 +363,6 @@ fauxFileInfo file =
     }
 
 {-------------------------------------------------------------------------------
-  The acid-state transactions
--------------------------------------------------------------------------------}
-
-makeAcidic ''SecurityState [
-    'getSecurityState
-  , 'replaceSecurityState
-  , 'getSecurityFiles
-  , 'updateSecurityState
-  , 'setRootMirrorsAndKeys
-  , 'setTarGzFileInfo
-  , 'resignSnapshotAndTimestamp
-  ]
-
-{-------------------------------------------------------------------------------
   Migration
 -------------------------------------------------------------------------------}
 
@@ -460,3 +445,19 @@ instance Migrate SecurityState where
     -- In this case (which can only happen with an empty server)
     -- we just use the new style initial state
     initialSecurityState
+
+deriveSafeCopy 2 'extension ''SecurityState
+
+{-------------------------------------------------------------------------------
+  The acid-state transactions
+-------------------------------------------------------------------------------}
+
+makeAcidic ''SecurityState
+  [ 'getSecurityState
+  , 'replaceSecurityState
+  , 'getSecurityFiles
+  , 'updateSecurityState
+  , 'setRootMirrorsAndKeys
+  , 'setTarGzFileInfo
+  , 'resignSnapshotAndTimestamp
+  ]

--- a/src/Distribution/Server/Features/Users.hs
+++ b/src/Distribution/Server/Features/Users.hs
@@ -204,6 +204,23 @@ emptyGroupIndex = GroupIndex IntMap.empty Map.empty
 instance MemSize GroupIndex where
     memSize (GroupIndex a b) = memSize2 a b
 
+--  Some types for JSON resources
+
+data UserNameIdResource = UserNameIdResource { ui_username    :: UserName,
+                                               ui_userid      :: UserId }
+data UserInfoResource   = UserInfoResource   { ui1_username    :: UserName,
+                                               ui1_userid      :: UserId,
+                                               ui1_groups      :: [T.Text] }
+data EnabledResource    = EnabledResource    { ui_enabled     :: Bool }
+data UserGroupResource  = UserGroupResource  { ui_title       :: T.Text,
+                                               ui_description :: T.Text,
+                                               ui_members     :: [UserNameIdResource] }
+
+deriveJSON (compatAesonOptionsDropPrefix "ui_")  ''UserNameIdResource
+deriveJSON (compatAesonOptionsDropPrefix "ui1_") ''UserInfoResource
+deriveJSON (compatAesonOptionsDropPrefix "ui_")  ''EnabledResource
+deriveJSON (compatAesonOptionsDropPrefix "ui_")  ''UserGroupResource
+
 -- TODO: add renaming
 initUserFeature :: ServerEnv -> IO (IO UserFeature)
 initUserFeature ServerEnv{serverStateDir, serverTemplatesDir, serverTemplatesMode} = do
@@ -923,23 +940,3 @@ userFeature templates usersState adminsState
                      -> (Map String GroupDescription -> Map String GroupDescription)
                      -> GroupIndex -> GroupIndex
     adjustGroupIndex f g (GroupIndex a b) = GroupIndex (f a) (g b)
-
-
-{------------------------------------------------------------------------------
-  Some types for JSON resources
-------------------------------------------------------------------------------}
-
-data UserNameIdResource = UserNameIdResource { ui_username    :: UserName,
-                                               ui_userid      :: UserId }
-data UserInfoResource   = UserInfoResource   { ui1_username    :: UserName,
-                                               ui1_userid      :: UserId,
-                                               ui1_groups      :: [T.Text] }
-data EnabledResource    = EnabledResource    { ui_enabled     :: Bool }
-data UserGroupResource  = UserGroupResource  { ui_title       :: T.Text,
-                                               ui_description :: T.Text,
-                                               ui_members     :: [UserNameIdResource] }
-
-deriveJSON (compatAesonOptionsDropPrefix "ui_")  ''UserNameIdResource
-deriveJSON (compatAesonOptionsDropPrefix "ui1_") ''UserInfoResource
-deriveJSON (compatAesonOptionsDropPrefix "ui_")  ''EnabledResource
-deriveJSON (compatAesonOptionsDropPrefix "ui_")  ''UserGroupResource

--- a/src/Distribution/Server/Features/Votes/State.hs
+++ b/src/Distribution/Server/Features/Votes/State.hs
@@ -32,9 +32,8 @@ newtype VotesState = VotesState (Map PackageName (Map UserId Score))
   deriving (Show, Eq, Typeable, MemSize)
 
 -- SafeCopy instances
-deriveSafeCopy 1 'extension ''VotesState
-
 deriveSafeCopy 0 'base      ''VotesState_v0
+deriveSafeCopy 1 'extension ''VotesState
 
 instance Migrate VotesState where
     type MigrateFrom VotesState = VotesState_v0

--- a/src/Distribution/Server/Framework/Instances.hs
+++ b/src/Distribution/Server/Framework/Instances.hs
@@ -91,17 +91,14 @@ instance SafeCopy VersionRange where
     kind    = extension
     putCopy = contain . cataVersionRange f
       where
-        f AnyVersionF = putWord8 0
         f (ThisVersionF v) = putWord8 1 >> safePut v
         f (LaterVersionF v) = putWord8 2 >> safePut v
         f (EarlierVersionF v) = putWord8 3 >> safePut v
         f (OrLaterVersionF v) = putWord8 4 >> safePut v
         f (OrEarlierVersionF v) = putWord8 5 >> safePut v
-        f (WildcardVersionF v) = putWord8 6 >> safePut v
         f (MajorBoundVersionF v) = putWord8 10 >> safePut v -- since Cabal-2.0
         f (UnionVersionRangesF u v) = putWord8 7 >> u >> v
         f (IntersectVersionRangesF u v) = putWord8 8 >> u >> v
-        f (VersionRangeParensF v) = putWord8 9 >> v
     getCopy = contain getVR
       where
         getVR = do

--- a/src/Distribution/Server/Framework/MemSize.hs
+++ b/src/Distribution/Server/Framework/MemSize.hs
@@ -240,17 +240,14 @@ instance MemSize Version where
 instance MemSize VersionRange where
     memSize = cataVersionRange f
       where
-        f AnyVersionF                   = memSize0
         f (ThisVersionF v)              = memSize1 v
         f (LaterVersionF v)             = memSize1 v
         f (OrLaterVersionF v)           = memSize1 v
         f (EarlierVersionF v)           = memSize1 v
         f (OrEarlierVersionF v)         = memSize1 v
-        f (WildcardVersionF v)          = memSize1 v
         f (MajorBoundVersionF v)        = memSize1 v
         f (UnionVersionRangesF u v)     = memSize2 u v
         f (IntersectVersionRangesF u v) = memSize2 u v
-        f (VersionRangeParensF v)       = memSize1 v
 
 instance MemSize PackageIdentifier where
     memSize (PackageIdentifier a b) = memSize2 a b

--- a/src/Distribution/Server/Packages/Index.hs
+++ b/src/Distribution/Server/Packages/Index.hs
@@ -1,4 +1,7 @@
-{-# LANGUAGE BangPatterns, TemplateHaskell #-}
+{-# LANGUAGE BangPatterns #-}
+{-# LANGUAGE PatternSynonyms #-}  -- for importing constructors
+{-# LANGUAGE TemplateHaskell #-}
+
 module Distribution.Server.Packages.Index (
     writeIncremental,
     TarIndexEntry(..),
@@ -30,7 +33,8 @@ import Distribution.Text
 import Distribution.Types.PackageName
 import Distribution.Package
          ( Package, PackageId, packageName, packageVersion )
-import Distribution.Version (mkVersion)
+import Distribution.CabalSpecVersion
+         ( pattern CabalSpecV2_0 )
 import Data.Time.Clock
          ( UTCTime )
 import Data.Time.Clock.POSIX
@@ -218,7 +222,7 @@ writeLegacyAux externalPackageRep updateEntry extras =
   where
     -- entry :: pkg -> Maybe Tar.Entry
     entry pkg
-      | specVer >= mkVersion [2] = Nothing
+      | specVerGEq2              = Nothing
       | otherwise                = Just
                                  . updateEntry pkg
                                  . Tar.fileEntry tarPath
@@ -230,5 +234,5 @@ writeLegacyAux externalPackageRep updateEntry extras =
                         </> name <.> "cabal"
 
         -- TODO: Hack-alert! We want to do this in a more elegant way.
-        specVer = parseSpecVerLazy cabalText
+        specVerGEq2 = maybe False (>= CabalSpecV2_0) $ parseSpecVerLazy cabalText
         cabalText = externalPackageRep pkg

--- a/src/Distribution/Server/Packages/Render.hs
+++ b/src/Distribution/Server/Packages/Render.hs
@@ -33,7 +33,6 @@ import Distribution.Text
 import Distribution.Pretty (prettyShow)
 import Distribution.Version
 import Distribution.ModuleName as ModuleName
-import Distribution.Types.CondTree
 import Distribution.Types.UnqualComponentName
 
 -- hackage-server
@@ -77,7 +76,7 @@ data PackageRender = PackageRender {
     rendUploadInfo   :: (UTCTime, Maybe UserInfo),
     rendUpdateInfo   :: Maybe (Int, UTCTime, Maybe UserInfo),
     rendPkgUri       :: String,
-    rendFlags        :: [Flag],
+    rendFlags        :: [PackageFlag],
     -- rendOther contains other useful fields which are merely strings, possibly empty
     --     for example: description, home page, copyright, author, stability
     -- If PackageRender is the One True Resource Representation, should they
@@ -287,7 +286,7 @@ evalCondition :: [(FlagName,Bool)] -> Condition ConfVar -> Maybe Bool
 evalCondition flags cond =
     let eval = evalCondition flags
     in case cond of
-         Var (Flag f) -> lookup f flags
+         Var (PackageFlag f) -> lookup f flags
          Var _ -> Nothing
          Lit b -> Just b
          CNot c -> not `fmap` eval c

--- a/src/Distribution/Server/Packages/Render.hs
+++ b/src/Distribution/Server/Packages/Render.hs
@@ -203,7 +203,7 @@ flatDependencies pkg =
       where
         fromMap = map fromPair . Map.toList
         fromPair (pkgname, Versions _ ver) =
-            Dependency pkgname (fromVersionIntervals ver) Set.empty -- XXX: ok?
+            Dependency pkgname (fromVersionIntervals ver) mainLibSet -- XXX: ok?
 
         notSubLib pn _ = packageNameToUnqualComponentName pn `Set.notMember` sublibs
         sublibs = Set.fromList $ map fst (condSubLibraries pkg)
@@ -276,7 +276,7 @@ sortDeps = sortOn $ \(Dependency pkgname _ _) -> map toLower (display pkgname)
 combineDepsBy :: (VersionIntervals -> VersionIntervals -> VersionIntervals)
               -> [Dependency] -> [Dependency]
 combineDepsBy f =
-    map (\(pkgname, ver) -> Dependency pkgname (fromVersionIntervals ver) Set.empty) -- XXX: ok?
+    map (\(pkgname, ver) -> Dependency pkgname (fromVersionIntervals ver) mainLibSet) -- XXX: ok?
   . Map.toList
   . Map.fromListWith f
   . map (\(Dependency pkgname ver _) -> (pkgname, toVersionIntervals ver))

--- a/src/Distribution/Server/Packages/Render.hs
+++ b/src/Distribution/Server/Packages/Render.hs
@@ -33,7 +33,7 @@ import Distribution.Text
 import Distribution.Pretty (prettyShow)
 import Distribution.Version
 import Distribution.ModuleName as ModuleName
-import Distribution.Types.UnqualComponentName
+import Distribution.Types.ModuleReexport
 
 -- hackage-server
 import Distribution.Server.Framework.CacheControl (ETag)

--- a/src/Distribution/Server/Packages/Unpack.hs
+++ b/src/Distribution/Server/Packages/Unpack.hs
@@ -17,8 +17,10 @@ import qualified Codec.Archive.Tar       as Tar
 import qualified Codec.Archive.Tar.Entry as Tar
 import qualified Codec.Archive.Tar.Check as Tar
 
+import Distribution.CabalSpecVersion
+         ( CabalSpecVersion(..), showCabalSpecVersion )
 import Distribution.Version
-         ( Version, nullVersion, mkVersion )
+         ( nullVersion )
 import Distribution.Types.PackageName
          ( mkPackageName, unPackageName )
 import Distribution.Package
@@ -196,30 +198,34 @@ basicChecks pkgid tarIndex = do
     -- special meaning in cabal's UI
     reservedPkgNames = map mkPackageName ["all","any","none","setup","lib","exe","test"]
 
-specVersionChecks :: MonadError String m => Bool -> Version -> m ()
+specVersionChecks :: MonadError String m => Bool -> CabalSpecVersion -> m ()
 specVersionChecks specVerOk specVer = do
-  when (not specVerOk || specVer < mkVersion [1]) $
+  when (not specVerOk) $
     throwError "The 'cabal-version' field could not be properly parsed."
 
   -- Don't allowing uploading new pre-1.2 .cabal files as the parser is likely too lax
   -- TODO: slowly phase out ancient cabal spec versions below 1.10
-  when (specVer < mkVersion [1,2]) $
+  when (specVer < CabalSpecV1_2) $
     throwError "'cabal-version' must be at least 1.2"
 
-  -- Reject not well-defined cabal spec versions on upload
-  when (specVer >= mkVersion [1,25] && specVer < mkVersion [2]) $
-    throwError "'cabal-version' in unassigned >=1.25 && <2 range; use 'cabal-version: 2.0' instead"
-
   -- Safeguard; should already be caught by parser
-  unless (specVer < mkVersion [2,5]) $
-    throwError "'cabal-version' must be lower than 2.5"
+  unless (specVer <= CabalSpecV2_4) $
+    throwError "'cabal-version' must be at most 2.4"
 
   -- Check whether a known spec version had been used
   -- TODO: move this into lib:Cabal
-  let knownSpecVersions = map mkVersion [ [1,18], [1,20], [1,22], [1,24], [2,0], [2,2], [2,4] ]
-  when (specVer >= mkVersion [1,18] && (specVer `notElem` knownSpecVersions)) $
+  let knownSpecVersions =
+        [ CabalSpecV1_18
+        , CabalSpecV1_20
+        , CabalSpecV1_22
+        , CabalSpecV1_24
+        , CabalSpecV2_0
+        , CabalSpecV2_2
+        , CabalSpecV2_4
+        ]
+  when (specVer >= CabalSpecV1_18 && (specVer `notElem` knownSpecVersions)) $
     throwError ("'cabal-version' refers to an unreleased/unknown cabal specification version "
-                ++ display specVer ++ "; for a list of valid specification versions please consult "
+                ++ showCabalSpecVersion specVer ++ "; for a list of valid specification versions please consult "
                 ++ "https://www.haskell.org/cabal/users-guide/file-format-changelog.html")
 
 -- | The issue is that browsers can upload the file name using either unix

--- a/src/Distribution/Server/Packages/Unpack.hs
+++ b/src/Distribution/Server/Packages/Unpack.hs
@@ -18,7 +18,7 @@ import qualified Codec.Archive.Tar.Entry as Tar
 import qualified Codec.Archive.Tar.Check as Tar
 
 import Distribution.CabalSpecVersion
-         ( CabalSpecVersion(..), showCabalSpecVersion )
+         ( CabalSpecVersion(..) )
 import Distribution.Version
          ( nullVersion )
 import Distribution.Types.PackageName
@@ -209,24 +209,8 @@ specVersionChecks specVerOk specVer = do
     throwError "'cabal-version' must be at least 1.2"
 
   -- Safeguard; should already be caught by parser
-  unless (specVer <= CabalSpecV2_4) $
-    throwError "'cabal-version' must be at most 2.4"
-
-  -- Check whether a known spec version had been used
-  -- TODO: move this into lib:Cabal
-  let knownSpecVersions =
-        [ CabalSpecV1_18
-        , CabalSpecV1_20
-        , CabalSpecV1_22
-        , CabalSpecV1_24
-        , CabalSpecV2_0
-        , CabalSpecV2_2
-        , CabalSpecV2_4
-        ]
-  when (specVer >= CabalSpecV1_18 && (specVer `notElem` knownSpecVersions)) $
-    throwError ("'cabal-version' refers to an unreleased/unknown cabal specification version "
-                ++ showCabalSpecVersion specVer ++ "; for a list of valid specification versions please consult "
-                ++ "https://www.haskell.org/cabal/users-guide/file-format-changelog.html")
+  unless (specVer <= CabalSpecV3_0) $
+    throwError "'cabal-version' must be at most 3.0"
 
 -- | The issue is that browsers can upload the file name using either unix
 -- or windows convention, so we need to take the basename using either

--- a/src/Distribution/Server/Pages/Package.hs
+++ b/src/Distribution/Server/Pages/Package.hs
@@ -526,7 +526,7 @@ sourceRepositoryToHtml :: SourceRepo -> Html
 sourceRepositoryToHtml sr
     = toHtml (display (repoKind sr) ++ ": ")
   +++ case repoType sr of
-      Just Darcs
+      Just (KnownRepoType Darcs)
        | (Just url, Nothing, Nothing) <-
          (repoLocation sr, repoModule sr, repoBranch sr) ->
           concatHtml [toHtml "darcs clone ",
@@ -540,7 +540,7 @@ sourceRepositoryToHtml sr
                                       << toHtml sd)
                                  +++ toHtml ")"
                           Nothing   -> noHtml]
-      Just Git
+      Just (KnownRepoType Git)
        | (Just url, Nothing) <-
          (repoLocation sr, repoModule sr) ->
           concatHtml [toHtml "git clone ",
@@ -554,7 +554,7 @@ sourceRepositoryToHtml sr
                       case repoSubdir sr of
                           Just sd -> toHtml ("(" ++ sd ++ ")")
                           Nothing -> noHtml]
-      Just SVN
+      Just (KnownRepoType SVN)
        | (Just url, Nothing, Nothing, Nothing) <-
          (repoLocation sr, repoModule sr, repoBranch sr, repoTag sr) ->
           concatHtml [toHtml "svn checkout ",
@@ -562,7 +562,7 @@ sourceRepositoryToHtml sr
                       case repoSubdir sr of
                           Just sd -> toHtml ("(" ++ sd ++ ")")
                           Nothing   -> noHtml]
-      Just CVS
+      Just (KnownRepoType CVS)
        | (Just url, Just m, Nothing, Nothing) <-
          (repoLocation sr, repoModule sr, repoBranch sr, repoTag sr) ->
           concatHtml [toHtml "cvs -d ",
@@ -571,7 +571,7 @@ sourceRepositoryToHtml sr
                       case repoSubdir sr of
                           Just sd -> toHtml ("(" ++ sd ++ ")")
                           Nothing   -> noHtml]
-      Just Mercurial
+      Just (KnownRepoType Mercurial)
        | (Just url, Nothing) <-
          (repoLocation sr, repoModule sr) ->
           concatHtml [toHtml "hg clone ",
@@ -585,7 +585,7 @@ sourceRepositoryToHtml sr
                       case repoSubdir sr of
                           Just sd -> toHtml ("(" ++ sd ++ ")")
                           Nothing   -> noHtml]
-      Just Bazaar
+      Just (KnownRepoType Bazaar)
        | (Just url, Nothing, Nothing) <-
          (repoLocation sr, repoModule sr, repoBranch sr) ->
           concatHtml [toHtml "bzr branch ",

--- a/src/Distribution/Server/Pages/Package.hs
+++ b/src/Distribution/Server/Pages/Package.hs
@@ -40,7 +40,6 @@ import Distribution.ModuleName (ModuleName)
 import Distribution.Package
 import Distribution.PackageDescription as P
 import Distribution.Version
-import Distribution.Types.CondTree
 import Distribution.Text        (display)
 import Distribution.Utils.ShortText (fromShortText, ShortText)
 import Text.XHtml.Strict hiding (p, name, title, content)
@@ -412,7 +411,7 @@ renderDetailedDependencies pkgRender =
 
             displayConfVar (OS os) = "os(" ++ display os ++ ")"
             displayConfVar (Arch arch) = "arch(" ++ display arch ++ ")"
-            displayConfVar (Flag fn) = "flag(" ++ unFlagName fn ++ ")"
+            displayConfVar (PackageFlag fn) = "flag(" ++ unFlagName fn ++ ")"
             displayConfVar (Impl compilerFlavor versionRange) =
                 "impl(" ++ display compilerFlavor ++ ver ++ ")"
               where

--- a/src/Distribution/Server/Pages/PackageFromTemplate.hs
+++ b/src/Distribution/Server/Pages/PackageFromTemplate.hs
@@ -471,6 +471,7 @@ sourceRepositoryToHtml sr
       _ ->
           -- We don't know how to show this SourceRepo.
           -- This is a kludge so that we at least show all the info.
+          -- currently missing known repo types are GnuArch and Monotone
            let url = fromMaybe "" $ repoLocation sr
                showRepoType (OtherRepoType rt) = rt
                showRepoType x = show x

--- a/src/Distribution/Server/Pages/PackageFromTemplate.hs
+++ b/src/Distribution/Server/Pages/PackageFromTemplate.hs
@@ -378,7 +378,7 @@ sourceRepositoryToHtml :: SourceRepo -> Html
 sourceRepositoryToHtml sr
     = toHtml (display (repoKind sr) ++ ": ")
   +++ case repoType sr of
-      Just Darcs
+      Just (KnownRepoType Darcs)
        | (Just url, Nothing, Nothing) <-
          (repoLocation sr, repoModule sr, repoBranch sr) ->
           concatHtml [toHtml "darcs get ",
@@ -392,7 +392,7 @@ sourceRepositoryToHtml sr
                                       << toHtml sd)
                                  +++ toHtml ")"
                           Nothing   -> noHtml]
-      Just Git
+      Just (KnownRepoType Git)
        | (Just url, Nothing) <-
          (repoLocation sr, repoModule sr) ->
           concatHtml [toHtml "git clone ",
@@ -406,7 +406,7 @@ sourceRepositoryToHtml sr
                       case repoSubdir sr of
                           Just sd -> toHtml ("(" ++ sd ++ ")")
                           Nothing -> noHtml]
-      Just SVN
+      Just (KnownRepoType SVN)
        | (Just url, Nothing, Nothing, Nothing) <-
          (repoLocation sr, repoModule sr, repoBranch sr, repoTag sr) ->
           concatHtml [toHtml "svn checkout ",
@@ -414,7 +414,7 @@ sourceRepositoryToHtml sr
                       case repoSubdir sr of
                           Just sd -> toHtml ("(" ++ sd ++ ")")
                           Nothing   -> noHtml]
-      Just CVS
+      Just (KnownRepoType CVS)
        | (Just url, Just m, Nothing, Nothing) <-
          (repoLocation sr, repoModule sr, repoBranch sr, repoTag sr) ->
           concatHtml [toHtml "cvs -d ",
@@ -423,7 +423,7 @@ sourceRepositoryToHtml sr
                       case repoSubdir sr of
                           Just sd -> toHtml ("(" ++ sd ++ ")")
                           Nothing   -> noHtml]
-      Just Mercurial
+      Just (KnownRepoType Mercurial)
        | (Just url, Nothing) <-
          (repoLocation sr, repoModule sr) ->
           concatHtml [toHtml "hg clone ",
@@ -437,7 +437,7 @@ sourceRepositoryToHtml sr
                       case repoSubdir sr of
                           Just sd -> toHtml ("(" ++ sd ++ ")")
                           Nothing   -> noHtml]
-      Just Bazaar
+      Just (KnownRepoType Bazaar)
        | (Just url, Nothing, Nothing) <-
          (repoLocation sr, repoModule sr, repoBranch sr) ->
           concatHtml [toHtml "bzr branch ",
@@ -456,7 +456,7 @@ sourceRepositoryToHtml sr
                       toHtml " ",
                       toHtml (takeFileName (dropTrailingPathSeparator url) ++ ".fossil")
                       ]
-      Just (OtherRepoType "pijul")
+      Just (KnownRepoType Pijul)
         | (Just url, Nothing, Nothing) <-
            (repoLocation sr, repoModule sr, repoTag sr) ->
                      concatHtml [toHtml "pijul clone ",

--- a/src/Distribution/Server/Users/Types.hs
+++ b/src/Distribution/Server/Users/Types.hs
@@ -93,6 +93,12 @@ data UserInfo_v0 = UserInfo_v0 {
                   userStatus_v0 :: !UserStatus
                 } deriving (Eq, Show, Typeable)
 
+$(deriveSafeCopy 0 'base ''UserId)
+$(deriveSafeCopy 0 'base ''UserName)
+$(deriveSafeCopy 1 'base ''UserAuth)
+$(deriveSafeCopy 0 'base ''UserStatus)
+$(deriveSafeCopy 0 'base ''UserInfo_v0)
+
 instance Migrate UserInfo where
     type MigrateFrom UserInfo = UserInfo_v0
     migrate v0 =
@@ -102,9 +108,4 @@ instance Migrate UserInfo where
         , userTokens = M.empty
         }
 
-$(deriveSafeCopy 0 'base ''UserId)
-$(deriveSafeCopy 0 'base ''UserName)
-$(deriveSafeCopy 1 'base ''UserAuth)
-$(deriveSafeCopy 0 'base ''UserStatus)
-$(deriveSafeCopy 0 'base ''UserInfo_v0)
 $(deriveSafeCopy 1 'extension ''UserInfo)

--- a/src/Distribution/Server/Users/Users.hs
+++ b/src/Distribution/Server/Users/Users.hs
@@ -379,6 +379,8 @@ data Users_v0 = Users_v0 {
   }
   deriving (Eq, Typeable, Show)
 
+$(deriveSafeCopy 0 'base ''Users_v0)
+
 instance Migrate Users where
     type MigrateFrom Users = Users_v0
     migrate v0 =
@@ -389,5 +391,4 @@ instance Migrate Users where
         , authTokenMap = Map.empty
         }
 
-$(deriveSafeCopy 0 'base ''Users_v0)
 $(deriveSafeCopy 1 'extension ''Users)

--- a/src/Distribution/Server/Util/Nonce.hs
+++ b/src/Distribution/Server/Util/Nonce.hs
@@ -48,9 +48,10 @@ parseNonceM = either fail return . parseNonce
 newtype Nonce_v0 = Nonce_v0 ByteString
   deriving (Eq, Ord, Show, Typeable, MemSize)
 
+$(deriveSafeCopy 0 'base ''Nonce_v0)
+
 instance Migrate Nonce where
     type MigrateFrom Nonce = Nonce_v0
     migrate (Nonce_v0 x) = either (const $ Nonce x) Nonce $ Base16.decode x
 
-$(deriveSafeCopy 0 'base ''Nonce_v0)
 $(deriveSafeCopy 1 'extension ''Nonce)

--- a/tests/PackageTestMain.hs
+++ b/tests/PackageTestMain.hs
@@ -78,7 +78,7 @@ badSpecVer =
        Left err ->
          HUnit.assertBool
            ("Error found, but not about invalid spec version: " ++ err)
-           ("cabal-version" `isInfixOf` err)
+           ("cabal spec version" `isInfixOf` err)
 
 -- | Some tar files in hackage are missing directory entries.
 -- Ensure that they can be verified even without the directory entries.


### PR DESCRIPTION
Migrating to GHC 9.0 needs (one commit):

- reordering declarations so that Template Haskell splices have everything in scope when they execute
- space after `!` and `$`
- putting constraints (`C =>`) before domains (`A ->`) in type signatures

Migration to Cabal 3.4 has these components (each one commit):
- `VersionRangeF`: some cases removed
- `Distribution.Server.Util.CabalRevisions`: copied from `hackage-cli`
- `mainLibSet`
- `Flag` -> `PackageFlag`
- need to import `Distribution.Types.ModuleReexport` explicitly
- `RepoType` got intermediate layer `KnownRepoType`:
  * [x] Do we add new code for new repo types?
- `FieldGrammar`
  * [ ] Do we need to add fields?
- `Version` to `CabalSpecVersion`: largest change, needs review.
  * [x] Is the code in `Distribution.Server.Packages.Unpack.specVersionChecks` still needed/meaninful?  It does not mention `cabal-version: 3.0` or higher.

- [x] This warning should be investigated:
```
src/Distribution/Server/Features/PackageCandidates.hs:209:42: warning: [-Wmissing-fields]
    • Fields of ‘CoreResource’ not initialised: coreCabalFileRev
    • In the expression:
        CoreResource
          {corePackagesPage = (resourceAt "/packages/candidates/.:format")
          ...
```