### PR TITLE
Avoid top-level await, QuteBrowser compat

### DIFF
--- a/datafiles/static/browse.js
+++ b/datafiles/static/browse.js
@@ -395,4 +395,7 @@ export const appendRating = async (evt) => {
   await submitSearch();
 };
 
-await refresh();
+// Avoid top-level await since as of Apr 2022 it only has 84% penetration:
+// https://caniuse.com/?search=top%20level%20await
+// We don't need the result anyway.
+refresh();


### PR DESCRIPTION
We don't need this result anyway, so we may as well not await it.

I tested that this fixes QuteBrowser compatibility on NixOS 21.11. `qutebrowser
--version` reports using `QtWebEngine 5.18.8, based on Chromium 87.0.4280.144`.
This could guide future compatibility testing.

Reported by @jumper149.
