### PR TITLE
Simplify getting all package names and use `itemCache` in Browse

### DIFF
--- a/src/Distribution/Server/Features/Browse.hs
+++ b/src/Distribution/Server/Features/Browse.hs
@@ -6,6 +6,7 @@ import Control.Monad.Except (ExceptT, liftIO, throwError)
 import Control.Monad.Trans.Class (lift)
 import Control.Monad.Trans.Except (except)
 import Data.ByteString.Lazy (ByteString)
+import qualified Data.Map as Map
 import Data.Time (getCurrentTime)
 
 import Data.Aeson (Value(Array), eitherDecode, object, toJSON, (.=))
@@ -14,9 +15,9 @@ import qualified Data.Vector as V
 
 import Distribution.Server.Features.Browse.ApplyFilter (applyFilter)
 import Distribution.Server.Features.Browse.Options (BrowseOptions(..), IsSearch(..))
-import Distribution.Server.Features.Core (CoreFeature(CoreFeature), queryGetPackageIndex, coreResource)
+import Distribution.Server.Features.Core (CoreFeature(CoreFeature), coreResource)
 import Distribution.Server.Features.Distro (DistroFeature)
-import Distribution.Server.Features.PackageList (ListFeature(ListFeature), makeItemList)
+import Distribution.Server.Features.PackageList (ListFeature(ListFeature), getAllLists, makeItemList)
 import Distribution.Server.Features.Search (SearchFeature(SearchFeature), searchPackages)
 import Distribution.Server.Features.Tags (TagsFeature(TagsFeature), tagsResource)
 import Distribution.Server.Features.Users (UserFeature(UserFeature), userResource)
@@ -24,7 +25,6 @@ import Distribution.Server.Framework.Error (ErrorResponse(ErrorResponse))
 import Distribution.Server.Framework.Feature (HackageFeature(..), emptyHackageFeature)
 import Distribution.Server.Framework.Resource (Resource(..), resourceAt)
 import Distribution.Server.Framework.ServerEnv (ServerEnv(..))
-import qualified Distribution.Server.Packages.PackageIndex as PackageIndex
 
 import Happstack.Server.Monads (ServerPartT)
 import Happstack.Server.Response (ToMessage(toResponse))
@@ -92,14 +92,18 @@ paginate PaginationConfig{totalNumberOfElements, pageNumber} = do
    )
 
 getNewPkgList :: CoreFeature -> UserFeature -> TagsFeature -> ListFeature -> SearchFeature -> DistroFeature -> ServerPartT (ExceptT ErrorResponse IO) Response
-getNewPkgList CoreFeature{queryGetPackageIndex, coreResource} UserFeature{userResource} TagsFeature{tagsResource} ListFeature{makeItemList} SearchFeature{searchPackages} distroFeature = do
+getNewPkgList CoreFeature{coreResource} UserFeature{userResource} TagsFeature{tagsResource} ListFeature{getAllLists, makeItemList} SearchFeature{searchPackages} distroFeature = do
   browseOptionsBS <- lookBS "browseOptions"
   browseOptions <- lift (parseBrowseOptions browseOptionsBS)
-  (isSearch, packageNames) <-
-    case boSearchTerms browseOptions of
-      [] ->    (IsNotSearch,) <$> PackageIndex.allPackageNames <$> queryGetPackageIndex
-      terms -> (IsSearch,)    <$> liftIO (searchPackages terms)
-  pkgDetails <- liftIO (makeItemList packageNames)
+  (isSearch, pkgDetails) <-
+    liftIO $ case boSearchTerms browseOptions of
+      [] -> do
+        allItemsMap <- getAllLists
+        pure (IsNotSearch, Map.elems allItemsMap)
+      terms -> do
+        packageNames <- searchPackages terms
+        items <- makeItemList packageNames
+        pure (IsSearch, items)
   now <- liftIO getCurrentTime
   listOfPkgs <- liftIO $ applyFilter now isSearch coreResource userResource tagsResource distroFeature browseOptions pkgDetails
   let config =

--- a/src/Distribution/Server/Features/Browse.hs
+++ b/src/Distribution/Server/Features/Browse.hs
@@ -24,7 +24,7 @@ import Distribution.Server.Framework.Error (ErrorResponse(ErrorResponse))
 import Distribution.Server.Framework.Feature (HackageFeature(..), emptyHackageFeature)
 import Distribution.Server.Framework.Resource (Resource(..), resourceAt)
 import Distribution.Server.Framework.ServerEnv (ServerEnv(..))
-import qualified Distribution.Server.Pages.Index as Pages
+import qualified Distribution.Server.Packages.PackageIndex as PackageIndex
 
 import Happstack.Server.Monads (ServerPartT)
 import Happstack.Server.Response (ToMessage(toResponse))
@@ -97,7 +97,7 @@ getNewPkgList CoreFeature{queryGetPackageIndex, coreResource} UserFeature{userRe
   browseOptions <- lift (parseBrowseOptions browseOptionsBS)
   (isSearch, packageNames) <-
     case boSearchTerms browseOptions of
-      [] ->    (IsNotSearch,) <$> Pages.toPackageNames <$> queryGetPackageIndex
+      [] ->    (IsNotSearch,) <$> PackageIndex.allPackageNames <$> queryGetPackageIndex
       terms -> (IsSearch,)    <$> liftIO (searchPackages terms)
   pkgDetails <- liftIO (makeItemList packageNames)
   now <- liftIO getCurrentTime

--- a/src/Distribution/Server/Features/Core.hs
+++ b/src/Distribution/Server/Features/Core.hs
@@ -683,8 +683,8 @@ coreFeature ServerEnv{serverBlobStore = store} UserFeature{..}
     servePackageList :: DynamicPath -> ServerPartE Response
     servePackageList _ = do
       pkgIndex <- queryGetPackageIndex
-      let pkgs = PackageIndex.allPackagesByName pkgIndex
-          list = [display . pkgName . pkgInfoId $ pkg | pkg <- map head pkgs]
+      let pkgNames = PackageIndex.allPackageNames pkgIndex
+          list = map display pkgNames
       -- We construct the JSON manually so that we control what it looks like;
       -- in particular, we use objects for the packages so that we can add
       -- additional fields later without (hopefully) breaking clients

--- a/src/Distribution/Server/Features/Tags.hs
+++ b/src/Distribution/Server/Features/Tags.hs
@@ -242,10 +242,8 @@ tagsFeature CoreFeature{ queryGetPackageIndex }
 
     -- tags on merging
     constructMergedTagIndex :: forall m. (Functor m, MonadIO m) => Tag -> Tag -> PackageIndex PkgInfo -> m PackageTags
-    constructMergedTagIndex orig depr = foldM addToTags emptyPackageTags . PackageIndex.allPackagesByName
-      where addToTags calcTags pkgList = do
-                let info = pkgDesc $ last pkgList
-                    !pn = packageName info
+    constructMergedTagIndex orig depr = foldM addToTags emptyPackageTags . PackageIndex.allPackageNames
+      where addToTags calcTags pn = do
                 pkgTags <- queryTagsForPackage pn
                 if Set.member depr pkgTags
                     then do

--- a/src/Distribution/Server/Packages/PackageIndex.hs
+++ b/src/Distribution/Server/Packages/PackageIndex.hs
@@ -42,6 +42,7 @@ module Distribution.Server.Packages.PackageIndex (
     searchByNameSubstring,
 
     -- ** Bulk queries
+    allPackageNames,
     allPackages,
     allPackagesByName
   ) where
@@ -256,6 +257,9 @@ allPackages (PackageIndex m) = concat (Map.elems m)
 --
 allPackagesByName :: Package pkg => PackageIndex pkg -> [[pkg]]
 allPackagesByName (PackageIndex m) = Map.elems m
+
+allPackageNames :: PackageIndex pkg -> [PackageName]
+allPackageNames (PackageIndex m) = Map.keys m
 
 --
 -- * Lookups

--- a/src/Distribution/Server/Pages/Index.hs
+++ b/src/Distribution/Server/Pages/Index.hs
@@ -1,6 +1,6 @@
 -- Generate an HTML page listing all available packages
 
-module Distribution.Server.Pages.Index (packageIndex, toPackageNames) where
+module Distribution.Server.Pages.Index (packageIndex) where
 
 import Distribution.Server.Pages.Template       ( hackagePage )
 import Distribution.Server.Pages.Util           ( packageType )
@@ -30,15 +30,6 @@ packageIndex = formatPkgGroups
                       . pkgDesc
                       . maximumBy (comparing packageVersion))
                  . PackageIndex.allPackagesByName
-
-toPackageNames :: PackageIndex.PackageIndex PkgInfo -> [PackageName]
-toPackageNames = map (pii_pkgName
-                      . mkPackageIndexInfo
-                      . flattenPackageDescription
-                      . pkgDesc
-                      . maximumBy (comparing packageVersion))
-                 . PackageIndex.allPackagesByName
-
 
 data PackageIndexInfo = PackageIndexInfo {
                             pii_pkgName :: !PackageName,


### PR DESCRIPTION
The first commit optimizes getting the list of all package names, by removing the highly inefficient `toPackageNames` and instead creating `allPackageNames` which uses the keys of a map instead of the values that `toPackageNames` was iterating over. This commit also introduces use of this new function in places where this is all we need.

The second commit optimizes the browse listing (i.e. not search), which was doing `n` map lookups using `makeItemList`, where `n` is the total amount of packages. This is now avoided by simply fetching pre-made `PackageItem`s using `getAllLists`. The speedup may not be large since the construction of these `PackageItem`s using `makeItemList` was already used in the search feature, and this branch wasn't reported to be slow.

Tested on my local Hackage instance, but not benchmarked properly yet.