### PR TITLE
Use assert{Bool,Failure} from tasty-hunit

### DIFF
--- a/tests/PackageTestMain.hs
+++ b/tests/PackageTestMain.hs
@@ -10,13 +10,12 @@ import Data.List (isInfixOf)
 
 import qualified Codec.Archive.Tar as Tar
 import qualified Codec.Compression.GZip as GZip
-import qualified Test.HUnit as HUnit
 
 import Distribution.Server.Packages.Unpack
 import Distribution.Server.Packages.UnpackTest
 
 import Test.Tasty (defaultMain, TestTree, testGroup)
-import Test.Tasty.HUnit (testCase, Assertion, HasCallStack)
+import Test.Tasty.HUnit (assertBool, assertFailure, testCase, Assertion, HasCallStack)
 
 main :: IO ()
 main = defaultMain allTests
@@ -81,9 +80,9 @@ missingConfigureScriptTest =
   do tar <- tarGzFile "missing-configure-0.1.0.0"
      now <- getCurrentTime
      case unpackPackage now "missing-configure-0.1.0.0.tar.gz" tar of
-       Right _ -> HUnit.assertFailure "error: unexpected success"
+       Right _ -> assertFailure "error: unexpected success"
        Left err ->
-         HUnit.assertBool
+         assertBool
            ("Error found, but not about missing ./configure: " ++ err)
            ("The 'build-type' is 'Configure'" `isInfixOf` err)
 
@@ -94,9 +93,9 @@ badSpecVer =
   do tar <- tarGzFile "bad-specver-package-0"
      now <- getCurrentTime
      case unpackPackage now "bad-specver-package-0.tar.gz" tar of
-       Right _ -> HUnit.assertFailure "error: unexpected success"
+       Right _ -> assertFailure "error: unexpected success"
        Left err ->
-         HUnit.assertBool
+         assertBool
            ("Error found, but not about invalid spec version: " ++ err)
            ("cabal spec version" `isInfixOf` err)
 
@@ -146,7 +145,7 @@ successTestTGZ pkg tar = do
   case unpackPackage now (pkg ++ ".tar.gz") tar of
     Right _ -> return ()
     Left err ->
-      HUnit.assertFailure $ "Expected success, but got: " ++ show err
+      assertFailure $ "Expected success, but got: " ++ show err
 
 ---------------------------------------------------------------------------
 -- * Tar utilities


### PR DESCRIPTION
Use `assert{Bool,Failure}` from `tasty-hunit` rather than `hunit`.  Gives better error printing.

Before:
```
    Accept GHC 9.2 LANGUAGE extensions: FAIL
      Exception: HUnitFailure (Just (SrcLoc {srcLocPackage = "main", srcLocModule = "Main", srcLocFile = "tests/PackageTestMain.hs", srcLocStartLine = 118, srcLocStartCol = 34, srcLocEndLine = 118, srcLocEndCol = 45})) (Reason "Expected success, but got: \"Unknown extensions: GarbageBlargh\"")
```
After:
```
    Accept GHC 9.2 LANGUAGE extensions: FAIL
      tests/PackageTestMain.hs:117:
      Expected success, but got: "Unknown extensions: GarbageBlargh"
```

### Background

Following the discussion at https://github.com/UnkindPartition/tasty/issues/327#issuecomment-1108667339 :

@andreasabel wrote:
There is a `Show` instance for `HUnitFailure` which gives the _Haskell_ representation of this exception.  So far so good.

I am looking for a function that _pretty-prints_ the exception, for presentation to the user.
It should look nicer than what `Show` gives me:
```
      Exception: HUnitFailure (Just (SrcLoc {srcLocPackage = "main", srcLocModule = "Main", srcLocFile =
"tests/PackageTestMain.hs", srcLocStartLine = 127, srcLocStartCol = 3, srcLocEndLine = 127, srcLocEndCol =
17})) (Reason "Expected success but got: \"correct-package-0.1.0.0/correct-package.cabal:11:34: \\nunexpected
Unknown cabal spec version specified: 1.10123456\\nexpecting \\\".\\\", \\\"-\\\", white space, \\\"&&\\\" or \\\"||
\\\"\\n\"")
```

@VictorCMiraldo wrote:
I started working on this today but I couldn't reproduce the problem. Eventually I discovered that @andreasabel and I did  something wrong. What we did is some variation on:

```haskell
import qualified Test.HUnit as Raw
import qualified Test.Tasty.HUnit as Tasty

t1 = Tasty.testCase "Some Test" $ Raw.assertFailure "Omg"
```

The issue comes from the fact that `Raw.HUnitAssertion` is a different type altogether from [`Tasty.HUnitAssertion`](https://github.com/UnkindPartition/tasty/blob/16289a77495eb8279c5e544886ef52503becd148/hunit/Test/Tasty/HUnit/Orig.hs#L136). Because `Tasty.Assertion == Raw.Assertion == IO ()`, and failures are communicated through exceptions, we're bypassing the `try` on [`Tasty.HUnit.run`](https://github.com/UnkindPartition/tasty/blob/master/hunit/Test/Tasty/HUnit.hs#L102) and flagging the test as failed through a random exception, since that method is `try`ing on `Tasty.HUnitAssertion`.

The solution is to *not* depend on `HUnit`, depend exclusively on `tasty-hunit` and use the functions from there. Your test failures will be printed properly then.