### PR TITLE
Helpful error message on missing mirror group

### DIFF
--- a/src/Distribution/Client/Mirror/Session.hs
+++ b/src/Distribution/Client/Mirror/Session.hs
@@ -455,7 +455,9 @@ requestPUT uri mimetype body = do
       _       -> return (Just (mkErrorResponse uri rsp))
   where
     headers = [ Header HdrContentLength (show (BS.length body))
-              , Header HdrContentType mimetype ]
+              , Header HdrContentType mimetype
+              , Header HdrAccept "text/plain"
+              ]
 
 {-------------------------------------------------------------------------------
   Auxiliary functions used by HttpSession actions

--- a/src/Distribution/Server/Features/Mirror.hs
+++ b/src/Distribution/Server/Features/Mirror.hs
@@ -159,6 +159,8 @@ mirrorFeature ServerEnv{serverBlobStore = store}
         groupsAllowedToAdd    = [adminGroup]
     }
 
+    guardMirrorGroup = guardAuthorisedWhenInAnyGroup [mirrorGroup]
+    guardMirrorGroup_ = void guardMirrorGroup
 
     -- result: error from unpacking, bad request error, or warning lines
     --
@@ -169,7 +171,7 @@ mirrorFeature ServerEnv{serverBlobStore = store}
     --      http://localhost:8080/package/$PACKAGENAME/$PACKAGEID.tar.gz
     tarballPut :: DynamicPath -> ServerPartE Response
     tarballPut dpath = do
-        uid         <- guardAuthorised [InGroup mirrorGroup]
+        uid         <- guardMirrorGroup
         pkgid       <- packageTarballInPath dpath
         fileContent <- expectCompressedTarball
         time        <- liftIO getCurrentTime
@@ -202,7 +204,7 @@ mirrorFeature ServerEnv{serverBlobStore = store}
 
     uploaderPut :: DynamicPath -> ServerPartE Response
     uploaderPut dpath = do
-        guardAuthorised_ [InGroup mirrorGroup]
+        guardMirrorGroup_
         pkgid <- packageInPath dpath
         nameContent <- expectTextPlain
         let uname = UserName (unpackUTF8 nameContent)
@@ -225,7 +227,7 @@ mirrorFeature ServerEnv{serverBlobStore = store}
                 parseTimeMaybe "%c" timeStr
                 <|>  parseTimeMaybe "%Y-%m-%dT%H:%M:%SZ" timeStr
                 )
-        guardAuthorised_ [InGroup mirrorGroup]
+        guardMirrorGroup_
         pkgid <- packageInPath dpath
         timeContent <- expectTextPlain
         case altParseTimeMaybe (unpackUTF8 timeContent) of
@@ -239,7 +241,7 @@ mirrorFeature ServerEnv{serverBlobStore = store}
     -- return: error from parsing, bad request error, or warning lines
     cabalPut :: DynamicPath -> ServerPartE Response
     cabalPut dpath = do
-        uid <- guardAuthorised [InGroup mirrorGroup]
+        uid <- guardMirrorGroup
         pkgid :: PackageId <- packageInPath dpath
         fileContent <- expectTextPlain
         time <- liftIO getCurrentTime


### PR DESCRIPTION
Before this PR:

    mirroring 3d-graphics-examples-0.0.0.0
    hackage-mirror: Failed to upload package 3d-graphics-examples-0.0.0.0,
      HTTP error code 403, Forbidden 
      http://admin:...@localhost:8080/package/3d-graphics-examples-0.0.0.0/3d-graphics-examples.cabal

Not very helpful, since you can't see what kind of problem there was. Were the credentials wrong? It's hard to tell.

One problem is that the server doesn't know that the client wants the error
message as `text/plain`, so this PR adds this `Accept` header.

This PR also improves the generated message such that it includes the groups
against which the users' membership is checked. It is done by added a generic group checker
mechanism, that could potentially be used in more places. But for now, only the
mirror client uses this.

After this PR, the message is much improved:

    mirroring 3d-graphics-examples-0.0.0.0
    hackage-mirror: Failed to upload package 3d-graphics-examples-0.0.0.0,
      HTTP error code 403, Forbidden 
      http://admin:...@localhost:8080/package/3d-graphics-examples-0.0.0.0/3d-graphics-examples.cabal
      Error: Missing group membership
      
      Access denied, you must be member of either of the following groups: ["Mirror
      clients"]
