### PR TITLE
Ask new uploaders to link to their packages

### DIFF
--- a/datafiles/templates/UserSignupReset/SignupConfirmation.email.st
+++ b/datafiles/templates/UserSignupReset/SignupConfirmation.email.st
@@ -7,10 +7,11 @@ this link:
   $confirmlink$
 
 After your account is created, you will need to email the Hackage
-Trustees at hackage-trustees@haskell.org requesting to be added to the
+Trustees at hackage-trustees@haskell.org requesting addition to the
 uploader group. In this email, please include your Hackage username
-and a package that you'd like to upload. (This measure is
-unfortunately necessary to prevent spam accounts.)
+and a link to the package you'd like to upload (on a host like gitlab
+or github) that you'd like to upload. (This measure is unfortunately
+necessary to prevent spam accounts.)
 
 For storage and bandwidth reasons, we ask uploaders to only upload
 packages they believe will be useful to others and that they intend to maintain.

--- a/datafiles/templates/UserSignupReset/SignupConfirmation.email.st
+++ b/datafiles/templates/UserSignupReset/SignupConfirmation.email.st
@@ -10,8 +10,8 @@ After your account is created, you will need to email the Hackage
 Trustees at hackage-trustees@haskell.org requesting addition to the
 uploader group. In this email, please include your Hackage username
 and a link to the package you'd like to upload (on a host like gitlab
-or github) that you'd like to upload. (This measure is unfortunately
-necessary to prevent spam accounts.)
+or github). This measure is unfortunately necessary to prevent spam
+accounts.
 
 For storage and bandwidth reasons, we ask uploaders to only upload
 packages they believe will be useful to others and that they intend to maintain.


### PR DESCRIPTION
New accounts are telling us what package they'd like to upload, which is good, but then they're emailing us cabal sdists, which is less good.