### PR TITLE
Add uploaded_at field in package api

### DIFF
--- a/src/Distribution/Server/Features/PackageInfoJSON.hs
+++ b/src/Distribution/Server/Features/PackageInfoJSON.hs
@@ -53,6 +53,7 @@ import Distribution.Utils.ShortText (fromShortText)
 import Data.Foldable (toList)
 import Data.Traversable (for)
 import qualified Data.List as List
+import Data.Time (UTCTime)
 
 
 data PackageInfoJSONFeature = PackageInfoJSONFeature {
@@ -130,12 +131,14 @@ initPackageInfoJSONFeature env = do
 
 -- | Pure function for extracting basic package info from a Cabal file
 getBasicDescription
-  :: CabalFileText
+  :: UTCTime
+    -- ^ Time of upload
+  -> CabalFileText
   -> Int
      -- ^ Metadata revision. This will be added to the resulting
      --   @PackageBasicDescription@
   -> Either String PackageBasicDescription
-getBasicDescription (CabalFileText cf) metadataRev =
+getBasicDescription uploadedAt (CabalFileText cf) metadataRev =
   let parseResult = PkgDescr.parseGenericPackageDescription (BS.toStrict cf)
   in case PkgDescr.runParseResult parseResult of
     (_, Right pkg) -> let
@@ -148,6 +151,7 @@ getBasicDescription (CabalFileText cf) metadataRev =
                                 PkgDescr.licenseRaw pkgd
       pbd_homepage          = T.pack . fromShortText $ PkgDescr.homepage pkgd
       pbd_metadata_revision = metadataRev
+      pbd_uploaded_at = uploadedAt
       in
       return $ PackageBasicDescription {..}
     (_, Left (_, perrs)) ->
@@ -201,6 +205,7 @@ servePackageBasicDescription resource preferred packageInfoState dpath = do
       pkg <- lookupPackageId resource pkgid
 
       let metadataRevs = fst <$> pkgMetadataRevisions pkg
+          uploadInfos  = snd <$> pkgMetadataRevisions pkg
           nMetadata    = Vector.length metadataRevs
           metadataInd  = fromMaybe (nMetadata - 1) metadataRev
 
@@ -212,7 +217,8 @@ servePackageBasicDescription resource preferred packageInfoState dpath = do
         )
 
       let cabalFile = metadataRevs Vector.! metadataInd
-          pkgDescr  = getBasicDescription cabalFile metadataInd
+          uploadedAt = fst $ uploadInfos Vector.! metadataInd
+          pkgDescr  = getBasicDescription uploadedAt cabalFile metadataInd
       case pkgDescr of
         Left e  -> Framework.errInternalError [Framework.MText e]
         Right d -> return d

--- a/src/Distribution/Server/Features/PackageInfoJSON.hs
+++ b/src/Distribution/Server/Features/PackageInfoJSON.hs
@@ -151,7 +151,7 @@ getBasicDescription uploadedAt (CabalFileText cf) metadataRev =
                                 PkgDescr.licenseRaw pkgd
       pbd_homepage          = T.pack . fromShortText $ PkgDescr.homepage pkgd
       pbd_metadata_revision = metadataRev
-      pbd_uploaded_at = uploadedAt
+      pbd_uploaded_at       = uploadedAt
       in
       return $ PackageBasicDescription {..}
     (_, Left (_, perrs)) ->

--- a/src/Distribution/Server/Features/PackageInfoJSON/State.hs
+++ b/src/Distribution/Server/Features/PackageInfoJSON/State.hs
@@ -54,7 +54,7 @@ data PackageBasicDescription = PackageBasicDescription
   , pbd_author            :: !T.Text
   , pbd_homepage          :: !T.Text
   , pbd_metadata_revision :: !Int
-  , pbd_uploaded_at  :: !UTCTime
+  , pbd_uploaded_at       :: !UTCTime
   } deriving (Eq, Show, Generic)
 
 instance SafeCopy PackageBasicDescription where
@@ -79,7 +79,7 @@ instance SafeCopy PackageBasicDescription where
         pbd_author            <- T.decodeUtf8 <$> get
         pbd_homepage          <- T.decodeUtf8 <$> get
         pbd_metadata_revision <- get
-        pbd_uploaded_at <- safeGet
+        pbd_uploaded_at       <- safeGet
         return PackageBasicDescription{..}
 
 
@@ -113,7 +113,7 @@ instance Aeson.FromJSON PackageBasicDescription where
         pbd_author            <- obj .: Key.fromString "author"
         pbd_homepage          <- obj .: Key.fromString "homepage"
         pbd_metadata_revision <- obj .: Key.fromString "metadata_revision"
-        pbd_uploaded_at  <- obj .: Key.fromString "uploaded_at"
+        pbd_uploaded_at       <- obj .: Key.fromString "uploaded_at"
         return $
           PackageBasicDescription {..}
 


### PR DESCRIPTION
At present time, the information returned by the Package JSON API amounts to:

```json
{
    "author": "Hécate Moonlight",
    "copyright": "",
    "description": "The 'Display' typeclass provides a solution for user-facing output that does not have to abide by the rules of the Show typeclass.",
    "homepage": "https://github.com/haskell-text/text-display#readme",
    "license": "MIT",
    "metadata_revision": 0,
    "synopsis": "A typeclass for user-facing output"
}
```

This PR aims to implement support for the package upload timestamp in this payload.

The final result is this:

```json
{
    "author": "Hécate Moonlight",
    "copyright": "",
    "description": "The 'Display' typeclass provides a solution for user-facing output that does not have to abide by the rules of the Show typeclass.",
    "homepage": "https://github.com/haskell-text/text-display#readme",
    "license": "MIT",
    "metadata_revision": 0,
    "synopsis": "A typeclass for user-facing output",
    "uploaded_at": "2022-05-22T22:24:48.997120639Z"
}
```