### PR TITLE
[#1127] Force .txt and .text to have UTF-8 MIME charset

### DIFF
--- a/src/Distribution/Server/Framework/HappstackUtils.hs
+++ b/src/Distribution/Server/Framework/HappstackUtils.hs
@@ -81,6 +81,8 @@ mime x =
       , ("chs", "text/plain; charset=utf-8")
       , ("c",  " text/plain; charset=utf-8")
       , ("h",  " text/plain; charset=utf-8")
+      , ("text", "text/plain; charset=utf-8")
+      , ("txt", "text/plain; charset=utf-8")
       ]
 
 


### PR DESCRIPTION
Fix #1127 

cc @gbaz @andreasabel 