### PR TITLE
Revert "add GA tag"

### DIFF
--- a/datafiles/templates/hackageCssTheme.st
+++ b/datafiles/templates/hackageCssTheme.st
@@ -3,13 +3,3 @@
 <link rel="stylesheet" href="/static/hackage.css" type="text/css" />
 <link rel="icon" type="image/png" href="/static/favicon.png" />
 <link rel="search" type="application/opensearchdescription+xml" title="Hackage" href="/packages/opensearch.xml" />
-<!-- Global site tag (gtag.js) - Google Analytics -->
-<script async src="https://www.googletagmanager.com/gtag/js?id=UA-83290513-3"></script>
-<script>
-  window.dataLayer = window.dataLayer || [];
-  function gtag(){dataLayer.push(arguments);}
-  gtag('js', new Date());
-
-  gtag('config', 'UA-83290513-3');
-</script>
-


### PR DESCRIPTION
This reverts commit 95826dfa47396d223ad58df91c53ce56fdb283a1.

The use of Google Analytics [has been declared unlawful in three EU countries](https://noyb.eu/en/update-further-eu-dpa-orders-stop-google-analytics) already, with probably more to follow.
Keeping it there is a huge liability.