### PR TITLE
Add support for 64-bit RISC-V architecture

### DIFF
--- a/src/Distribution/Server/Framework/Instances.hs
+++ b/src/Distribution/Server/Framework/Instances.hs
@@ -180,6 +180,7 @@ instance SafeCopy  Arch where
     putCopy Vax           = contain $ putWord8 15
     putCopy JavaScript    = contain $ putWord8 16
     putCopy AArch64       = contain $ putWord8 17
+    putCopy RISCV64       = contain $ putWord8 18
 
     getCopy = contain $ do
       tag <- getWord8
@@ -202,6 +203,7 @@ instance SafeCopy  Arch where
         15 -> return Vax
         16 -> return JavaScript
         17 -> return AArch64
+        18 -> return RISCV64
         _  -> fail "SafeCopy Arch getCopy: unexpected tag"
 
 instance SafeCopy CompilerFlavor where
@@ -370,7 +372,8 @@ instance Arbitrary Arch where
   arbitrary = oneof [ pure OtherArch <*> vectorOf 3 (choose ('A', 'Z'))
                     , pure I386, pure X86_64, pure PPC, pure PPC64, pure Sparc
                     , pure Arm, pure Mips, pure SH, pure IA64, pure S390
-                    , pure Alpha, pure Hppa, pure Rs6000, pure M68k, pure Vax ]
+                    , pure Alpha, pure Hppa, pure Rs6000, pure M68k, pure Vax
+                    , pure AArch64, pure RISCV64]
 
 instance Arbitrary OS where
   arbitrary = oneof [ pure OtherOS <*> vectorOf 3 (choose ('A', 'Z'))


### PR DESCRIPTION
This helps some projects to keep support for this architecture (for example: https://github.com/haskell-primitive/primitive-unaligned/commit/2a8ec3167e9cabb520884a7e963ec6bc733983d6)