### PR TITLE
attempt to speed up GitHub Action for Nix Shell

### DIFF
--- a/.github/workflows/nix-shell.yml
+++ b/.github/workflows/nix-shell.yml
@@ -13,15 +13,15 @@ jobs:
     runs-on: ubuntu-latest
     steps:
     - uses: actions/checkout@v2.4.0
-    - uses: cachix/install-nix-action@v16
+    - uses: cachix/install-nix-action@v17
       with:
         nix_path: nixpkgs=channel:nixos-21.11
         extra_nix_config: |
-          trusted-public-keys = hydra.iohk.io:f/Ea+s+dFdN+3Y/G+FDgSq+a5NEWhJGzdjvKNGv0/EQ= cache.nixos.org-1:6NCHdD59X431o0gWypbMrAURkbJ16ZPMQFGspcDShjY=
-          substituters = https://hydra.iohk.io https://cache.nixos.org/
+          trusted-public-keys = hydra.iohk.io:f/Ea+s+dFdN+3Y/G+FDgSq+a5NEWhJGzdjvKNGv0/EQ= cache.nixos.org-1:6NCHdD59X431o0gWypbMrAURkbJ16ZPMQFGspcDShjY= hackage-server.cachix.org-1:iw0iRh6+gsFIrxROFaAt5gKNgIHejKjIfyRdbpPYevY=
+          substituters = https://hydra.iohk.io https://cache.nixos.org/ https://hackage-server.cachix.org/
     - uses: cachix/cachix-action@v10
       with:
         # https://nix.dev/tutorials/continuous-integration-github-actions#setting-up-github-actions
         name: hackage-server
         authToken: '${{ secrets.CACHIX_AUTH_TOKEN }}'
-    - run: nix-shell --pure --run "cabal update && cabal build all --enable-tests"
+    - run: nix-shell --pure --run ./.github/workflows/test-nix-shell.sh

--- a/.github/workflows/test-nix-shell.sh
+++ b/.github/workflows/test-nix-shell.sh
@@ -1,0 +1,4 @@
+#!/bin/bash
+
+cabal update hackage.haskell.org,2022-08-27T00:00:00Z
+cabal build all --enable-tests


### PR DESCRIPTION
https://github.com/haskell/hackage-server/issues/1078

Unsure if this will work.
It appears `cabal update` is necessary but makes the cache unusable. Maybe using a specific date will avoid this:
https://github.com/haskell/hackage-server/blob/9142bb53a3fdd206504a4dddca1a7ad03989f0e9/.github/workflows/test-nix-shell.sh#L3