### PR TITLE
Add instructions for native deps installation on Fedora

### DIFF
--- a/README.md
+++ b/README.md
@@ -65,6 +65,16 @@ You'll need to do the following to get `hackage-server`'s dependency `text-icu` 
         sudo apt update
         sudo apt install libbrotli-dev
 
+  - Fedora/CentOS
+
+        sudo dnf install brotli-devel
+
+#### openssl
+
+  - Fedora/CentOS
+
+      sudo dnf install openssl-devel
+
 #### zlib
 
   - Mac OS X


### PR DESCRIPTION
I don't insist on adding these instructions, but I had to install these native dependencies to be able to compile this project on Fedora.
Feel free to close this if you think the "installation instructions" section is getting to bloated.