### PR TITLE
List maintainers on package page

### DIFF
--- a/datafiles/templates/Html/candidate-page.html.st
+++ b/datafiles/templates/Html/candidate-page.html.st
@@ -130,6 +130,12 @@
     $downloadSection$
 
     <h4>Maintainer's Corner</h4>
+    <p>Maintainers</p>
+    <ul>
+      <li>
+        $maintainers$
+      </li>
+    </ul>
     <p>For package maintainers and hackage trustees</p>
     <ul>
       <li>

--- a/datafiles/templates/Html/candidate-page.html.st
+++ b/datafiles/templates/Html/candidate-page.html.st
@@ -130,7 +130,7 @@
     $downloadSection$
 
     <h4>Maintainer's Corner</h4>
-    <p>Maintainers</p>
+    <p>Package maintainers</p>
     <ul>
       <li>
         $maintainers$

--- a/datafiles/templates/Html/package-page.html.st
+++ b/datafiles/templates/Html/package-page.html.st
@@ -88,13 +88,13 @@
 
         <div id="maintainer-corner">
           <h4>Maintainer's Corner</h4>
-          <p>Maintainers</p>
+          <p><a href="$package.maintainerURL$">Package maintainers</a></p>
           <ul>
             <li>
               $maintainers$
             </li>
           </ul>
-          <p>For $package.maintainerURL$ and hackage trustees</p>
+          <p>For package maintainers and hackage trustees</p>
           <ul>
             <li>
               <a href="$baseurl$/package/$package.name$/maintain">

--- a/datafiles/templates/Html/package-page.html.st
+++ b/datafiles/templates/Html/package-page.html.st
@@ -88,6 +88,12 @@
 
         <div id="maintainer-corner">
           <h4>Maintainer's Corner</h4>
+          <p>Maintainers</p>
+          <ul>
+            <li>
+              $maintainers$
+            </li>
+          </ul>
           <p>For $package.maintainerURL$ and hackage trustees</p>
           <ul>
             <li>

--- a/src/Distribution/Server/Pages/Group.hs
+++ b/src/Distribution/Server/Pages/Group.hs
@@ -70,11 +70,11 @@ removeUser uname uri =
     ]
 
 listGroup :: [Users.UserName] -> Maybe String -> Html
-listGroup [] _ = p << "No member exist presently"
+listGroup [] _ = p << "No current members of group"
 listGroup users muri = unordList (map (displayName muri) users)
 
 listGroupCompact :: [Users.UserName] -> Html
-listGroupCompact [] = toHtml "No member exist presently"
+listGroupCompact [] = toHtml "No current members of group"
 listGroupCompact users = foldr1 (\a b -> a +++ ", " +++ b) (map (displayName Nothing) users)
 
 displayName :: Maybe String -> Users.UserName -> Html

--- a/src/Distribution/Server/Pages/Group.hs
+++ b/src/Distribution/Server/Pages/Group.hs
@@ -71,11 +71,12 @@ removeUser uname uri =
 
 listGroup :: [Users.UserName] -> Maybe String -> Html
 listGroup [] _ = p << "No member exist presently"
-listGroup users muri = unordList (map displayName users)
-  where displayName uname = (anchor ! [href $ "/user/" ++ display uname] << display uname) +++
-                            maybe [] (removeUser uname) muri
+listGroup users muri = unordList (map (displayName muri) users)
 
 listGroupCompact :: [Users.UserName] -> Html
 listGroupCompact [] = toHtml "No member exist presently"
-listGroupCompact users = foldr1 (\a b -> a +++ ", " +++ b) (map displayName users)
-  where displayName uname = (anchor ! [href $ "/user/" ++ display uname] << display uname)
+listGroupCompact users = foldr1 (\a b -> a +++ ", " +++ b) (map (displayName Nothing) users)
+
+displayName :: Maybe String -> Users.UserName -> Html
+displayName muri uname = (anchor ! [href $ "/user/" ++ display uname] << display uname) +++
+                            maybe [] (removeUser uname) muri

--- a/src/Distribution/Server/Pages/Group.hs
+++ b/src/Distribution/Server/Pages/Group.hs
@@ -1,7 +1,8 @@
 -- Body of the HTML page for a package
 module Distribution.Server.Pages.Group (
     groupPage,
-    renderGroupName
+    renderGroupName,
+    listGroupCompact
     -- renderGroupNameWithCands
   ) where
 
@@ -73,3 +74,8 @@ listGroup [] _ = p << "No member exist presently"
 listGroup users muri = unordList (map displayName users)
   where displayName uname = (anchor ! [href $ "/user/" ++ display uname] << display uname) +++
                             maybe [] (removeUser uname) muri
+
+listGroupCompact :: [Users.UserName] -> Html
+listGroupCompact [] = toHtml "No member exist presently"
+listGroupCompact users = foldr1 (\a b -> a +++ ", " +++ b) (map displayName users)
+  where displayName uname = (anchor ! [href $ "/user/" ++ display uname] << display uname)

--- a/src/Distribution/Server/Pages/PackageFromTemplate.hs
+++ b/src/Distribution/Server/Pages/PackageFromTemplate.hs
@@ -166,8 +166,7 @@ packagePageTemplate render
       , templateVal "license"       (Old.rendLicense render)
       , templateVal "author"        (toHtml $ author desc)
       , templateVal "maintainer"    (Old.maintainField $ rendMaintainer render)
-      , templateVal "maintainerURL" (toHtml $
-        anchor ! [href $ "/package" </> pkgName </> "maintainers" ] << "package maintainers")
+      , templateVal "maintainerURL" (toHtml $ "/package" </> pkgName </> "maintainers")
       , templateVal "buildDepends"  (snd (Old.renderDependencies render))
       , templateVal "optional"      optionalPackageInfoTemplate
       , templateVal "candidateBanner" candidateBanner


### PR DESCRIPTION
This pull request implements issue #637 as a gsoc project mentored by @gbaz. It displays hackage maintainers in Maintainer's Corner, on both package and candidate pages. Looks like this:

![4](https://user-images.githubusercontent.com/42169770/178150654-17ece2b9-2018-4f8b-917b-59c0ff6039de.png)
