### PR TITLE
Default to HTML handler, not the first

### DIFF
--- a/src/Distribution/Server/Framework/Resource.hs
+++ b/src/Distribution/Server/Framework/Resource.hs
@@ -464,8 +464,14 @@ serveResource errRes (Resource _ rget rput rpost rdelete rformat rend _) = \dpat
                 Just answer -> handleErrors (Just format) $ answer dpath
                 Nothing -> mzero -- return 404 if the specific format is not found
                   -- return default response when format is empty or non-existent
-            _ -> do (format,answer) <- negotiateContent (head res) res
-                    handleErrors (Just format) $ answer dpath
+            _ -> do
+              let
+                contentResponsePair =
+                  case find ((== "html") . fst) res of
+                    Just x -> x
+                    Nothing -> head res
+              (format,answer) <- negotiateContent contentResponsePair res
+              handleErrors (Just format) $ answer dpath
 
     handleErrors format =
       handleErrorResponse (serveErrorResponse errRes format)


### PR DESCRIPTION
Before this commit, the first handler would be chosen as the default, in the absense of an Accept header from the client.

This means that Elinks gets the JSON version of the package page, because it
doesn't send an Accept header, this was reported by @Merivuokko in [a comment](https://github.com/haskell/hackage-server/issues/1051#issuecomment-1090669842).

After this commit, the package page is again defaulting to HTML:

    % curl -s -D - "http://localhost:8080/package/2captcha" | grep -i Content-type
    Content-Type: text/html; charset=utf-8
