### PR TITLE
Divide sitemap into parts

### DIFF
--- a/src/Distribution/Server/Features.hs
+++ b/src/Distribution/Server/Features.hs
@@ -337,6 +337,7 @@ initHackageFeatures env@ServerEnv{serverVerbosity = verbosity} = do
                         coreFeature
                         documentationCoreFeature
                         tagsFeature
+                        tarIndexCacheFeature
 
     packageFeedFeature <- mkPackageFeedFeature
                             coreFeature

--- a/src/Distribution/Server/Features/Sitemap/Functions.hs
+++ b/src/Distribution/Server/Features/Sitemap/Functions.hs
@@ -23,6 +23,7 @@
 module Distribution.Server.Features.Sitemap.Functions (
     SitemapEntry
   , ChangeFreq(..)
+  , renderSitemapIndex
   , renderSitemap
   , urlsToSitemapEntries
   , pathsAndDatesToSitemapEntries
@@ -46,6 +47,22 @@ data SitemapEntry = SitemapEntry {
                }
 
 data ChangeFreq = Monthly | Weekly | Daily
+
+-- | Generate a sitemap index file from each sitemap uri.
+renderSitemapIndex :: URI -> [String] -> ByteString
+renderSitemapIndex serverBaseURI sitemaps =
+  xrender $
+    doc defaultDocInfo $
+      xelem "sitemapindex" $
+          xattr "xmlns" "http://www.sitemaps.org/schemas/sitemap/0.9"
+        <#> map renderLink sitemaps
+  where
+    serverBaseURI' = T.pack (show serverBaseURI)
+    renderLink :: String -> Xml Elem
+    renderLink uri = xelem "sitemap" $ 
+      xelems [
+        xelem "loc" (xtext (serverBaseURI' <> T.pack (uri)))
+      ]
 
 -- | Primary function - generates the XML file from a list of Nodes.
 renderSitemap :: URI -> [SitemapEntry] -> ByteString


### PR DESCRIPTION
This pr resolves #592 as a gsoc project mentored by @gbaz. It devides the sitemap into 50000-url parts. Moreover, It add all the html files in the doc tarball to the sitemap.