### PR TITLE
Updated accepted licenses

### DIFF
--- a/src/Distribution/Server/Packages/Unpack.hs
+++ b/src/Distribution/Server/Packages/Unpack.hs
@@ -42,6 +42,7 @@ import Distribution.Text
 -- import qualified Distribution.Compat.CharParsing as P
 import Distribution.Server.Util.ParseSpecVer
 import qualified Distribution.SPDX as SPDX
+import qualified Distribution.SPDX.LicenseId as SPDX.LId
 import qualified Distribution.License as License
 
 import Control.Monad.Except
@@ -492,7 +493,7 @@ isAcceptableLicense = either goSpdx goLegacy . licenseRaw
         goSimple (SPDX.ELicenseRef _)      = False -- don't allow referenced licenses
         goSimple (SPDX.ELicenseIdPlus _)   = False -- don't allow + licenses (use GPL-3.0-or-later e.g.)
         goSimple (SPDX.ELicenseId SPDX.CC0_1_0) = True -- CC0 isn't OSI approved, but we allow it as "PublicDomain", this is eg. PublicDomain in http://hackage.haskell.org/package/string-qq-0.0.2/src/LICENSE
-        goSimple (SPDX.ELicenseId lid)     = SPDX.licenseIsOsiApproved lid -- allow only OSI approved licenses.
+        goSimple (SPDX.ELicenseId lid)     = SPDX.licenseIsOsiApproved lid || SPDX.LId.licenseIsFsfLibre lid -- allow only OSI or FSF approved licenses.
 
     -- pre `cabal-version: 2.2`
     goLegacy License.AllRightsReserved = False


### PR DESCRIPTION
Added licenseIsFsfLibre to accepted licenses

Have imported Distribution.SPDX.LicenseId as SPDX.LId (to get the licenseIsFsfLibre function)

Not sure what coding style is used

Closes #745 