### PR TITLE
Add support for embedding of analytics pixels on package pages

### DIFF
--- a/datafiles/templates/Html/analytics-pixels-page.html.st
+++ b/datafiles/templates/Html/analytics-pixels-page.html.st
@@ -1,0 +1,45 @@
+<!DOCTYPE html>
+<html>
+<head>
+$hackageCssTheme()$
+<title>Analytics pixels for $pkgname$ | Hackage</title>
+</head>
+
+<body>
+$hackagePageHeader()$
+
+<div id="content">
+
+<h2>Adding a analytics pixel to <a href="/package/$pkgname$">$pkgname$</a></h2>
+
+<p> 
+  Configure an analytics pixel to be automatically loaded on your package’s page on Hackage. 
+  You’ll need an image URL from any external analytics provider, which is provided 
+  for free and can surface information about web traffic to your package including geographic 
+  distribution, version distribution, and companies.
+</p>
+
+<form method="POST" class="box" action="/package/$pkgname$/analytics-pixels">
+    <label for="analytics-pixel">Analytics Image URL</label>
+    <input name="analytics-pixel" type="text" />
+    <input type="submit" />
+</form>
+
+<h2>Existing analytics pixels for <a href="/package/$pkgname$">$pkgname$</a></h2>
+
+<ul>
+  $analyticsPixels:{analyticsPixel|
+    <li>
+        <form method="POST" action="/package/$pkgname$/analytics-pixels">
+            <label for="analytics-pixel">$analyticsPixel$</label>
+            <input type="hidden" name="analytics-pixel" value="$analyticsPixel$"/>
+            <input type="hidden" name="_method" value="DELETE" />
+            <input type="submit" value="Delete" />
+        </form>
+    </li>
+  }; separator=""$
+</ul>
+
+</div>
+</body>
+</html>

--- a/datafiles/templates/Html/package-page.html.st
+++ b/datafiles/templates/Html/package-page.html.st
@@ -95,6 +95,11 @@
                 edit package information
               </a>
             </li>
+            <li>
+              <a href="$baseurl$/package/$package.name$/analytics-pixels">
+                edit package analytics pixels
+              </a>
+            </li>
           </ul>
           <p>Candidates</p>
           <ul>
@@ -272,5 +277,10 @@
   <script src="$doc.baseUrl$/quick-jump.min.js" type="text/javascript"></script>
   <script type="text/javascript"> quickNav.init("$doc.baseUrl$", function(toggle) {var t = document.getElementById('quickjump-trigger');if (t) {t.onclick = function(e) { e.preventDefault(); toggle(); };}}); </script>
   $endif$
+
+  $analyticsPixels:{analyticsPixelUrl|
+  <img referrerpolicy="no-referrer-when-downgrade" src="$analyticsPixelUrl$" />
+  }; separator=""$
+
 </body>
 </html>

--- a/datafiles/templates/Html/user-analytics-pixels-page.html.st
+++ b/datafiles/templates/Html/user-analytics-pixels-page.html.st
@@ -1,0 +1,59 @@
+<!DOCTYPE html>
+<html>
+<head>
+$hackageCssTheme()$
+<title>Analytics pixels for all of $username$'s packages | Hackage</title>
+</head>
+
+<body>
+$hackagePageHeader()$
+
+<div id="content">
+
+<h2>Create a analytics pixel</h2>
+
+<p> 
+  Configure an analytics pixel to be automatically loaded on your package’s page on Hackage. 
+  You’ll need an image URL from any external analytics provider, which is provided 
+  for free and can surface information about web traffic to your package including geographic 
+  distribution, version distribution, and companies.
+</p>
+
+<form method="POST" class="box" action="/user/$username$/analytics-pixels">
+    <p>    
+        <label for="package">Package</label>
+        <select name="package">
+        $pkgs:{pkg|
+            <option value="$pkg$">$pkg$</option>      
+        }; separator=""$
+        </select>
+    </p>
+    <p>
+        <label for="analytics-pixel">Analytics pixel URL</label>
+        <input name="analytics-pixel" type="text" />
+    </p>
+    <input type="submit" />
+</form>
+
+<h2>Existing analytics pixels</h2>
+
+$pkgpixels:{pkgpixel|
+<h3><a href="/package/$pkgpixel.0$">$pkgpixel.0$</a></h3>
+<ul>
+  $pkgpixel.1:{analyticsPixel|
+    <li>
+        <form method="POST" action="/user/$username$/analytics-pixels">
+            <label for="analytics-pixel">$analyticsPixel$</label>
+            <input type="hidden" name="package" value="$pkgpixel.0$" />
+            <input type="hidden" name="analytics-pixel" value="$analyticsPixel$"/>
+            <input type="hidden" name="_method" value="DELETE" />
+            <input type="submit" value="Delete" />
+        <form>
+    </li>
+  }; separator=""$
+</ul>
+}; separator=""$
+
+</div>
+</body>
+</html>

--- a/datafiles/templates/Users/manage.html.st
+++ b/datafiles/templates/Users/manage.html.st
@@ -64,6 +64,9 @@ $tokens:{token|
   <li>
     <a href="/user/$username$/password">Change your password</a>
   </li>
+  <li>
+    <a href="/user/$username$/analytics-pixels">Analytics pixels</a>
+  </li>
 </ul>
 
 </div>

--- a/hackage-server.cabal
+++ b/hackage-server.cabal
@@ -347,6 +347,8 @@ library lib-server
       Distribution.Server.Features.Tags
       Distribution.Server.Features.Tags.Backup
       Distribution.Server.Features.Tags.State
+      Distribution.Server.Features.AnalyticsPixels
+      Distribution.Server.Features.AnalyticsPixels.State
       Distribution.Server.Features.UserDetails
       Distribution.Server.Features.UserSignup
       Distribution.Server.Features.StaticFiles

--- a/src/Distribution/Server/Features.hs
+++ b/src/Distribution/Server/Features.hs
@@ -36,6 +36,7 @@ import Distribution.Server.Features.PreferredVersions   (initVersionsFeature)
 -- [reverse index disabled] import Distribution.Server.Features.ReverseDependencies (initReverseFeature)
 import Distribution.Server.Features.DownloadCount       (initDownloadFeature)
 import Distribution.Server.Features.Tags                (initTagsFeature)
+import Distribution.Server.Features.AnalyticsPixels     (initAnalyticsPixelsFeature)
 import Distribution.Server.Features.Search              (initSearchFeature)
 import Distribution.Server.Features.PackageList         (initListFeature)
 import Distribution.Server.Features.HaskellPlatform     (initPlatformFeature)
@@ -127,6 +128,8 @@ initHackageFeatures env@ServerEnv{serverVerbosity = verbosity} = do
                                initDownloadFeature env
     mkTagsFeature           <- logStartup "tags" $
                                initTagsFeature env
+    mkAnalyticsPixelsFeature <- logStartup "analytics pixels" $ 
+                               initAnalyticsPixelsFeature env
     mkVersionsFeature       <- logStartup "versions" $
                                initVersionsFeature env
     -- mkReverseFeature     <- logStartup "reverse deps" $
@@ -255,6 +258,11 @@ initHackageFeatures env@ServerEnv{serverVerbosity = verbosity} = do
                          uploadFeature
                          usersFeature
 
+    analyticsPixelsFeature <- mkAnalyticsPixelsFeature
+                               coreFeature
+                               usersFeature
+                               uploadFeature
+
     versionsFeature <- mkVersionsFeature
                          coreFeature
                          uploadFeature
@@ -292,6 +300,7 @@ initHackageFeatures env@ServerEnv{serverVerbosity = verbosity} = do
                          versionsFeature
                          -- [reverse index disabled] reverseFeature
                          tagsFeature
+                         analyticsPixelsFeature
                          downloadFeature
                          votesFeature
                          listFeature
@@ -372,6 +381,7 @@ initHackageFeatures env@ServerEnv{serverVerbosity = verbosity} = do
          , getFeatureInterface documentationCandidatesFeature
          , getFeatureInterface downloadFeature
          , getFeatureInterface tagsFeature
+         , getFeatureInterface analyticsPixelsFeature
          , getFeatureInterface versionsFeature
          -- [reverse index disabled] , getFeatureInterface reverseFeature
          , getFeatureInterface searchFeature

--- a/src/Distribution/Server/Features/AnalyticsPixels.hs
+++ b/src/Distribution/Server/Features/AnalyticsPixels.hs
@@ -1,0 +1,128 @@
+{-# LANGUAGE RankNTypes, NamedFieldPuns, RecordWildCards #-}
+
+-- | Implements a system to allow users to upvote packages.
+--
+module Distribution.Server.Features.AnalyticsPixels
+  ( AnalyticsPixelsFeature(..)
+  , AnalyticsPixel(..)
+  , initAnalyticsPixelsFeature
+  ) where
+
+import Data.Set (Set)
+
+import Distribution.Server.Features.AnalyticsPixels.State
+
+import Distribution.Server.Framework
+import Distribution.Server.Framework.BackupRestore
+
+import Distribution.Server.Features.Core
+import Distribution.Server.Features.Upload
+import Distribution.Server.Features.Users
+
+import Distribution.Package
+
+-- | Define the prototype for this feature
+data AnalyticsPixelsFeature = AnalyticsPixelsFeature {
+    analyticsPixelsFeatureInterface :: HackageFeature,
+    analyticsPixelsResource         :: Resource,
+    userAnalyticsPixelsResource     :: Resource,
+
+    analyticsPixelAdded             :: Hook (PackageName, AnalyticsPixel) (),
+    analyticsPixelRemoved           :: Hook (PackageName, AnalyticsPixel) (),
+
+    -- | Returns all 'AnalyticsPixel's associated with a 'Package'.
+    getPackageAnalyticsPixels       :: forall m. MonadIO m => PackageName -> m (Set AnalyticsPixel),
+
+    -- | Adds a new 'AnalyticsPixel' to a 'Package'. Returns True in case it was added. False in case
+    -- it's already existing.
+    addPackageAnalyticsPixel        :: forall m. MonadIO m => PackageName -> AnalyticsPixel -> m Bool,
+
+    -- | Remove a 'AnalyticsPixel' from a 'Package'.
+    removePackageAnalyticsPixel     :: forall m. MonadIO m => PackageName -> AnalyticsPixel -> m ()
+}
+
+-- | Implement the isHackageFeature 'interface'
+instance IsHackageFeature AnalyticsPixelsFeature where
+  getFeatureInterface = analyticsPixelsFeatureInterface
+
+-- | Called from Features.hs to initialize this feature
+initAnalyticsPixelsFeature :: ServerEnv
+                          -> IO ( CoreFeature
+                            -> UserFeature
+                            -> UploadFeature
+                            -> IO AnalyticsPixelsFeature)
+initAnalyticsPixelsFeature env@ServerEnv{serverStateDir} = do
+  dbAnalyticsPixelsState <- analyticsPixelsStateComponent serverStateDir
+  analyticsPixelAdded    <- newHook
+  analyticsPixelRemoved  <- newHook
+
+  return $ \coref@CoreFeature{..} userf@UserFeature{..} uploadf -> do
+    let feature = analyticsPixelsFeature env
+                  dbAnalyticsPixelsState
+                  coref userf uploadf analyticsPixelAdded analyticsPixelRemoved
+
+    return feature
+
+-- | Define the backing store (i.e. database component)
+analyticsPixelsStateComponent :: FilePath -> IO (StateComponent AcidState AnalyticsPixelsState)
+analyticsPixelsStateComponent stateDir = do
+  st <- openLocalStateFrom (stateDir </> "db" </> "AnalyticsPixels") initialAnalyticsPixelsState
+  return StateComponent {
+      stateDesc    = "Backing store for AnalyticsPixels feature"
+    , stateHandle  = st
+    , getState     = query st GetAnalyticsPixelsState
+    , putState     = update st . ReplaceAnalyticsPixelsState
+    , resetState   = analyticsPixelsStateComponent
+    , backupState  = \_ _ -> []
+    , restoreState = RestoreBackup {
+                         restoreEntry    = error "Unexpected backup entry"
+                       , restoreFinalize = return initialAnalyticsPixelsState
+                       }
+   }
+
+
+-- | Default constructor for building this feature.
+analyticsPixelsFeature :: ServerEnv
+                      -> StateComponent AcidState AnalyticsPixelsState
+                      -> CoreFeature                          -- To get site package list
+                      -> UserFeature                          -- To authenticate users
+                      -> UploadFeature                        -- For accessing package maintainers and trustees
+                      -> Hook (PackageName, AnalyticsPixel) () -- Signals addition of a new AnalyticsPixel
+                      -> Hook (PackageName, AnalyticsPixel) () -- Signals removeal of a AnalyticsPixel
+                      -> AnalyticsPixelsFeature
+
+analyticsPixelsFeature  ServerEnv{..}
+              analyticsPixelsState
+              CoreFeature { coreResource = CoreResource{..} }
+              UserFeature{..}
+              UploadFeature{..}
+              analyticsPixelAdded
+              analyticsPixelRemoved
+  = AnalyticsPixelsFeature {..}
+  where
+    analyticsPixelsFeatureInterface  = (emptyHackageFeature "AnalyticsPixels") {
+        featureDesc      = "Allow users to attach analytics pixels to their packages",
+        featureResources = [analyticsPixelsResource, userAnalyticsPixelsResource]
+      , featureState     = [abstractAcidStateComponent analyticsPixelsState]
+      }
+
+    analyticsPixelsResource :: Resource
+    analyticsPixelsResource = resourceAt "/package/:package/analytics-pixels.:format"
+
+    userAnalyticsPixelsResource :: Resource
+    userAnalyticsPixelsResource = resourceAt "/user/:username/analytics-pixels.:format"
+
+    getPackageAnalyticsPixels :: MonadIO m => PackageName -> m (Set AnalyticsPixel)
+    getPackageAnalyticsPixels name = 
+        queryState analyticsPixelsState (AnalyticsPixelsForPackage name)
+
+    addPackageAnalyticsPixel :: MonadIO m => PackageName -> AnalyticsPixel -> m Bool
+    addPackageAnalyticsPixel name pixel = do
+        added <- updateState analyticsPixelsState (AddPackageAnalyticsPixel name pixel)
+        when added $ runHook_ analyticsPixelAdded (name, pixel)
+        pure added
+
+    removePackageAnalyticsPixel :: MonadIO m => PackageName -> AnalyticsPixel -> m ()
+    removePackageAnalyticsPixel name pixel = do
+        updateState analyticsPixelsState (RemovePackageAnalyticsPixel name pixel)
+        runHook_ analyticsPixelRemoved (name, pixel)

--- a/src/Distribution/Server/Features/AnalyticsPixels/State.hs
+++ b/src/Distribution/Server/Features/AnalyticsPixels/State.hs
@@ -1,0 +1,109 @@
+{-# LANGUAGE DeriveDataTypeable, GeneralizedNewtypeDeriving,
+             TypeFamilies, TemplateHaskell #-}
+
+module Distribution.Server.Features.AnalyticsPixels.State 
+    ( AnalyticsPixel(..)
+    , AnalyticsPixelsState(..)
+    , initialAnalyticsPixelsState
+
+    -- * State queries and updates
+    , AnalyticsPixelsForPackage(..)
+    , AddPackageAnalyticsPixel(..)
+    , RemovePackageAnalyticsPixel(..)
+    , GetAnalyticsPixelsState(..)
+    , ReplaceAnalyticsPixelsState(..)
+    ) where
+
+import Distribution.Package (PackageName)
+
+import Distribution.Server.Framework.MemSize (MemSize)
+import Distribution.Server.Users.State ()
+
+import Data.Text (Text)
+import Data.Typeable (Typeable)
+import Data.Map (Map)
+import qualified Data.Map.Strict as Map
+import Data.Acid     (Query, Update, makeAcidic)
+import Data.SafeCopy (base, deriveSafeCopy)
+import Data.Set (Set)
+import qualified Data.Set as Set
+
+import Control.DeepSeq (NFData)
+import qualified Control.Monad.State as State
+import Control.Monad.Reader.Class (ask, asks)
+
+newtype AnalyticsPixel = AnalyticsPixel
+    {
+        analyticsPixelUrl :: Text
+    }
+    deriving (Show, Eq, Ord, NFData, Typeable, MemSize)
+
+newtype AnalyticsPixelsState = AnalyticsPixelsState
+    {
+        analyticsPixels :: Map PackageName (Set AnalyticsPixel)
+    }
+  deriving (Show, Eq, NFData, Typeable, MemSize)
+
+-- SafeCopy instances
+$(deriveSafeCopy 0 'base ''AnalyticsPixel)
+$(deriveSafeCopy 0 'base ''AnalyticsPixelsState)
+
+--
+
+initialAnalyticsPixelsState :: AnalyticsPixelsState
+initialAnalyticsPixelsState = AnalyticsPixelsState
+    {
+        analyticsPixels = Map.empty
+    }
+
+analyticsPixelsForPackage :: PackageName -> Query AnalyticsPixelsState (Set AnalyticsPixel)
+analyticsPixelsForPackage name = asks $ Map.findWithDefault Set.empty name . analyticsPixels
+
+-- | Adds a 'AnalyticsPixel' to a 'Package'. Returns 'True' if the pixel was inserted, and 'False' if
+-- the 'AnalyticsPixel' was already present.
+addPackageAnalyticsPixel :: PackageName -> AnalyticsPixel -> Update AnalyticsPixelsState Bool
+addPackageAnalyticsPixel name analyticsPixel = do
+    state <- State.get
+    let (successfullyInserted, pixels) = Map.alterF insertAnalyticsPixel name (analyticsPixels state)
+    State.put (state { analyticsPixels = pixels })
+    pure successfullyInserted
+    where
+        insertAnalyticsPixel :: Maybe (Set AnalyticsPixel) -> (Bool, Maybe (Set AnalyticsPixel))
+        insertAnalyticsPixel Nothing = 
+            (True, Just (Set.singleton analyticsPixel))
+        insertAnalyticsPixel existingPixels@(Just pixels)
+            | analyticsPixel `Set.member` pixels = 
+                (False, existingPixels)
+            | otherwise = 
+                (True, Just (Set.insert analyticsPixel pixels))
+
+-- | Removes a 'AnalyticsPixel' from a 'Package'.
+removePackageAnalyticsPixel :: PackageName -> AnalyticsPixel -> Update AnalyticsPixelsState ()
+removePackageAnalyticsPixel name analyticsPixel = do
+    state <- State.get
+    let pixels = Map.alter removeAnalyticsPixel name (analyticsPixels state)
+    State.put (state { analyticsPixels = pixels })
+    pure ()
+    where
+        removeAnalyticsPixel Nothing =
+            Nothing
+        removeAnalyticsPixel (Just pixels) =
+            let pixels' = analyticsPixel `Set.delete` pixels in
+                if Set.null pixels' then Nothing else Just pixels'
+
+-- get and replace the entire state, for backups
+
+getAnalyticsPixelsState :: Query AnalyticsPixelsState AnalyticsPixelsState
+getAnalyticsPixelsState = ask
+
+replaceAnalyticsPixelsState :: AnalyticsPixelsState -> Update AnalyticsPixelsState ()
+replaceAnalyticsPixelsState = State.put
+
+makeAcidic
+  ''AnalyticsPixelsState
+  [ 'getAnalyticsPixelsState
+  , 'analyticsPixelsForPackage
+  , 'replaceAnalyticsPixelsState
+  , 'addPackageAnalyticsPixel
+  , 'removePackageAnalyticsPixel
+  ]

--- a/src/Distribution/Server/Features/Users.hs
+++ b/src/Distribution/Server/Features/Users.hs
@@ -157,6 +157,8 @@ data UserResource = UserResource {
     userPage :: Resource,
     -- | A user's password.
     passwordResource :: Resource,
+    -- | A user's package tracking pixels.
+    analyticsPixelsResource :: Resource,
     -- | A user's enabled status.
     enabledResource  :: Resource,
     -- | The admin group.
@@ -362,6 +364,7 @@ userFeature templates usersState adminsState
               , resourceGet  = [ ("", const (redirectUserManagement r)) ]
               }
       , passwordResource = resourceAt "/user/:username/password.:format"
+      , analyticsPixelsResource = resourceAt "/user/:username/analytics-pixels.:format"
                            --TODO: PUT
       , enabledResource  = (resourceAt "/user/:username/enabled.:format") {
             resourceDesc = [ (GET, "return if the user is enabled")

--- a/src/Distribution/Server/Framework/Templating.hs
+++ b/src/Distribution/Server/Framework/Templating.hs
@@ -52,6 +52,7 @@ import qualified Data.Aeson as JSON
 
 import Distribution.Package (PackageName, PackageIdentifier)
 import Distribution.Version (Version)
+import Distribution.Server.Users.Types (UserName)
 import Distribution.Text    (display)
 
 import Control.Monad (when)
@@ -120,6 +121,7 @@ instance ToSElem XHtml.Html where
 
 instance ToSElem URI               where toSElem = toSElem . show
 instance ToSElem PackageName       where toSElem = toSElem . display
+instance ToSElem UserName          where toSElem = toSElem . display
 instance ToSElem Version           where toSElem = toSElem . display
 instance ToSElem PackageIdentifier where toSElem = toSElem . display
 


### PR DESCRIPTION

## Summary

This PR adds support for package maintainers to attach analytics pixels to one or more of their packages in order to better understand the web traffic to their package pages on Hackage. Specifying an analytics pixel URL will result in Hackage automatically embedding the provided URL in an image tag on the main package page. 

## Context

This PR comes from a previous discussion that @aviaviavi, @gbaz, and the hackage-admin email group. The original suggestion for the direction in this PR came @davean, in discussion with the Haskell Foundation regarding approaches for introducing more analytical tools for maintainers within Hackage.

## What not in this PR

Support for analytics pixels to be embedded in generated Haddock documentation is a natural next step and can be included in a future PR.
