### PR TITLE
Restore two-column layout for very wide viewports

### DIFF
--- a/datafiles/static/hackage.css
+++ b/datafiles/static/hackage.css
@@ -321,8 +321,11 @@ table.properties td, table.properties th {
        * = (100% - 40%                  ) * 60vw                - 2em
        * = 60%                            * 60vw                - 2em
        * = 36vw - 2em
+       *
+       * The 36vw only applies if the #content max-width of 1450px isn't hit.
+       * So we use min(...) for this special case.
        */
-      width: calc(36vw - 2em);
+      width: calc(min(36vw, .6 * 1450px) - 2em);
   }
 }
 
@@ -350,6 +353,7 @@ table.properties td, table.properties th {
   }
 
   #content {
+    /* keep this in sync with the calculation above */
     max-width: 1450px;
   }
 }


### PR DESCRIPTION
I failed to test for very wide viewports where the `#content` max-width of 1450px comes into play. In this case, the left-pane would be too wide, and the properties pane would be pushed down, as shown on the first screenshot.

Before this PR:
![Description block is 887px wide](https://user-images.githubusercontent.com/284023/161649249-8aed227d-6c74-4cfa-987b-d1757d570dbe.png)
The width of 887px is more than 60% of 1450px minus 2em (which equals 870px minus 2em), which means that there is no room for the properties pane. It would exceed that limit by even more as the screen grows larger (see later for how to reproduce).

This is fixed by using the `min(...)` CSS function to provide this upper limit. Now the two columns are used as expected:

![With this PR applied, the layout uses two columns as expected](https://user-images.githubusercontent.com/284023/161649840-d722e0b5-b6f6-4307-b2bf-bc043f6bf228.png)

To reproduce this, you can simply just zoom out using Control-Hyphen. This makes the pixel size smaller, which eventually triggers this problem.