### PR TITLE
Fix incomplete-record-updates warnings

### DIFF
--- a/hackage-server.cabal
+++ b/hackage-server.cabal
@@ -129,7 +129,7 @@ common defaults
     , vector                ^>= 0.12
     , zlib                  ^>= 0.6.2
 
-  ghc-options: -Wall -fwarn-tabs -fno-warn-unused-do-bind -fno-warn-deprecated-flags -fwarn-incomplete-record-updates -funbox-strict-fields
+  ghc-options: -Wall -fwarn-tabs -fno-warn-unused-do-bind -fno-warn-deprecated-flags -funbox-strict-fields
 
   if impl(ghc >= 8.2)
     ghc-options: -Werror=incomplete-patterns -Werror=missing-methods

--- a/hackage-server.cabal
+++ b/hackage-server.cabal
@@ -129,7 +129,7 @@ common defaults
     , vector                ^>= 0.12
     , zlib                  ^>= 0.6.2
 
-  ghc-options: -Wall -fwarn-tabs -fno-warn-unused-do-bind -fno-warn-deprecated-flags -funbox-strict-fields
+  ghc-options: -Wall -fwarn-tabs -fno-warn-unused-do-bind -fno-warn-deprecated-flags -fwarn-incomplete-record-updates -funbox-strict-fields
 
   if impl(ghc >= 8.2)
     ghc-options: -Werror=incomplete-patterns -Werror=missing-methods

--- a/src/Distribution/Server/Features/Users.hs
+++ b/src/Distribution/Server/Features/Users.hs
@@ -495,7 +495,9 @@ userFeature templates usersState adminsState
           overrideResponse <- msum <$> runHook authFailHook err
           let resp' = fromMaybe defaultResponse overrideResponse
               -- reset authn to "0" on auth failures
-              resp'' = resp' { errorHeaders = ("Set-Cookie","authn=\"0\";Path=/;Version=\"1\""):errorHeaders resp' }
+              resp'' = case resp' of
+                ErrorResponse{..} -> ErrorResponse { errorHeaders = ("Set-Cookie","authn=\"0\";Path=/;Version=\"1\""):errorHeaders, .. }
+                GenericErrorResponse -> GenericErrorResponse
           throwError resp''
 
     -- Check if there is an authenticated userid, and return info, if so.

--- a/src/Distribution/Server/Features/Users.hs
+++ b/src/Distribution/Server/Features/Users.hs
@@ -496,7 +496,7 @@ userFeature templates usersState adminsState
           let resp' = fromMaybe defaultResponse overrideResponse
               -- reset authn to "0" on auth failures
               resp'' = case resp' of
-                ErrorResponse{..} -> ErrorResponse { errorHeaders = ("Set-Cookie","authn=\"0\";Path=/;Version=\"1\""):errorHeaders, .. }
+                r@ErrorResponse{} -> r { errorHeaders = ("Set-Cookie","authn=\"0\";Path=/;Version=\"1\""):errorHeaders r }
                 GenericErrorResponse -> GenericErrorResponse
           throwError resp''
 

--- a/src/Distribution/Server/Framework/Auth.hs
+++ b/src/Distribution/Server/Framework/Auth.hs
@@ -3,7 +3,7 @@
 -- We authenticate clients using HTTP Basic or Digest authentication and we
 -- authorise users based on membership of particular user groups.
 --
-{-# LANGUAGE PatternGuards #-}
+{-# LANGUAGE LambdaCase, PatternGuards #-}
 module Distribution.Server.Framework.Auth (
     -- * Checking authorisation
     guardAuthorised,
@@ -429,9 +429,10 @@ data AuthError = NoAuthError
 authErrorResponse :: MonadIO m => RealmName -> AuthError -> m ErrorResponse
 authErrorResponse realm autherr = do
     digestHeader <- liftIO (headerDigestAuthChallenge realm)
+
     let
       toErrorResponse :: AuthError -> ErrorResponse
-      toErrorResponse ae = case ae of
+      toErrorResponse = \case
         NoAuthError ->
           ErrorResponse 401 [digestHeader] "No authorization provided" []
 
@@ -448,7 +449,7 @@ authErrorResponse realm autherr = do
         BadApiKeyError ->
           ErrorResponse 401 [digestHeader] "Bad auth token" []
 
-      -- we don't want to leak info for the other cases, so same message for them all:
+        -- we don't want to leak info for the other cases, so same message for them all:
         _ ->
           ErrorResponse 401 [digestHeader] "Username or password incorrect" []
 

--- a/src/Distribution/Server/Framework/HappstackUtils.hs
+++ b/src/Distribution/Server/Framework/HappstackUtils.hs
@@ -1,4 +1,4 @@
-{-# LANGUAGE FlexibleContexts, RecordWildCards #-}
+{-# LANGUAGE FlexibleContexts #-}
 {-|
 
 Functions and combinators to expose functioanlity buiding
@@ -172,14 +172,14 @@ enableGZip compressParams modifyETag = do
   where
     gzipFilter :: Response -> Response
     gzipFilter r@SendFile{} = r -- Leave files alone
-    gzipFilter Response{..} =
+    gzipFilter r@Response{} =
         chunked
       . setHeader "Content-Encoding" "gzip"
       . setHeader "Vary" "Accept-Encoding"
       . removeResponseHeader "Content-Length"
       . removeResponseHeader "Content-MD5"
       . alterResponseHeader "ETag" (map modifyETag)
-      $ Response { rsBody = GZip.compressWith compressParams rsBody, .. }
+      $ r { rsBody = GZip.compressWith compressParams $ rsBody r }
 
 -- | Variation on 'enableGZip' with sensible defaults
 --
@@ -216,14 +216,12 @@ enableRange = do
     -- out the original length.
     rangeFilter :: (Int64, Int64) -> Response -> Response
     rangeFilter _ r@SendFile{} = r
-    rangeFilter (fr, to) r@Response{..} =
+    rangeFilter (fr, to) r@Response{} =
         setHeader "Content-Length" (show rangeLen)
       . setHeaderBS (BS.C8.pack "Content-Range") (contentRange fr to fullLen)
       . removeResponseHeader "Content-MD5"
-      $ Response
-          { rsBody = BS.Lazy.take rangeLen $ BS.Lazy.drop fr rsBody
+      $ r { rsBody = BS.Lazy.take rangeLen $ BS.Lazy.drop fr $ rsBody r
           , rsCode = 206
-          , ..
           }
       where
         rangeLen = to - fr + 1


### PR DESCRIPTION
Fixing some ghc warnings that show up in CI as discussed in https://github.com/haskell/hackage-server/pull/1056#issuecomment-1100179791

There are some issues in ghc with -fwarn-incomplete-record-updates giving false positives, e.g. 
https://gitlab.haskell.org/ghc/ghc/-/issues/5728
https://gitlab.haskell.org/ghc/ghc/-/issues/17783

Some of those should be fixed in recent versions of GHC (9+),
but we can avoid them even on GHC 8 by using RecordWildCards trick mentioned [here](https://gitlab.haskell.org/ghc/ghc/-/issues/5728#note_60108)
The other instances of this warning are fixed by restructuring the code a bit to make it more obvious to GHC that all cases are handled.

