### PR TITLE
Small BuildClient fixes

### DIFF
--- a/exes/BuildClient.hs
+++ b/exes/BuildClient.hs
@@ -798,6 +798,7 @@ cabal opts cmd args moutput = do
                  : verbosityArgs
                 ++ args
     info verbosity $ unwords ("cabal":all_args)
+    createDirectoryIfMissing False $ installDirectory opts
     ph <- runProcess "cabal" all_args (Just $ installDirectory opts)
                         Nothing Nothing moutput moutput
     waitForProcess ph


### PR DESCRIPTION
The following commands were executed with ghcup configured to use 8.10.7.

I am trying to run a local hackage-server and upload a build report to it.

But an error occurs once trying to launch cabal:

```
$ cabal run hackage-server -- run --ip=0.0.0.0 --base-uri=http://janus-ux305ca.local:8080
$ cabal run hackage-build -- init http://janus-ux305ca.local:8080
$ cabal run hackage-build -- -vvv build transformers
Up to date
Initialising
cabal
--config-file=/home/janus/flipstone/hackage-server/build-cache/cabal-config
update
cabal: runProcess: chdir: does not exist (No such file or directory)
```

The first commit of this PR fixes this problem by creating the installDirectory before trying to cwd into it.

With that fix applied, the next run of the same command ends with

    Warning: (4,0,0) Bad Request

This is because `build-cache/cabal-config` contains:

    remote-repo: janus-ux305ca.local:http://janus-ux305ca.local:8080
    remote-repo-cache: build-cache/cached-tarballs

This is a problem because `runProcess` is called with the working directory set
to `installDirectory` (which will be `build-cache/tmp-install`). This relative
path to the `remote-repo-cache` is thus wrong when `cabal` is running. To fix
this, the second commit makes `writeCabalConfig` use an absolute path for
`remote-repo-cache` instead.
