### PR TITLE
Fix analyticsPixel template variable name

### DIFF
--- a/src/Distribution/Server/Features/Html.hs
+++ b/src/Distribution/Server/Features/Html.hs
@@ -1918,7 +1918,7 @@ mkHtmlAnalyticsPixels HtmlUtilities{..} CoreFeature{..} UserFeature{..} UploadFe
         template <- getTemplate templates "analytics-pixels-page.html"
         return $ toResponse $ template
             [ "pkgname" $= pkgname,
-              "AnalyticsPixels" $= map analyticsPixelUrl (Set.toList analyticsPixels)
+              "analyticsPixels" $= map analyticsPixelUrl (Set.toList analyticsPixels)
             ]
 
     userPackagesAnalyticsPixelsHtml :: UserName -> ServerPartE Response


### PR DESCRIPTION
This PR addressess @gbaz's comment 

> I merged in preperation for a redeploy, but noticed in testing that the list of pixels already created did not show up properly 
> in the package page. (It does show up in the page that lists all pixels for all packages for a user). So I'm going to comment > out links to this functionality for now in the release. A patch fixing that up would be welcome.

in https://github.com/haskell/hackage-server/pull/1042#issuecomment-1126827553

