### PR TITLE
package page: Include virtual-modules in module tree

### DIFF
--- a/src/Distribution/Server/Packages/Render.hs
+++ b/src/Distribution/Server/Packages/Render.hs
@@ -149,6 +149,7 @@ doPackageRender users info = PackageRender
       = let mod_ix = mkForest $ exposedModules lib
                            -- Assumes that there is an HTML per reexport
                            ++ map moduleReexportName (reexportedModules lib)
+                           ++ virtualModules (libBuildInfo lib)
             sig_ix = mkForest $ signatures lib
             mkForest = moduleForest . map (\m -> (m, moduleHasDocs docindex m))
         in Just (ModSigIndex { modIndex = mod_ix, sigIndex = sig_ix })


### PR DESCRIPTION
The virtual-modules field is used by ghc-prim to provide a magic module
which doesn't exist on disk but still has documentation and so-on. By
including it here the module appears in the module list on the package
homepage.