### PR TITLE
Minimal migration to Cabal-3.6.3.0

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -17,6 +17,8 @@ jobs:
       fail-fast: false
       matrix:
         versions:
+          - ghc: '9.2.2'
+            cabal: '3.6'
           - ghc: '9.0.2'
             cabal: '3.6'
           - ghc: '8.10.7'

--- a/hackage-server.cabal
+++ b/hackage-server.cabal
@@ -113,7 +113,7 @@ common defaults
   -- other dependencies shared by most components
   build-depends:
     , aeson                 ^>= 2.0.3.0
-    , Cabal                 ^>= 3.4.1.0
+    , Cabal                 ^>= 3.6.3.0
     , fail                  ^>= 4.9.0
       -- we use Control.Monad.Except, introduced in mtl-2.2.1
     , network               >=  3 && < 3.2

--- a/hackage-server.cabal
+++ b/hackage-server.cabal
@@ -27,7 +27,7 @@ copyright:    2008-2015 Duncan Coutts,
 license:      BSD-3-Clause
 license-file: LICENSE
 
-tested-with: GHC == { 8.10.7, 8.8.4 }
+tested-with: GHC == { 9.2.2, 9.0.2, 8.10.7, 8.8.4 }
 
 data-dir: datafiles
 data-files:
@@ -95,9 +95,9 @@ common defaults
   -- see `cabal.project.local-ghc-${VERSION}` files
   build-depends:
     , array                  >= 0.5   && < 0.6
-    , base                   >= 4.13  && < 4.16
+    , base                   >= 4.13  && < 4.17
     , binary                 >= 0.8   && < 0.9
-    , bytestring             >= 0.10  && < 0.11
+    , bytestring             >= 0.10  && < 0.12
     , containers            ^>= 0.6.0
     , deepseq                >= 1.4   && < 1.5
     , directory              >= 1.3   && < 1.4
@@ -105,8 +105,8 @@ common defaults
     , mtl                   ^>= 2.2.1
     , pretty                 >= 1.1   && < 1.2
     , process                >= 1.6   && < 1.7
-    , text                  ^>= 1.2.2
-    , time                   >= 1.9   && < 1.12
+    , text                  ^>= 1.2.5.0
+    , time                   >= 1.9   && < 1.13
     , transformers           >= 0.5   && < 0.6
     , unix                   >= 2.7   && < 2.8
     , scientific
@@ -356,7 +356,7 @@ library lib-server
   -- NB: see also build-depends in `common defaults`!
   build-depends:
     , HStringTemplate       ^>= 0.8
-    , HTTP                  ^>= 4000.3.6
+    , HTTP                  ^>= 4000.3.16
     , QuickCheck            ^>= 2.14
     , acid-state            ^>= 0.16
     , async                 ^>= 2.2.1
@@ -364,7 +364,7 @@ library lib-server
     , attoparsec            ^>= 0.14.4
     , base16-bytestring     ^>= 1.0
     -- requires bumping http-io-streams
-    , base64-bytestring     ^>= 1.1
+    , base64-bytestring     ^>= 1.2.1.0
       --NOTE: blaze-builder-0.4 is now a compat package that uses bytestring-0.10 builder
     , blaze-builder         ^>= 0.4
     , blaze-html            ^>= 0.9
@@ -511,7 +511,7 @@ test-suite HighLevelTest
       -- component-specific dependencies
     , xml             ^>= 1.3.14
     , io-streams      ^>= 1.5.0.1
-    , http-io-streams ^>= 0.1.0.0
+    , http-io-streams ^>= 0.1.6.1
 
 test-suite CreateUserTest
   import:         test-defaults

--- a/src/Distribution/Server/Packages/Render.hs
+++ b/src/Distribution/Server/Packages/Render.hs
@@ -31,7 +31,15 @@ import Distribution.PackageDescription.Configuration
 import Distribution.Package
 import Distribution.Text
 import Distribution.Pretty (prettyShow)
-import Distribution.Version
+import Distribution.Version (noVersion)
+import Distribution.Types.VersionInterval.Legacy
+  -- Andreas Abel, 2022-03-27:
+  -- Note that this "Legacy" module is both new and deprecated in Cabal-3.6.
+  -- However, the non-deprecated module "Distribution.Types.VersionInterval"
+  -- does not define the functions anymore we rely on here, namely
+  -- @{union,intersect}VersionIntervals@.
+  -- I criticized this unfortunate development at length at:
+  -- https://github.com/haskell/cabal/issues/7916
 import Distribution.ModuleName as ModuleName
 import Distribution.Types.ModuleReexport
 
@@ -41,7 +49,9 @@ import Distribution.Server.Packages.Types
 import Distribution.Server.Packages.ModuleForest
 import qualified Distribution.Server.Users.Users as Users
 import Distribution.Server.Users.Types
+import Distribution.Utils.Path (getSymbolicPath)
 import Distribution.Utils.ShortText (fromShortText)
+
 import qualified Data.TarIndex as TarIndex
 import Data.TarIndex (TarIndex, TarEntryOffset)
 
@@ -95,7 +105,7 @@ doPackageRender users info = PackageRender
     , rendSublibraryDeps = (unUnqualComponentName *** depTree libBuildInfo)
                                 `map` condSubLibraries genDesc
     , rendLicenseName  = prettyShow (license desc) -- maybe make this a bit more human-readable
-    , rendLicenseFiles = licenseFiles desc
+    , rendLicenseFiles = map getSymbolicPath $ licenseFiles desc
     , rendMaintainer   = case fromShortText $ maintainer desc of
                            "None" -> Nothing
                            "none" -> Nothing

--- a/src/Distribution/Server/Util/ParseSpecVer.hs
+++ b/src/Distribution/Server/Util/ParseSpecVer.hs
@@ -239,8 +239,8 @@ decodeVerFallback v0 = simpleParse v <|> parseSpecVR
     parseSpecVR = do
         vr <- simpleParse v
         case asVersionIntervals vr of
-          []                            -> Just $ mkVersion [0]
-          ((LowerBound version _, _):_) -> Just $ version
+          VersionInterval (LowerBound version _) _ : _ -> Just version
+          [] -> Just $ mkVersion [0]
 
     v = BC8.unpack v0
 

--- a/tests/PackageTestMain.hs
+++ b/tests/PackageTestMain.hs
@@ -63,9 +63,12 @@ badDirMangler entry =
 
 cabalPackageCheckTests :: [TestTree]
 cabalPackageCheckTests =
+  -- Failing tests
     [ testCase "Missing ./configure script" missingConfigureScriptTest
-    , testCase "Missing directories in tar file" missingDirsInTarFileTest
     , testCase "Bad spec-version" badSpecVer
+  -- Successful tests
+    , testCase "Missing directories in tar file" missingDirsInTarFileTest
+    , testCase "Accept GHC 9.2 LANGUAGE extensions" acceptGHC902LanguageExtensions
     ]
 
 ---------------------------------------------------------------------------
@@ -108,6 +111,11 @@ missingDirsInTarFileTest =
   successTestTGZ pkg =<< do keepOnlyFiles <$> tarGzFile pkg
   where
   pkg = "correct-package-0.1.0.0"
+
+-- | Hackage should accept GHC 9.2 language extensions (issue #1030).
+
+acceptGHC902LanguageExtensions :: Assertion
+acceptGHC902LanguageExtensions = successTest "LANGUAGE-GHC-9.2"
 
 ---------------------------------------------------------------------------
 -- * Auxiliary functions to construct tests

--- a/tests/unpack-checks/LANGUAGE-GHC-9.2/LANGUAGE-GHC.cabal
+++ b/tests/unpack-checks/LANGUAGE-GHC-9.2/LANGUAGE-GHC.cabal
@@ -1,0 +1,20 @@
+name:                LANGUAGE-GHC
+version:             9.2
+synopsis:            Test for LANGUAGE extensions (issue #1030)
+description:         Test whether Hackage accepts the latest LANGUAGE extensions
+license:             BSD3
+license-file:        LICENSE
+author:              Hackage Server Team
+maintainer:          no@email.com
+category:            Test case
+build-type:          Simple
+cabal-version:       >=1.10
+
+executable foo
+  main-is:             Main.hs
+  build-depends:       base >=4.16 && <4.17
+  default-language:    GHC2021
+  default-extensions:
+    -- These LANGUAGE extensions are new in GHC 9.2:
+    NoFieldSelectors
+    OverloadedRecordDot

--- a/tests/unpack-checks/LANGUAGE-GHC-9.2/LICENSE
+++ b/tests/unpack-checks/LANGUAGE-GHC-9.2/LICENSE
@@ -1,0 +1,30 @@
+Copyright (c) 2016, Hackage Server Team
+
+All rights reserved.
+
+Redistribution and use in source and binary forms, with or without
+modification, are permitted provided that the following conditions are met:
+
+    * Redistributions of source code must retain the above copyright
+      notice, this list of conditions and the following disclaimer.
+
+    * Redistributions in binary form must reproduce the above
+      copyright notice, this list of conditions and the following
+      disclaimer in the documentation and/or other materials provided
+      with the distribution.
+
+    * Neither the name of Hackage Server Team nor the names of other
+      contributors may be used to endorse or promote products derived
+      from this software without specific prior written permission.
+
+THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
+"AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
+LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR
+A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT
+OWNER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL,
+SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT
+LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE,
+DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY
+THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+(INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.

--- a/tests/unpack-checks/LANGUAGE-GHC-9.2/Main.hs
+++ b/tests/unpack-checks/LANGUAGE-GHC-9.2/Main.hs
@@ -1,0 +1,4 @@
+module Main where
+
+main :: IO ()
+main = putStrLn "Hello, Haskell!"

--- a/tests/unpack-checks/LANGUAGE-GHC-9.2/Setup.hs
+++ b/tests/unpack-checks/LANGUAGE-GHC-9.2/Setup.hs
@@ -1,0 +1,2 @@
+import Distribution.Simple
+main = defaultMain


### PR DESCRIPTION
This patch makes the minimal changes to compile with Cabal-3.6.3.0.
UPDATE: This also enables compilation with GHC 9.2 (#1040).

Cabal-3.6 intends a semantics of the caret operator `^>=` that is more subtle than expanding it into its version interval.
We do not pick up this intention in this patch, but fall back to

    Distribution.Types.VersionInterval.Legacy

Further background:
- https://github.com/haskell/cabal/issues/7916 

Cabal-3.6 probably also intends a safer handling of pathes (`SymbolicPath`), yet we simply fall back to `FilePath` using `getSymbolicPath`.

Questions to reviewer:
- [ ] Are there new feature in Cabal-3.6 that would require a complementing implementation on the `hackage-server` side?