### PR TITLE
Add search/browse form for users without JavaScript

### DIFF
--- a/datafiles/static/browse.js
+++ b/datafiles/static/browse.js
@@ -36,14 +36,18 @@ addEventListener('popstate', async (evt) => {
 });
 
 const get = () => new Promise((resolve,reject) => {
-    const formData = new FormData();
     const obj =
       {   page: state.page
-        , sort: {column: state.column, direction: state.direction}
+        , sortColumn: state.column
+        , sortDirection: state.direction
         , searchQuery: state.searchQuery
       };
-    formData.append('browseOptions', JSON.stringify(obj));
-    fetch('/packages/search', {method:'POST', body: formData}).then(async (response) => {
+    const fetchOptions =
+      {   method: 'POST'
+        , headers: {'content-type': 'application/json'}
+        , body: JSON.stringify(obj)
+      };
+    fetch('/packages/search', fetchOptions).then(async (response) => {
       if (!response.ok) {
         const el = d.querySelector("#fatalError");
         el.style.display = "block";

--- a/datafiles/templates/Html/browse.html.st
+++ b/datafiles/templates/Html/browse.html.st
@@ -159,104 +159,120 @@
       font-family: monospace;
     }
     </style>
+    <noscript>
+    <style>
+    .javaScriptOnly {
+      display: none;
+    }
+    </style>
+    </noscript>
   </head>
   <body>
     $hackagePageHeader()$
     <div id=content>
       <h1>$heading$</h1>
-      $content$
-      <div id=fatalError></div>
-      <form onsubmit="javascript: submitSearch(event)">
-      <input type=text id=searchQuery />
-      <input type=submit value="Search" />
-      </form>
-      <h3 id=toggleAdvanced>
-        <a aria-expanded=false aria-controls=advancedForm href="javascript: toggleAdvanced();">
-          <span id=chevron>&#x25B8;</span>
-          Advanced options
-        </a>
-      </h3>
-      <div id=advancedForm>
-      <form class=filterSuggestion onsubmit="javascript:appendDeprecated(event);"><input type=submit value=Append> <div>Also show deprecated packages</div></form>
-      <form class=filterSuggestion onsubmit="javascript:appendAgeOfLastUL(event);"><input type=submit value=Append><div><span>Last uploaded version younger than</span><input placeholder="e.g. 2y for 2 years" id=advAgeLastUL oninput="validateAgeOfLastUL();"></div></form>
-      <form class=filterSuggestion onsubmit="javascript:appendTag(event);"><input type=submit value=Append>        <div><span>Only show packages with tag</span><input id=advTag placeholder="e.g. bsd3" oninput="validateTag();"></div></form>
-      <form class=filterSuggestion onsubmit="javascript:appendRating(event);"><input type=submit value=Append>     <div><span>Rating greater than, or equal to</span><span id=sliderAndOutput><input id=advRatingSlider type=range min=0 max=3 step=.1 oninput="this.nextElementSibling.value = this.value" value=2><output>2</output></span></div></form>
-      <h5>Usage</h5>
-      <p>Apart from just writing words to search everywhere in package metadata,
-      you can also use filters in the search query string input field above.
-      Filters are surrounded by parentheses.
-      All filters have to pass for every package shown in the result,
-      that is, it is a
-      <a href="https://en.wikipedia.org/wiki/Logical_conjunction" target=_blank>
-      logical conjunction</a>.
-      </p>
-      <dl>
-        <dt>(downloads > 1000)</dt>
-        <dd>Only show packages with more than 1000 downloads within the last 30 days. The download count is inexact because Hackage uses a <a href="https://en.wikipedia.org/wiki/Content_delivery_network" target=_blank>content delivery network</a>.</dd>
-        <dt>(lastUpload &lt; 2021-10-29)</dt>
-        <dd>Only show packages for which the last upload was before (i.e. excluding) the given UTC date in <a target=_blank href="https://www.w3.org/TR/NOTE-datetime">the 'complete date' format as specified using ISO 8601</a>.</dd>
-        <dt>(lastUpload = 2021-10-29)</dt>
-        <dd>Only show packages for which the last upload was within the 24 hours of the given UTC date.</dd>
-        <dt>(maintainer:SimonMarlow)</dt>
-        <dd>Only show packages for which the maintainers list includes the user name <a target=_blank href="/user/SimonMarlow">SimonMarlow</a>.</dd>
-        <dt>(tag:bsd3)</dt>
-        <dd>Only show packages with the <code><a target=_blank href="/packages/tag/bsd3">bsd3</a></code> tag.</dd>
-        <dt>(not tag:network)</dt>
-        <dd>Do not show packages with the <code><a target=_blank href="/packages/tag/network">network</a></code> tag. The <code>not</code> operator can also be used with other filters.</dd>
-        <dt>(ageOfLastUpload > 5d)</dt>
-        <dd>Only show packages uploaded more than five days ago.</dd>
-        <dt>(ageOfLastUpload > 4w)</dt>
-        <dd>Only show packages uploaded more than four weeks ago. A week has seven days.</dd>
-        <dt>(ageOfLastUpload &lt; 1m)</dt>
-        <dd>Only show packages last uploaded less than one month ago. A month is considered to have 30.437 days.</dd>
-        <dt>(ageOfLastUpload &lt; 2.5y)</dt>
-        <dd>Only show packages last uploaded less than 2.5 years ago. A year is considered to be 365.25 days.</dd>
-        <dt>(rating > 2.5)</dt>
-        <dd>Only show packages with a rating of more than 2.5. The dot is the only accepted decimal separator.</dd>
-        <dt>(rating /= 0)</dt>
-        <dd>Only show packages with a rating unequal to zero.</dd>
-        <dt>(deprecated:any)</dt>
-        <dd>Do not filter out deprecated packages. This must be explicitly added if desired.</dd>
-        <dt>(deprecated:true)</dt>
-        <dd>Only show deprecated packages.</dd>
-        <dt>(deprecated:false)</dt>
-        <dd>Only show packages that are not deprecated. If no other deprecation filter is given, this filter is automatically added.</dd>
-        <dt>(distro:Debian)</dt>
-        <dd>Only show packages that are available in the Debian distribution. See the <a href="/distros">full list of available distributions</a>.</dd>
-      </dl>
-      </div>
-      <table id=browseTable class=fancy>
-        <thead>
-          <tr>
-            <th id=arrow-name><a href="javascript: sort('name')">Name</a></th>
-            <th id=arrow-downloads title="Over the last 30 days"><a href="javascript: sort('downloads')">DLs</a></th>
-            <th id=arrow-rating title="Ranges from 0 to 3"><a href="javascript: sort('rating')">Rating</a></th>
-            <th id=arrow-description><a href="javascript: sort('description')">Description</a></th>
-            <th id=arrow-tags><a href="javascript: sort('tags')">Tags</a></th>
-            <th id=arrow-lastUpload><a href="javascript: sort('lastUpload')">Last U/L</a></th>
-            <th id=arrow-maintainers><a href="javascript: sort('maintainers')">Maintainers</a></th>
-          </tr>
-        </thead>
-        <tbody id="listing"></tbody>
-      </table>
-      <script type=module>
-      import { sort, submitSearch, toggleAdvanced, appendDeprecated, appendAgeOfLastUL,
-               appendTag, appendRating, validateAgeOfLastUL, validateTag }
-             from "/static/browse.js";
-      window.sort = sort;
-      window.submitSearch = submitSearch;
-      window.toggleAdvanced = toggleAdvanced;
-      window.appendDeprecated = appendDeprecated;
-      window.appendAgeOfLastUL = appendAgeOfLastUL;
-      window.appendTag = appendTag;
-      window.appendRating = appendRating;
-      window.validateAgeOfLastUL = validateAgeOfLastUL;
-      window.validateTag = validateTag;
-      </script>
-      <div id=paginatorContainer>
-      </div>
-      <div id=browseFooter>
-      Alternatively, if you are looking for a particular function then try <a href="#" id=hoogleLink target=_blank>Hoogle</a>.
+      <noscript>
+        $formFragment$
+        <!-- Elinks does not understand CSS, so it will show the full page.
+             We add this warning such that users will not use the wrong form.
+             The class attribute hides the notice for Firefox/Chrome users.
+         -->
+        <p class=javaScriptOnly>Please disregard the following form, it only works with JavaScript.</p>
+      </noscript>
+      <div class=javaScriptOnly>
+        <div id=fatalError></div>
+        <form onsubmit="javascript: submitSearch(event)">
+        <input type=text id=searchQuery />
+        <input type=submit value="Search" />
+        </form>
+        <h3 id=toggleAdvanced>
+          <a aria-expanded=false aria-controls=advancedForm href="javascript: toggleAdvanced();">
+            <span id=chevron>&#x25B8;</span>
+            Advanced options
+          </a>
+        </h3>
+        <div id=advancedForm>
+        <form class=filterSuggestion onsubmit="javascript:appendDeprecated(event);"><input type=submit value=Append> <div>Also show deprecated packages</div></form>
+        <form class=filterSuggestion onsubmit="javascript:appendAgeOfLastUL(event);"><input type=submit value=Append><div><span>Last uploaded version younger than</span><input placeholder="e.g. 2y for 2 years" id=advAgeLastUL oninput="validateAgeOfLastUL();"></div></form>
+        <form class=filterSuggestion onsubmit="javascript:appendTag(event);"><input type=submit value=Append>        <div><span>Only show packages with tag</span><input id=advTag placeholder="e.g. bsd3" oninput="validateTag();"></div></form>
+        <form class=filterSuggestion onsubmit="javascript:appendRating(event);"><input type=submit value=Append>     <div><span>Rating greater than, or equal to</span><span id=sliderAndOutput><input id=advRatingSlider type=range min=0 max=3 step=.1 oninput="this.nextElementSibling.value = this.value" value=2><output>2</output></span></div></form>
+        <h5>Usage</h5>
+        <p>Apart from just writing words to search everywhere in package metadata,
+        you can also use filters in the search query string input field above.
+        Filters are surrounded by parentheses.
+        All filters have to pass for every package shown in the result,
+        that is, it is a
+        <a href="https://en.wikipedia.org/wiki/Logical_conjunction" target=_blank>
+        logical conjunction</a>.
+        </p>
+        <dl>
+          <dt>(downloads > 1000)</dt>
+          <dd>Only show packages with more than 1000 downloads within the last 30 days. The download count is inexact because Hackage uses a <a href="https://en.wikipedia.org/wiki/Content_delivery_network" target=_blank>content delivery network</a>.</dd>
+          <dt>(lastUpload &lt; 2021-10-29)</dt>
+          <dd>Only show packages for which the last upload was before (i.e. excluding) the given UTC date in <a target=_blank href="https://www.w3.org/TR/NOTE-datetime">the 'complete date' format as specified using ISO 8601</a>.</dd>
+          <dt>(lastUpload = 2021-10-29)</dt>
+          <dd>Only show packages for which the last upload was within the 24 hours of the given UTC date.</dd>
+          <dt>(maintainer:SimonMarlow)</dt>
+          <dd>Only show packages for which the maintainers list includes the user name <a target=_blank href="/user/SimonMarlow">SimonMarlow</a>.</dd>
+          <dt>(tag:bsd3)</dt>
+          <dd>Only show packages with the <code><a target=_blank href="/packages/tag/bsd3">bsd3</a></code> tag.</dd>
+          <dt>(not tag:network)</dt>
+          <dd>Do not show packages with the <code><a target=_blank href="/packages/tag/network">network</a></code> tag. The <code>not</code> operator can also be used with other filters.</dd>
+          <dt>(ageOfLastUpload > 5d)</dt>
+          <dd>Only show packages uploaded more than five days ago.</dd>
+          <dt>(ageOfLastUpload > 4w)</dt>
+          <dd>Only show packages uploaded more than four weeks ago. A week has seven days.</dd>
+          <dt>(ageOfLastUpload &lt; 1m)</dt>
+          <dd>Only show packages last uploaded less than one month ago. A month is considered to have 30.437 days.</dd>
+          <dt>(ageOfLastUpload &lt; 2.5y)</dt>
+          <dd>Only show packages last uploaded less than 2.5 years ago. A year is considered to be 365.25 days.</dd>
+          <dt>(rating > 2.5)</dt>
+          <dd>Only show packages with a rating of more than 2.5. The dot is the only accepted decimal separator.</dd>
+          <dt>(rating /= 0)</dt>
+          <dd>Only show packages with a rating unequal to zero.</dd>
+          <dt>(deprecated:any)</dt>
+          <dd>Do not filter out deprecated packages. This must be explicitly added if desired.</dd>
+          <dt>(deprecated:true)</dt>
+          <dd>Only show deprecated packages.</dd>
+          <dt>(deprecated:false)</dt>
+          <dd>Only show packages that are not deprecated. If no other deprecation filter is given, this filter is automatically added.</dd>
+          <dt>(distro:Debian)</dt>
+          <dd>Only show packages that are available in the Debian distribution. See the <a href="/distros">full list of available distributions</a>.</dd>
+        </dl>
+        </div>
+        <table id=browseTable class=fancy>
+          <thead>
+            <tr>
+              <th id=arrow-name><a href="javascript: sort('name')">Name</a></th>
+              <th id=arrow-downloads title="Over the last 30 days"><a href="javascript: sort('downloads')">DLs</a></th>
+              <th id=arrow-rating title="Ranges from 0 to 3"><a href="javascript: sort('rating')">Rating</a></th>
+              <th id=arrow-description><a href="javascript: sort('description')">Description</a></th>
+              <th id=arrow-tags><a href="javascript: sort('tags')">Tags</a></th>
+              <th id=arrow-lastUpload><a href="javascript: sort('lastUpload')">Last U/L</a></th>
+              <th id=arrow-maintainers><a href="javascript: sort('maintainers')">Maintainers</a></th>
+            </tr>
+          </thead>
+          <tbody id="listing"></tbody>
+        </table>
+        <script type=module>
+        import { sort, submitSearch, toggleAdvanced, appendDeprecated, appendAgeOfLastUL,
+                 appendTag, appendRating, validateAgeOfLastUL, validateTag }
+               from "/static/browse.js";
+        window.sort = sort;
+        window.submitSearch = submitSearch;
+        window.toggleAdvanced = toggleAdvanced;
+        window.appendDeprecated = appendDeprecated;
+        window.appendAgeOfLastUL = appendAgeOfLastUL;
+        window.appendTag = appendTag;
+        window.appendRating = appendRating;
+        window.validateAgeOfLastUL = validateAgeOfLastUL;
+        window.validateTag = validateTag;
+        </script>
+        <div id=paginatorContainer>
+        </div>
+        <div id=browseFooter>
+        Alternatively, if you are looking for a particular function then try <a href="#" id=hoogleLink target=_blank>Hoogle</a>.
+        </div>
       </div>
     </div>
   </body>

--- a/datafiles/templates/Html/noscript-next-page-form.html.st
+++ b/datafiles/templates/Html/noscript-next-page-form.html.st
@@ -1,0 +1,14 @@
+Showing $minIdx$ to $maxIdx$ of $total$ entries.
+$if(hasNext)$
+<form method='POST' enctype='multipart/form-data'>
+  <input type=hidden name='_method' value='POST'>
+  <input type=hidden name='_transform' value='form2json'>
+  <input type=hidden name='page=%n' value='$page$'>
+  <input type=hidden name='searchQuery=%s' value='$searchQuery$'>
+  <input type=hidden name='sortDirection=%s' value='$sortDirection$'>
+  <input type=hidden name='sortColumn=%s' value='$sortColumn$'>
+  <input type=submit value='Next page (page $page$)'>
+</form>
+$else$
+<p>There are no more pages of results for this query.
+$endif$

--- a/datafiles/templates/Html/noscript-search-form.html.st
+++ b/datafiles/templates/Html/noscript-search-form.html.st
@@ -1,0 +1,41 @@
+<p>To view all packages, submit the form with an empty search query.</p>
+<form method="POST" action="/packages/noscript-search" enctype="multipart/form-data">
+  <input type=hidden name="_method" value="POST">
+  <input type=hidden name="_transform" value="form2json">
+  <div>
+    <label>
+      Sort direction:
+      <select name="sortDirection=%s">
+        <option $if(ascending)$  selected $endif$ value=ascending>ascending</option>
+        <option $if(descending)$ selected $endif$ value=descending>descending</option>
+      </select>
+    </label>
+  </div>
+  <div>
+    <label>
+      Sort column:
+      <select name="sortColumn=%s">
+        <option $if(default)$     selected $endif$ value=default>default</option>
+        <option $if(name)$        selected $endif$ value=name>name</option>
+        <option $if(downloads)$   selected $endif$ value=downloads>number of downloads</option>
+        <option $if(rating)$      selected $endif$ value=rating>rating</option>
+        <option $if(description)$ selected $endif$ value=description>description</option>
+        <option $if(tags)$        selected $endif$ value=tags>tags</option>
+        <option $if(lastUpload)$  selected $endif$ value=lastUpload>date of last upload</option>
+        <option $if(maintainers)$ selected $endif$ value=maintainers>maintainers</option>
+      </select>
+    </label>
+  </div>
+  <div>
+    <label>
+      Search query (leave empty to show all non-deprecated packages):
+      <input name="searchQuery=%s" value="$searchQuery$">
+    </label>
+  </div>
+  <div>
+    <label>Page number (zero-indexed):
+      <input type=number name="page=%n" min=0 value="$pageNumber$">
+    </label>
+  </div>
+  <input type=submit>
+</form>

--- a/datafiles/templates/Html/table-interface.html.st
+++ b/datafiles/templates/Html/table-interface.html.st
@@ -3,10 +3,12 @@
 
     <head>
         $hackageCssTheme()$
+        $if(!noDatatable)$
         <script src="/static/jquery.min.js"></script>
         <link rel="stylesheet" type="text/css" href="https://cdn.datatables.net/v/dt/dt-1.11.4/sp-1.4.0/datatables.min.css"/>
 
         <script type="text/javascript" src="https://cdn.datatables.net/v/dt/dt-1.11.4/sp-1.4.0/datatables.min.js"></script>
+        $endif$
         <title>All packages by name | Hackage</title>
     </head>
 
@@ -24,7 +26,7 @@
                         <th><div style="width:50px"><span title="(0-3)">Rating</span></div></th>
                         <th><div style="min-width:160px">Description</div></th>
                         <th><div style="width:140px">Tags</div></th>
-                        <th><div style="width:80px">Last U/L</th>
+                        <th><div style="width:80px">Last U/L</div></th>
                         <th><div style="width:100px">Maintainer</div></th>
                     </tr>
                 </thead>
@@ -34,6 +36,7 @@
             </table>
             $footer$
         </div>
+        $if(!noDatatable)$
         <script>
             function filterGlobal() {
                 \$('#table').DataTable().search(
@@ -76,6 +79,7 @@
             });
 
         </script>
+        $endif$
     </body>
 
 </html>

--- a/src/Distribution/Server/Features.hs
+++ b/src/Distribution/Server/Features.hs
@@ -340,7 +340,8 @@ initHackageFeatures env@ServerEnv{serverVerbosity = verbosity} = do
                        listFeature
                        searchFeature
                        distroFeature
-                       
+                       candidatesFeature
+
     packageInfoJSONFeature <- mkPackageJSONFeature
                                 coreFeature
                                 versionsFeature

--- a/src/Distribution/Server/Features/Browse.hs
+++ b/src/Distribution/Server/Features/Browse.hs
@@ -1,35 +1,43 @@
 {-# LANGUAGE BlockArguments, NamedFieldPuns #-}
 module Distribution.Server.Features.Browse (initBrowseFeature, PaginationConfig(..), StartIndex(..), NumElems(..), paginate) where
 
-import Control.Arrow (left)
 import Control.Monad.Except (ExceptT, liftIO, throwError)
 import Control.Monad.Trans.Class (lift)
-import Control.Monad.Trans.Except (except)
-import Data.ByteString.Lazy (ByteString)
 import qualified Data.Map as Map
+import Data.Maybe (isJust)
+import qualified Data.Set as S
 import Data.Time (getCurrentTime)
+import Data.Time.Format.ISO8601 (iso8601Show)
+import System.FilePath ((</>))
 
-import Data.Aeson (Value(Array), eitherDecode, object, toJSON, (.=))
+import Data.Aeson (Value(Array), object, toJSON, (.=))
 import qualified Data.Aeson.Key as Key
 import qualified Data.Vector as V
+import Text.XHtml.Strict (renderHtmlFragment)
 
 import Distribution.Server.Features.Browse.ApplyFilter (applyFilter)
-import Distribution.Server.Features.Browse.Options (BrowseOptions(..), IsSearch(..))
-import Distribution.Server.Features.Core (CoreFeature(CoreFeature), coreResource)
+import Distribution.Server.Features.Browse.Options (BrowseOptions(..), IsSearch(..), Column(DefaultColumn), Direction(Ascending), columnToTemplateName, directionToTemplateName, parseSearchQuery)
+import Distribution.Server.Features.Core (CoreFeature(CoreFeature), CoreResource, coreResource, corePackageNameUri)
 import Distribution.Server.Features.Distro (DistroFeature)
-import Distribution.Server.Features.PackageList (ListFeature(ListFeature), getAllLists, makeItemList)
+import Distribution.Server.Features.Html.HtmlUtilities (HtmlUtilities(HtmlUtilities), htmlUtilities, makeRow)
+import Distribution.Server.Features.PackageCandidates (PackageCandidatesFeature)
+import Distribution.Server.Features.PackageList (ListFeature(ListFeature), PackageItem(..), getAllLists, makeItemList)
 import Distribution.Server.Features.Search (SearchFeature(SearchFeature), searchPackages)
-import Distribution.Server.Features.Tags (TagsFeature(TagsFeature), tagsResource)
-import Distribution.Server.Features.Users (UserFeature(UserFeature), userResource)
+import Distribution.Server.Features.Tags (Tag(..), TagsFeature(TagsFeature), TagsResource, tagUri, tagsResource)
+import Distribution.Server.Features.Users (UserFeature(UserFeature), UserResource, userResource, userPageUri)
 import Distribution.Server.Framework.Error (ErrorResponse(ErrorResponse))
 import Distribution.Server.Framework.Feature (HackageFeature(..), emptyHackageFeature)
+import Distribution.Server.Framework.RequestContentTypes (expectAesonContent)
 import Distribution.Server.Framework.Resource (Resource(..), resourceAt)
 import Distribution.Server.Framework.ServerEnv (ServerEnv(..))
+import Distribution.Server.Framework.Templating
+import Distribution.Server.Users.Types (UserName)
+import Distribution.Simple.Utils (toUTF8LBS)
+import Distribution.Text (display)
 
 import Happstack.Server.Monads (ServerPartT)
 import Happstack.Server.Response (ToMessage(toResponse))
-import Happstack.Server.RqData (lookBS)
-import Happstack.Server.Types (Method(POST), Response)
+import Happstack.Server.Types (Method(GET, POST), Response)
 
 type BrowseFeature =
     CoreFeature
@@ -38,21 +46,54 @@ type BrowseFeature =
     -> ListFeature
     -> SearchFeature
     -> DistroFeature
+    -> PackageCandidatesFeature
     -> IO HackageFeature
 
+data ResponseFormatWithMethod
+  = JSON_POST
+  | HTML_POST
+  | HTML_GET
+
 initBrowseFeature :: ServerEnv -> IO BrowseFeature
-initBrowseFeature _env =
-  pure \coreFeature userFeature tagsFeature listFeature searchFeature distroFeature ->
+initBrowseFeature ServerEnv{serverTemplatesDir, serverTemplatesMode} = do
+  templates <-
+    loadTemplates serverTemplatesMode
+      [ serverTemplatesDir, serverTemplatesDir </> "Html" ]
+      [ "table-interface.html"
+      , "noscript-search-form.html"
+      , "noscript-next-page-form.html"
+      ]
+  pure \coreFeature userFeature tagsFeature listFeature searchFeature distroFeature packageCandidatesFeature -> do
+    let
+      html = htmlUtilities coreFeature packageCandidatesFeature tagsFeature userFeature
+      renderer :: ResponseFormatWithMethod -> ServerPartT (ExceptT ErrorResponse IO) Response
+      renderer = renderResultPage coreFeature userFeature tagsFeature listFeature searchFeature distroFeature html templates
     pure $
-      (emptyHackageFeature "json")
+      (emptyHackageFeature "search/browse backend")
         { featureResources =
           [ (resourceAt "/packages/search")
             { resourceDesc =
-              [ (POST, "Browse and search using a BrowseOptions structure in multipart/form-data encoding")
+              [ (POST, "Browse and search for users with JavaScript enabled")
               ]
             , resourcePost =
               [ ("json"
-                , \_ -> getNewPkgList coreFeature userFeature tagsFeature listFeature searchFeature distroFeature
+                , \_ -> renderer JSON_POST
+                )
+              ]
+            }
+          , (resourceAt "/packages/noscript-search")
+            { resourceDesc =
+              [ (POST, "Browse and search for users without JavaScript enabled")
+              , (GET,  "Browse and search for users without JavaScript enabled")
+              ]
+            , resourcePost =
+              [ ("html"
+                , \_ -> renderer HTML_POST
+                )
+              ]
+            , resourceGet =
+              [ ("html"
+                , \_ -> renderer HTML_GET
                 )
               ]
             }
@@ -71,9 +112,11 @@ newtype NumElems = NumElems Int
 newtype StartIndex = StartIndex Int
   deriving (Eq, Show)
 
+pageSize :: Int
+pageSize = 50 -- make sure it is kept in sync with frontend
+
 paginate :: PaginationConfig -> Maybe (StartIndex, NumElems)
 paginate PaginationConfig{totalNumberOfElements, pageNumber} = do
- let pageSize = 50 -- make sure it is kept in sync with frontend
  startIndex <-
    if totalNumberOfElements <= pageNumber * pageSize
       then
@@ -91,25 +134,62 @@ paginate PaginationConfig{totalNumberOfElements, pageNumber} = do
          else pageSize
    )
 
-getNewPkgList :: CoreFeature -> UserFeature -> TagsFeature -> ListFeature -> SearchFeature -> DistroFeature -> ServerPartT (ExceptT ErrorResponse IO) Response
-getNewPkgList CoreFeature{coreResource} UserFeature{userResource} TagsFeature{tagsResource} ListFeature{getAllLists, makeItemList} SearchFeature{searchPackages} distroFeature = do
-  browseOptionsBS <- lookBS "browseOptions"
-  browseOptions <- lift (parseBrowseOptions browseOptionsBS)
+packageIndexInfoToValue :: CoreResource -> TagsResource -> UserResource -> PackageItem -> Value
+packageIndexInfoToValue
+  coreResource tagsResource userResource
+  PackageItem{itemName, itemDownloads, itemVotes,
+    itemDesc, itemTags, itemLastUpload, itemMaintainer} =
+  object
+    [ Key.fromString "name" .= renderPackage itemName
+    , Key.fromString "downloads" .= itemDownloads
+    , Key.fromString "votes" .= itemVotes
+    , Key.fromString "description" .= itemDesc
+    , Key.fromString "tags" .= map renderTag (S.toAscList itemTags)
+    , Key.fromString "lastUpload" .= iso8601Show itemLastUpload
+    , Key.fromString "maintainers" .= map renderUser itemMaintainer
+    ]
+  where
+  renderTag :: Tag -> Value
+  renderTag tag =
+    object
+      [ Key.fromString "uri" .= tagUri tagsResource "" tag
+      , Key.fromString "display" .= display tag
+      ]
+  renderUser :: UserName -> Value
+  renderUser user =
+    object
+      [ Key.fromString "uri" .= userPageUri userResource "" user
+      , Key.fromString "display" .= display user
+      ]
+  renderPackage pkg =
+    object
+      [ Key.fromString "uri" .= corePackageNameUri coreResource "" pkg
+      , Key.fromString "display" .= display pkg
+      ]
+
+renderResultPage :: CoreFeature -> UserFeature -> TagsFeature -> ListFeature -> SearchFeature -> DistroFeature -> HtmlUtilities -> Templates -> ResponseFormatWithMethod -> ServerPartT (ExceptT ErrorResponse IO) Response
+renderResultPage CoreFeature{coreResource} UserFeature{userResource} TagsFeature{tagsResource} ListFeature{getAllLists, makeItemList} SearchFeature{searchPackages} distroFeature HtmlUtilities{makeRow} templates format = do
+  browseOptions <-
+    case format of
+      HTML_GET -> pure (BrowseOptions 0 DefaultColumn Ascending mempty)
+      _        -> expectAesonContent
+  (filters, terms) <- parseSearchQuery (boSearchQuery browseOptions)
   (isSearch, pkgDetails) <-
-    liftIO $ case boSearchTerms browseOptions of
+    liftIO $ case terms of
       [] -> do
         allItemsMap <- getAllLists
         pure (IsNotSearch, Map.elems allItemsMap)
-      terms -> do
-        packageNames <- searchPackages terms
+      nonEmptyTerms -> do
+        packageNames <- searchPackages nonEmptyTerms
         items <- makeItemList packageNames
         pure (IsSearch, items)
   now <- liftIO getCurrentTime
-  listOfPkgs <- liftIO $ applyFilter now isSearch coreResource userResource tagsResource distroFeature browseOptions pkgDetails
-  let config =
+  listOfPkgs <- liftIO $ applyFilter now isSearch distroFeature (boSortColumn browseOptions) (boSortDirection browseOptions) filters pkgDetails
+  let page = fromIntegral (boPage browseOptions)
+      config =
         PaginationConfig
           { totalNumberOfElements = length listOfPkgs
-          , pageNumber = fromIntegral $ boPage browseOptions
+          , pageNumber = page
           }
   (StartIndex startIndex, NumElems numElems) <-
     lift $ maybe
@@ -117,17 +197,53 @@ getNewPkgList CoreFeature{coreResource} UserFeature{userResource} TagsFeature{ta
       pure
       (paginate config)
   let pageContents = V.slice startIndex numElems (V.fromList listOfPkgs)
-  pure . toResponse $
-    object
-      [ Key.fromString "pageContents" .= Array pageContents
-      , Key.fromString "numberOfResults" .= toJSON (length listOfPkgs)
-      ]
-
-parseBrowseOptions :: ByteString -> ExceptT ErrorResponse IO BrowseOptions
-parseBrowseOptions browseOptionsBS = except eiDecoded
-  where
-  eiDecoded :: Either ErrorResponse BrowseOptions
-  eiDecoded = left badRespFromString (eitherDecode browseOptionsBS)
+  case format of
+    JSON_POST ->
+      pure . toResponse $
+        object
+          [ Key.fromString "pageContents" .= Array (fmap (packageIndexInfoToValue coreResource tagsResource userResource) pageContents)
+          , Key.fromString "numberOfResults" .= toJSON (length listOfPkgs)
+          ]
+    _ -> do
+      template <- getTemplate templates "table-interface.html"
+      noscriptForm <- getTemplate templates "noscript-search-form.html"
+      nextPageForm <- getTemplate templates "noscript-next-page-form.html"
+      let
+        rowList = fmap makeRow pageContents
+        tabledata = toUTF8LBS . renderHtmlFragment $ V.toList rowList
+        noscriptFormRendered =
+          renderTemplate $ noscriptForm
+            [ directionToTemplateName (boSortDirection browseOptions) $= True
+            , columnToTemplateName (boSortColumn browseOptions) $= True
+            , "pageNumber" $= show page
+            , "searchQuery" $= boSearchQuery browseOptions
+            ]
+        minIdx = page * pageSize + 1;
+        maxIdx' = (page + 1) * pageSize
+        total = totalNumberOfElements config
+        hasNext = isJust (paginate config { pageNumber = page + 1})
+        maxIdx = min maxIdx' total
+        footer =
+          renderTemplate $
+            nextPageForm
+              [ "page" $= page + 1
+              , "searchQuery" $= boSearchQuery browseOptions
+              , "sortDirection" $= directionToTemplateName (boSortDirection browseOptions)
+              , "sortColumn" $= columnToTemplateName (boSortColumn browseOptions)
+              , "maxIdx" $= maxIdx
+              , "minIdx" $= minIdx
+              , "total" $= total
+              , "hasNext" $= hasNext
+              ]
+      pure . toResponse $ template
+        [ templateUnescaped "tabledata" tabledata
+        , templateUnescaped "content" noscriptFormRendered
+        , if total == 0
+             then "footer" $= "No results found."
+             else templateUnescaped "footer" footer
+        , "heading" $= "Search without JavaScript"
+        , "noDatatable" $= True
+        ]
 
 badRespFromString :: String -> ErrorResponse
 badRespFromString err = ErrorResponse 400 [] err []

--- a/src/Distribution/Server/Features/Browse/ApplyFilter.hs
+++ b/src/Distribution/Server/Features/Browse/ApplyFilter.hs
@@ -5,59 +5,21 @@ import Control.Monad (filterM)
 import Data.List (sortBy)
 import Data.Ord (comparing)
 import Data.Time.Clock (UTCTime(utctDay), diffUTCTime)
-import Data.Time.Format.ISO8601 (iso8601Show)
-
-import Data.Aeson (Value, (.=), object)
-import qualified Data.Aeson.Key as Key
 
 import qualified Data.Set as S
 
-import Distribution.Server.Features.Browse.Options (BrowseOptions(..), Direction(..), Column(..), Sort(..), NormalColumn(..), IsSearch(..))
+import Distribution.Server.Features.Browse.Options (Direction(..), Column(..), NormalColumn(..), IsSearch(..))
 import Distribution.Server.Features.Browse.Parsers (DeprecatedOption(..), Filter(..), operatorToFunction)
-import Distribution.Server.Features.Core (CoreResource, corePackageNameUri)
 import Distribution.Server.Features.Distro (DistroFeature(DistroFeature, queryPackageStatus))
 import Distribution.Server.Features.Distro.Types (DistroName(..))
 import Distribution.Server.Features.PackageList(PackageItem(..))
-import Distribution.Server.Features.Tags (Tag(..), TagsResource, tagUri)
-import Distribution.Server.Features.Users (UserResource, userPageUri)
-import Distribution.Server.Users.Types (UserName)
 import Distribution.Text (display)
 
-applyFilter :: UTCTime -> IsSearch -> CoreResource -> UserResource -> TagsResource -> DistroFeature -> BrowseOptions -> [PackageItem] -> IO [Value]
-applyFilter now isSearch coreResource userResource tagsResource DistroFeature{queryPackageStatus} browseOptions items = do
+applyFilter :: UTCTime -> IsSearch -> DistroFeature -> Column -> Direction -> [Filter] -> [PackageItem] -> IO [PackageItem]
+applyFilter now isSearch DistroFeature{queryPackageStatus} column direction filtersWithoutDefaults items = do
  packages <- filterM filterForItem items
- pure $
-   map packageIndexInfoToValue $
-   sort isSearch (boSort browseOptions) packages
+ pure (sort isSearch column direction packages)
  where
-  packageIndexInfoToValue :: PackageItem -> Value
-  packageIndexInfoToValue PackageItem{..} =
-    object
-      [ Key.fromString "name" .= renderPackage itemName
-      , Key.fromString "downloads" .= itemDownloads
-      , Key.fromString "votes" .= itemVotes
-      , Key.fromString "description" .= itemDesc
-      , Key.fromString "tags" .= map renderTag (S.toAscList itemTags)
-      , Key.fromString "lastUpload" .= iso8601Show itemLastUpload
-      , Key.fromString "maintainers" .= map renderUser itemMaintainer
-      ]
-  renderTag :: Tag -> Value
-  renderTag tag =
-    object
-      [ Key.fromString "uri" .= tagUri tagsResource "" tag
-      , Key.fromString "display" .= display tag
-      ]
-  renderUser :: UserName -> Value
-  renderUser user =
-    object
-      [ Key.fromString "uri" .= userPageUri userResource "" user
-      , Key.fromString "display" .= display user
-      ]
-  renderPackage pkg =
-    object
-      [ Key.fromString "uri" .= corePackageNameUri coreResource "" pkg
-      , Key.fromString "display" .= display pkg
-      ]
 
   includeItem :: PackageItem -> Filter -> IO Bool
   includeItem PackageItem{ itemDownloads }  (DownloadsFilter ( op, sndParam))    = pure $ operatorToFunction op (fromIntegral @Int @Word itemDownloads) sndParam
@@ -72,8 +34,6 @@ applyFilter now isSearch coreResource userResource tagsResource DistroFeature{qu
   includeItem PackageItem{ itemName }       (DistroFilter distroStr)             = elem (DistroName distroStr) . map fst <$> queryPackageStatus itemName
   includeItem packageItem (Not filt) = not <$> includeItem packageItem filt
 
-  filtersWithoutDefaults = boFilters browseOptions
-
   filtersWithDefaults =
     -- The lack of other filters means we don't care.
     -- But deprecated packages are excluded by default.
@@ -86,8 +46,8 @@ applyFilter now isSearch coreResource userResource tagsResource DistroFeature{qu
   filterForItem item =
     and <$> traverse (includeItem item) filtersWithDefaults
 
-sort :: IsSearch -> Sort -> [PackageItem] -> [PackageItem]
-sort isSearch Sort {sortColumn, sortDirection} =
+sort :: IsSearch -> Column -> Direction -> [PackageItem] -> [PackageItem]
+sort isSearch sortColumn sortDirection =
   case sortColumn of
     DefaultColumn ->
       case isSearch of


### PR DESCRIPTION
Fixes #1051. Tested in Elinks.

Note: best to view the diff with whitespace hidden. (click the cog on the "Files changed" tab)

This adds a new paginated package browse/search page at `/packages/noscript-search`. Users without JavaScript enabled are now suggested to go there from the regular search page. This new page allows for adjusting sort parameters with regular HTML form elements like `select` (drop down). It uses the same search engine and allows for filtering with the same language that the regular page does.