### PR TITLE
Bump CI to GHC 9.2.3 and restrict to master branch

### DIFF
--- a/.github/workflows/haskell-ci.yml
+++ b/.github/workflows/haskell-ci.yml
@@ -8,18 +8,24 @@
 #
 # For more information, see https://github.com/haskell-CI/haskell-ci
 #
-# version: 0.14.3.20220416
+# version: 0.15.20220710
 #
-# REGENDATA ("0.14.3.20220416",["github","hackage-server.cabal"])
+# REGENDATA ("0.15.20220710",["github","hackage-server.cabal"])
 #
 name: Haskell-CI
 on:
-  - push
-  - pull_request
+  push:
+    branches:
+      - master
+      - ci*
+  pull_request:
+    branches:
+      - master
+      - ci*
 jobs:
   linux:
     name: Haskell-CI - Linux - ${{ matrix.compiler }}
-    runs-on: ubuntu-18.04
+    runs-on: ubuntu-20.04
     timeout-minutes:
       60
     container:
@@ -28,9 +34,9 @@ jobs:
     strategy:
       matrix:
         include:
-          - compiler: ghc-9.2.2
+          - compiler: ghc-9.2.3
             compilerKind: ghc
-            compilerVersion: 9.2.2
+            compilerVersion: 9.2.3
             setup-method: ghcup
             allow-failure: false
           - compiler: ghc-9.0.2
@@ -56,10 +62,10 @@ jobs:
           apt-get install -y --no-install-recommends gnupg ca-certificates dirmngr curl git software-properties-common libtinfo5
           if [ "${{ matrix.setup-method }}" = ghcup ]; then
             mkdir -p "$HOME/.ghcup/bin"
-            curl -sL https://downloads.haskell.org/ghcup/0.1.17.5/x86_64-linux-ghcup-0.1.17.5 > "$HOME/.ghcup/bin/ghcup"
+            curl -sL https://downloads.haskell.org/ghcup/0.1.17.8/x86_64-linux-ghcup-0.1.17.8 > "$HOME/.ghcup/bin/ghcup"
             chmod a+x "$HOME/.ghcup/bin/ghcup"
-            "$HOME/.ghcup/bin/ghcup" install ghc "$HCVER"
-            "$HOME/.ghcup/bin/ghcup" install cabal 3.6.2.0
+            "$HOME/.ghcup/bin/ghcup" install ghc "$HCVER" || (cat "$HOME"/.ghcup/logs/*.* && false)
+            "$HOME/.ghcup/bin/ghcup" install cabal 3.6.2.0 || (cat "$HOME"/.ghcup/logs/*.* && false)
             apt-get update
             apt-get install -y libbrotli-dev
           else
@@ -67,9 +73,9 @@ jobs:
             apt-get update
             apt-get install -y "$HCNAME" libbrotli-dev
             mkdir -p "$HOME/.ghcup/bin"
-            curl -sL https://downloads.haskell.org/ghcup/0.1.17.5/x86_64-linux-ghcup-0.1.17.5 > "$HOME/.ghcup/bin/ghcup"
+            curl -sL https://downloads.haskell.org/ghcup/0.1.17.8/x86_64-linux-ghcup-0.1.17.8 > "$HOME/.ghcup/bin/ghcup"
             chmod a+x "$HOME/.ghcup/bin/ghcup"
-            "$HOME/.ghcup/bin/ghcup" install cabal 3.6.2.0
+            "$HOME/.ghcup/bin/ghcup" install cabal 3.6.2.0 || (cat "$HOME"/.ghcup/logs/*.* && false)
           fi
         env:
           HCKIND: ${{ matrix.compilerKind }}
@@ -212,7 +218,7 @@ jobs:
           ${CABAL} -vnormal check
       - name: haddock
         run: |
-          $CABAL v2-haddock $ARG_COMPILER --with-haddock $HADDOCK $ARG_TESTS $ARG_BENCH all
+          $CABAL v2-haddock --haddock-all $ARG_COMPILER --with-haddock $HADDOCK $ARG_TESTS $ARG_BENCH all
       - name: unconstrained build
         run: |
           rm -f cabal.project.local

--- a/.github/workflows/nix-shell.yml
+++ b/.github/workflows/nix-shell.yml
@@ -1,7 +1,13 @@
 name: "Test nix-shell"
 on:
-  - push
-  - pull_request
+  push:
+    branches:
+      - master
+      - ci*
+  pull_request:
+    branches:
+      - master
+      - ci*
 jobs:
   nix-shell:
     runs-on: ubuntu-latest

--- a/cabal.haskell-ci
+++ b/cabal.haskell-ci
@@ -1,3 +1,5 @@
+branches: master ci*
+
 installed: +all -Cabal -text -parsec
 
 -- -- irc-channels works with GHA, but why send to a channel

--- a/hackage-server.cabal
+++ b/hackage-server.cabal
@@ -27,7 +27,7 @@ copyright:    2008-2015 Duncan Coutts,
 license:      BSD-3-Clause
 license-file: LICENSE
 
-tested-with: GHC == { 9.2.2, 9.0.2, 8.10.7, 8.8.4 }
+tested-with: GHC == { 9.2.3, 9.0.2, 8.10.7, 8.8.4 }
 
 data-dir: datafiles
 data-files:


### PR DESCRIPTION
CI is now only run on PRs and pushes on `master`.  This saves duplicate CI runs when opening a PR.  As an exception, branches starting with letters `ci` also run the CI.