### PR TITLE
use cache in Nix Shell Github Action

### DIFF
--- a/.github/workflows/nix-shell.yml
+++ b/.github/workflows/nix-shell.yml
@@ -1,13 +1,7 @@
-# https://nix.dev/tutorials/continuous-integration-github-actions
 name: "Test nix-shell"
 on:
-  push:
-    branches:
-    - '**'
-    paths-ignore: []
-  pull_request:
-    paths-ignore: []
-
+  - push
+  - pull_request
 jobs:
   nix-shell:
     runs-on: ubuntu-latest
@@ -16,4 +10,12 @@ jobs:
     - uses: cachix/install-nix-action@v16
       with:
         nix_path: nixpkgs=channel:nixos-21.11
+        extra_nix_config: |
+          trusted-public-keys = hydra.iohk.io:f/Ea+s+dFdN+3Y/G+FDgSq+a5NEWhJGzdjvKNGv0/EQ= cache.nixos.org-1:6NCHdD59X431o0gWypbMrAURkbJ16ZPMQFGspcDShjY=
+          substituters = https://hydra.iohk.io https://cache.nixos.org/
+    - uses: cachix/cachix-action@v10
+      with:
+        # https://nix.dev/tutorials/continuous-integration-github-actions#setting-up-github-actions
+        name: hackage-server
+        authToken: '${{ secrets.CACHIX_AUTH_TOKEN }}'
     - run: nix-shell --pure --run "cabal update && cabal build all --enable-tests"


### PR DESCRIPTION
Closes https://github.com/haskell/hackage-server/issues/1078

~The caching should begin to work when a Cachix account is created and `secrets.CACHIX_SIGNING_KEY` and `secrets.CACHIX_AUTH_TOKEN` are set in GitHub~ done

https://nix.dev/tutorials/continuous-integration-github-actions#setting-up-github-actions

https://github.com/haskell/hackage-server/issues/1078#issuecomment-1136488245

I've had no success with trying to get simple https://github.com/actions/cache working for this.


The auth key has been set. There is nothing in the cache yet.
Per this comment
https://github.com/cachix/cachix-action#security
> Pull requests do not have access to secrets so read access to a public binary cache will work, but pushing will be disabled since there is no signing key.
> Note that malicious code submitted via a pull request can, once merged into master, reveal the tokens.

I expect the cache will work and the GitHub Action will be fast after this PR is merged.