### PR TITLE
Link to last working doc

### DIFF
--- a/datafiles/templates/Html/package-page.html.st
+++ b/datafiles/templates/Html/package-page.html.st
@@ -114,9 +114,6 @@
             <tr>
               <th>Versions <span style="font-weight:normal;font-size: small;">[<a href="/package/$package.name$.rss">RSS</a>]</span></th>
               <td>$versions$</td>
-              $if(! hasDocs)$
-                <td class="word-wrap">$lastDoc$</td>
-              $endif$
             </tr>
 
             $if(package.optional.hasChangelog)$

--- a/src/Distribution/Server/Features.hs
+++ b/src/Distribution/Server/Features.hs
@@ -230,6 +230,17 @@ initHackageFeatures env@ServerEnv{serverVerbosity = verbosity} = do
                          uploadFeature
                          (candidatesCoreResource candidatesFeature)
 
+    tagsFeature     <- mkTagsFeature
+                         coreFeature
+                         uploadFeature
+                         usersFeature
+
+    versionsFeature <- mkVersionsFeature
+                         coreFeature
+                         uploadFeature
+                         tagsFeature
+                         usersFeature
+
     documentationCoreFeature <- mkDocumentationCoreFeature
                          (coreResource coreFeature)
                          (map packageId . allPackages <$> queryGetPackageIndex coreFeature)
@@ -237,6 +248,7 @@ initHackageFeatures env@ServerEnv{serverVerbosity = verbosity} = do
                          tarIndexCacheFeature
                          reportsCoreFeature
                          usersFeature
+                         versionsFeature
 
     documentationCandidatesFeature <- mkDocumentationCandidatesFeature
                          (candidatesCoreResource candidatesFeature)
@@ -245,6 +257,7 @@ initHackageFeatures env@ServerEnv{serverVerbosity = verbosity} = do
                          tarIndexCacheFeature
                          reportsCandidatesFeature
                          usersFeature
+                         versionsFeature
 
     downloadFeature <- mkDownloadFeature
                          coreFeature
@@ -254,21 +267,10 @@ initHackageFeatures env@ServerEnv{serverVerbosity = verbosity} = do
                            coreFeature
                            usersFeature
 
-    tagsFeature     <- mkTagsFeature
-                         coreFeature
-                         uploadFeature
-                         usersFeature
-
     analyticsPixelsFeature <- mkAnalyticsPixelsFeature
                                coreFeature
                                usersFeature
                                uploadFeature
-
-    versionsFeature <- mkVersionsFeature
-                         coreFeature
-                         uploadFeature
-                         tagsFeature
-                         usersFeature
 
     {- [reverse index disabled]
     reverseFeature  <- mkReverseFeature

--- a/src/Distribution/Server/Features/Documentation.hs
+++ b/src/Distribution/Server/Features/Documentation.hs
@@ -156,16 +156,14 @@ documentationFeature name
                        , guardValidPackageId
                        , corePackagePage
                        , corePackagesPage
+                       , lookupPackageName
                        }
                      getPackages
                      UploadFeature{..}
                      TarIndexCacheFeature{cachedTarIndex}
                      ReportsFeature{..}
                      UserFeature{ guardAuthorised_ }
-                     VersionsFeature
-                        { queryGetPreferredInfo
-                        , withPackagePreferred
-                        }
+                     VersionsFeature{queryGetPreferredInfo}
                      documentationState
                      documentationChangeHook
   = DocumentationFeature{..}
@@ -391,7 +389,8 @@ documentationFeature name
 
       case pkgVersion pkgid == nullVersion of
         -- if no version is given we want to redirect to the latest version with docs
-        True -> withPackagePreferred pkgid $ \_ pkgs -> do
+        True -> do
+            pkgs <- lookupPackageName (pkgName pkgid)
             prefInfo <- queryGetPreferredInfo (pkgName pkgid)
             findLastVerWithDoc queryHasDocumentation prefInfo pkgs >>= \case
               Just (latestWithDocs, _) -> do
@@ -454,7 +453,7 @@ findLastVerWithDoc queryHasDoc prefInfo ps = helper (reverse ps)
     helper (pkg:pkgs) = do
       hasDoc <- queryHasDoc (pkgInfoId pkg)
       let status = getVersionStatus prefInfo (packageVersion pkg)
-      if hasDoc && status /= DeprecatedVersion 
+      if hasDoc && status == NormalVersion 
           then pure (Just (packageId pkg, status)) 
           else helper pkgs
 

--- a/src/Distribution/Server/Features/Html.hs
+++ b/src/Distribution/Server/Features/Html.hs
@@ -604,6 +604,7 @@ mkHtmlCore ServerEnv{serverBaseURI, serverBlobStore}
         deprs         <- queryGetDeprecatedFor pkgname
         mreadme       <- makeReadme render
         hasDocs       <- queryHasDocumentation documentationFeature realpkg
+        eachHasDocs   <- traverse (queryHasDocumentation documentationFeature . pkgInfoId) pkgs
         rptStats      <- queryLastReportStats reportsFeature realpkg
         candidates    <- lookupCandidateName pkgname
         buildStatus   <- renderBuildStatus
@@ -642,8 +643,10 @@ mkHtmlCore ServerEnv{serverBaseURI, serverBlobStore}
           , "cabalVersion"      $= display cabalVersion
           , "tags"              $= (renderTags tags)
           , "analyticsPixels"   $= map analyticsPixelUrl (Set.toList analyticsPixels)
-          , "versions"          $= (PagesNew.renderVersion realpkg
-              (classifyVersions prefInfo $ map packageVersion pkgs) infoUrl)
+          , "versions"          $= PagesNew.renderVersionWithDocs 
+                                      realpkg
+                                      (zip (classifyVersions prefInfo $ map packageVersion pkgs) (map Just eachHasDocs))
+                                      infoUrl
           , "totalDownloads"    $= totalDown
           , "hasexecs"          $= not (null execs)
           , "recentDownloads"   $= recentDown

--- a/src/Distribution/Server/Features/Html.hs
+++ b/src/Distribution/Server/Features/Html.hs
@@ -593,15 +593,6 @@ mkHtmlCore ServerEnv{serverBaseURI, serverBlobStore}
             pkgdesc = flattenPackageDescription $ pkgDesc pkg
 
         prefInfo      <- queryGetPreferredInfo pkgname
-
-        -- let findLastDocVer [] = pure Nothing
-        --     findLastDocVer (pkg':pkgs') = do
-        --         hasDoc <- queryHasDocumentation documentationFeature (pkgInfoId pkg')
-        --         let status = getVersionStatus prefInfo (packageVersion pkg')
-        --         if hasDoc && status /= DeprecatedVersion 
-        --             then pure (Just (packageVersion pkg', status)) 
-        --             else findLastDocVer pkgs'
-
         distributions <- queryPackageStatus pkgname
         totalDown     <- cmFind pkgname `liftM` totalPackageDownloads
         recentDown    <- cmFind pkgname `liftM` recentPackageDownloads
@@ -614,7 +605,7 @@ mkHtmlCore ServerEnv{serverBaseURI, serverBlobStore}
         deprs         <- queryGetDeprecatedFor pkgname
         mreadme       <- makeReadme render
         hasDocs       <- queryHasDocumentation documentationFeature realpkg
-        lastVerWithDoc<- findLastVerWithDoc (queryHasDocumentation documentationFeature) prefInfo (reverse pkgs)
+        lastVerWithDoc<- findLastVerWithDoc (queryHasDocumentation documentationFeature) prefInfo pkgs
         rptStats      <- queryLastReportStats reportsFeature realpkg
         candidates    <- lookupCandidateName pkgname
         buildStatus   <- renderBuildStatus

--- a/src/Distribution/Server/Features/Html.hs
+++ b/src/Distribution/Server/Features/Html.hs
@@ -604,8 +604,8 @@ mkHtmlCore ServerEnv{serverBaseURI, serverBlobStore}
         deprs         <- queryGetDeprecatedFor pkgname
         mreadme       <- makeReadme render
         hasDocs       <- queryHasDocumentation documentationFeature realpkg
-        mDocPkgId     <- if hasDocs then pure Nothing 
-                              else findLastVerWithDoc (queryHasDocumentation documentationFeature) prefInfo pkgs
+        mDocPkgId     <- if hasDocs then pure Nothing
+                              else latestPackageWithDocumentation documentationFeature prefInfo pkgs
         rptStats      <- queryLastReportStats reportsFeature realpkg
         candidates    <- lookupCandidateName pkgname
         buildStatus   <- renderBuildStatus


### PR DESCRIPTION
This pull request implements issue #668 as an GSoC project, mentored by @gbaz. It adds an indicator for each package version with a working doc. It looks like this, where version `0.1.0` has doc but `0.1.1` not:

![Screenshot_20220708_164253](https://user-images.githubusercontent.com/42169770/177953846-b417c3e8-fecd-4e63-b781-780f1b54376a.png)

Actually I'm not very satisfied with the UI and am expecting a better idea.

This is my first time contributing here, so if I did something wrong in code style or structure please point it out.
