### PR TITLE
Migrate to `aeson-2.0`

### DIFF
--- a/hackage-server.cabal
+++ b/hackage-server.cabal
@@ -112,7 +112,7 @@ common defaults
     , scientific
   -- other dependencies shared by most components
   build-depends:
-    , aeson                 ^>= 1.5
+    , aeson                 ^>= 2.0.3.0
     , Cabal                 ^>= 3.4.1.0
     , fail                  ^>= 4.9.0
       -- we use Control.Monad.Except, introduced in mtl-2.2.1
@@ -361,7 +361,7 @@ library lib-server
     , acid-state            ^>= 0.16
     , async                 ^>= 2.2.1
     -- requires bumping http-io-streams
-    , attoparsec            ^>= 0.13
+    , attoparsec            ^>= 0.14.4
     , base16-bytestring     ^>= 1.0
     -- requires bumping http-io-streams
     , base64-bytestring     ^>= 1.1

--- a/src/Distribution/Server/Features/Core.hs
+++ b/src/Distribution/Server/Features/Core.hs
@@ -23,9 +23,10 @@ module Distribution.Server.Features.Core (
 -- stdlib
 import qualified Codec.Compression.GZip                             as GZip
 import           Data.Aeson                                         (Value (..))
+import qualified Data.Aeson.Key                                     as Key
+import qualified Data.Aeson.KeyMap                                  as KeyMap
 import           Data.ByteString.Lazy                               (ByteString)
 import qualified Data.Foldable                                      as Foldable
-import qualified Data.HashMap.Strict                                as HashMap
 import qualified Data.Text                                          as Text
 import           Data.Time.Clock                                    (UTCTime, getCurrentTime)
 import           Data.Time.Format                                   (defaultTimeLocale, formatTime)
@@ -688,8 +689,8 @@ coreFeature ServerEnv{serverBlobStore = store} UserFeature{..}
       -- in particular, we use objects for the packages so that we can add
       -- additional fields later without (hopefully) breaking clients
       let json = flip map list $ \str ->
-            Object . HashMap.fromList $ [
-                (Text.pack "packageName", String (Text.pack str))
+            Object . KeyMap.fromList $ [
+                (Key.fromString "packageName", String (Text.pack str))
               ]
       return . toResponse $ Array (Vec.fromList json)
 
@@ -727,10 +728,10 @@ coreFeature ServerEnv{serverBlobStore = store} UserFeature{..}
       let revisions = pkgMetadataRevisions pkginfo
           revisionToObj rev (_, (utime, uid)) =
             let uname = userIdToName users uid in
-            Object $ HashMap.fromList
-              [ (Text.pack "number", Number (fromIntegral rev))
-              , (Text.pack "user", String (Text.pack (display uname)))
-              , (Text.pack "time", String (Text.pack (formatTime defaultTimeLocale "%Y-%m-%dT%H:%M:%SZ" utime)))
+            Object $ KeyMap.fromList
+              [ (Key.fromString "number", Number (fromIntegral rev))
+              , (Key.fromString "user", String (Text.pack (display uname)))
+              , (Key.fromString "time", String (Text.pack (formatTime defaultTimeLocale "%Y-%m-%dT%H:%M:%SZ" utime)))
               ]
           revisionsJson = Array $ Vec.imap revisionToObj revisions
       return (toResponse revisionsJson)

--- a/src/Distribution/Server/Features/Search.hs
+++ b/src/Distribution/Server/Features/Search.hs
@@ -32,6 +32,7 @@ import qualified Data.Map as Map
 
 import Control.Applicative (optional)
 import Data.Aeson
+import qualified Data.Aeson.Key as Key
 
 data SearchFeature = SearchFeature {
     searchFeatureInterface :: HackageFeature,
@@ -185,7 +186,7 @@ searchFeature ServerEnv{serverBaseURI} CoreFeature{..} ListFeature{getAllLists}
         _ ->
           errBadRequest "Invalid search request" [MText $ "Empty terms query"]
       where packageNameJSON pkgName =
-              object [ T.pack "name" .= unPackageName pkgName ]
+              object [ Key.fromString "name" .= unPackageName pkgName ]
 
 {-
     suggestJson :: ServerPartE Response

--- a/src/Distribution/Server/Features/ServerIntrospect.hs
+++ b/src/Distribution/Server/Features/ServerIntrospect.hs
@@ -14,7 +14,8 @@ import Text.XHtml.Strict
          , anchor, (!), href, name
          , ordList, unordList )
 import Data.Aeson (Value(..))
-import qualified Data.HashMap.Strict as HashMap
+import qualified Data.Aeson.Key      as Key
+import qualified Data.Aeson.KeyMap   as KeyMap
 import qualified Data.Vector         as Vector
 import qualified Data.Text           as Text
 import Data.List
@@ -338,7 +339,7 @@ array :: [Value] -> Value
 array = Array . Vector.fromList
 
 object :: [(String, Value)] -> Value
-object = Object . HashMap.fromList . map (first Text.pack)
+object = Object . KeyMap.fromList . map (first Key.fromString)
 
 string :: String -> Value
 string = String . Text.pack

--- a/src/Distribution/Server/Features/Votes.hs
+++ b/src/Distribution/Server/Features/Votes.hs
@@ -21,9 +21,10 @@ import Distribution.Package
 import Distribution.Text
 
 import Data.Aeson
+import qualified Data.Aeson.Key    as Key
+import qualified Data.Aeson.KeyMap as KeyMap
 import qualified Data.Map as Map
 import qualified Data.Text as T
-import qualified Data.HashMap.Strict as HashMap
 
 import Control.Arrow (first)
 import qualified Text.XHtml.Strict as X
@@ -212,7 +213,7 @@ votesFeature  ServerEnv{..}
 
 -- Use to construct a list of tuples that can be toJSON'd
 objectL :: [(String, Value)] -> Value
-objectL = Object . HashMap.fromList . map (first T.pack)
+objectL = Object . KeyMap.fromList . map (first Key.fromString)
 
 -- Use inside an objectL to transform strings into json values
 string :: String -> Value

--- a/src/Distribution/Server/Framework/HtmlFormWrapper.hs
+++ b/src/Distribution/Server/Framework/HtmlFormWrapper.hs
@@ -181,9 +181,10 @@ parsePathTmpl v = parseKey
     parseJVal s                          = JSON.decode (BS8.pack s)
 
 accumJPaths :: [JPath] -> Maybe JSON.Value
-accumJPaths js = foldr (\j r v -> case insertJPath j v of
-                                    Nothing -> Nothing
-                                    Just v' -> r v') Just js JSON.Null
+accumJPaths js = f JSON.Null
+  where
+  f :: JSON.Value -> Maybe JSON.Value
+  f = foldr (\ j r -> insertJPath j >=> r) Just js
 
 insertJPath :: JPath -> JSON.Value -> Maybe JSON.Value
 insertJPath (JField f p) JSON.Null = do

--- a/src/Distribution/Server/Framework/HtmlFormWrapper.hs
+++ b/src/Distribution/Server/Framework/HtmlFormWrapper.hs
@@ -13,7 +13,8 @@ import qualified Data.ByteString.Lazy as BS
 import qualified Data.ByteString.Lazy.Char8 as BS8
 import qualified Data.Aeson as JSON
 import qualified Data.Text as T
-import qualified Data.HashMap.Strict as HMap
+import qualified Data.Aeson.Key as Key
+import qualified Data.Aeson.KeyMap as KeyMap
 import Control.Concurrent.MVar
 
 import Distribution.Server.Framework.HappstackUtils (showContentType)
@@ -187,18 +188,20 @@ accumJPaths js = f JSON.Null
   f = foldr (\ j r -> insertJPath j >=> r) Just js
 
 insertJPath :: JPath -> JSON.Value -> Maybe JSON.Value
+
 insertJPath (JField f p) JSON.Null = do
   v <- insertJPath p JSON.Null
-  return (JSON.object [(f, v)])
+  return (JSON.object [(Key.fromText f, v)])
 
 insertJPath (JField f p) (JSON.Object obj) = do
-  case HMap.lookup f obj of
+  let k = Key.fromText f
+  case KeyMap.lookup k obj of
     Nothing -> do
       v <- insertJPath p JSON.Null
-      return (JSON.Object (HMap.insert f v obj))
+      return (JSON.Object (KeyMap.insert k v obj))
     Just v0 -> do
       v <- insertJPath p v0
-      return (JSON.Object (HMap.insert f v obj))
+      return (JSON.Object (KeyMap.insert k v obj))
 
 insertJPath (JVal v) JSON.Null = return v
 insertJPath _        _         = Nothing


### PR DESCRIPTION
Migrate to `aeson-2.0`.  No functional change.
- `HashMap` -> `KeyMap`
- `Text` -> `Key`