### PR TITLE
Build with Cabal-3.8 and GHC 9.4

### DIFF
--- a/.github/workflows/haskell-ci.yml
+++ b/.github/workflows/haskell-ci.yml
@@ -54,34 +54,19 @@ jobs:
             compilerVersion: 8.10.7
             setup-method: ghcup
             allow-failure: false
-          - compiler: ghc-8.8.4
-            compilerKind: ghc
-            compilerVersion: 8.8.4
-            setup-method: hvr-ppa
-            allow-failure: false
       fail-fast: false
     steps:
       - name: apt
         run: |
           apt-get update
           apt-get install -y --no-install-recommends gnupg ca-certificates dirmngr curl git software-properties-common libtinfo5
-          if [ "${{ matrix.setup-method }}" = ghcup ]; then
-            mkdir -p "$HOME/.ghcup/bin"
-            curl -sL https://downloads.haskell.org/ghcup/0.1.18.0/x86_64-linux-ghcup-0.1.18.0 > "$HOME/.ghcup/bin/ghcup"
-            chmod a+x "$HOME/.ghcup/bin/ghcup"
-            "$HOME/.ghcup/bin/ghcup" install ghc "$HCVER" || (cat "$HOME"/.ghcup/logs/*.* && false)
-            "$HOME/.ghcup/bin/ghcup" install cabal 3.6.2.0 || (cat "$HOME"/.ghcup/logs/*.* && false)
-            apt-get update
-            apt-get install -y libbrotli-dev
-          else
-            apt-add-repository -y 'ppa:hvr/ghc'
-            apt-get update
-            apt-get install -y "$HCNAME" libbrotli-dev
-            mkdir -p "$HOME/.ghcup/bin"
-            curl -sL https://downloads.haskell.org/ghcup/0.1.18.0/x86_64-linux-ghcup-0.1.18.0 > "$HOME/.ghcup/bin/ghcup"
-            chmod a+x "$HOME/.ghcup/bin/ghcup"
-            "$HOME/.ghcup/bin/ghcup" install cabal 3.6.2.0 || (cat "$HOME"/.ghcup/logs/*.* && false)
-          fi
+          mkdir -p "$HOME/.ghcup/bin"
+          curl -sL https://downloads.haskell.org/ghcup/0.1.18.0/x86_64-linux-ghcup-0.1.18.0 > "$HOME/.ghcup/bin/ghcup"
+          chmod a+x "$HOME/.ghcup/bin/ghcup"
+          "$HOME/.ghcup/bin/ghcup" install ghc "$HCVER" || (cat "$HOME"/.ghcup/logs/*.* && false)
+          "$HOME/.ghcup/bin/ghcup" install cabal 3.6.2.0 || (cat "$HOME"/.ghcup/logs/*.* && false)
+          apt-get update
+          apt-get install -y libbrotli-dev
         env:
           HCKIND: ${{ matrix.compilerKind }}
           HCNAME: ${{ matrix.compiler }}
@@ -93,20 +78,11 @@ jobs:
           echo "CABAL_DIR=$HOME/.cabal" >> "$GITHUB_ENV"
           echo "CABAL_CONFIG=$HOME/.cabal/config" >> "$GITHUB_ENV"
           HCDIR=/opt/$HCKIND/$HCVER
-          if [ "${{ matrix.setup-method }}" = ghcup ]; then
-            HC=$HOME/.ghcup/bin/$HCKIND-$HCVER
-            echo "HC=$HC" >> "$GITHUB_ENV"
-            echo "HCPKG=$HOME/.ghcup/bin/$HCKIND-pkg-$HCVER" >> "$GITHUB_ENV"
-            echo "HADDOCK=$HOME/.ghcup/bin/haddock-$HCVER" >> "$GITHUB_ENV"
-            echo "CABAL=$HOME/.ghcup/bin/cabal-3.6.2.0 -vnormal+nowrap" >> "$GITHUB_ENV"
-          else
-            HC=$HCDIR/bin/$HCKIND
-            echo "HC=$HC" >> "$GITHUB_ENV"
-            echo "HCPKG=$HCDIR/bin/$HCKIND-pkg" >> "$GITHUB_ENV"
-            echo "HADDOCK=$HCDIR/bin/haddock" >> "$GITHUB_ENV"
-            echo "CABAL=$HOME/.ghcup/bin/cabal-3.6.2.0 -vnormal+nowrap" >> "$GITHUB_ENV"
-          fi
-
+          HC=$HOME/.ghcup/bin/$HCKIND-$HCVER
+          echo "HC=$HC" >> "$GITHUB_ENV"
+          echo "HCPKG=$HOME/.ghcup/bin/$HCKIND-pkg-$HCVER" >> "$GITHUB_ENV"
+          echo "HADDOCK=$HOME/.ghcup/bin/haddock-$HCVER" >> "$GITHUB_ENV"
+          echo "CABAL=$HOME/.ghcup/bin/cabal-3.6.2.0 -vnormal+nowrap" >> "$GITHUB_ENV"
           HCNUMVER=$(${HC} --numeric-version|perl -ne '/^(\d+)\.(\d+)\.(\d+)(\.(\d+))?$/; print(10000 * $1 + 100 * $2 + ($3 == 0 ? $5 != 1 : $3))')
           echo "HCNUMVER=$HCNUMVER" >> "$GITHUB_ENV"
           echo "ARG_TESTS=--enable-tests" >> "$GITHUB_ENV"
@@ -190,6 +166,9 @@ jobs:
           echo "package hackage-server" >> cabal.project
           echo "    ghc-options: -Werror=missing-methods" >> cabal.project
           cat >> cabal.project <<EOF
+          EOF
+          cat >> cabal.project.local <<EOF
+          constraints: ghc installed
           EOF
           cat cabal.project
           cat cabal.project.local

--- a/.github/workflows/haskell-ci.yml
+++ b/.github/workflows/haskell-ci.yml
@@ -54,19 +54,34 @@ jobs:
             compilerVersion: 8.10.7
             setup-method: ghcup
             allow-failure: false
+          - compiler: ghc-8.8.4
+            compilerKind: ghc
+            compilerVersion: 8.8.4
+            setup-method: hvr-ppa
+            allow-failure: false
       fail-fast: false
     steps:
       - name: apt
         run: |
           apt-get update
           apt-get install -y --no-install-recommends gnupg ca-certificates dirmngr curl git software-properties-common libtinfo5
-          mkdir -p "$HOME/.ghcup/bin"
-          curl -sL https://downloads.haskell.org/ghcup/0.1.18.0/x86_64-linux-ghcup-0.1.18.0 > "$HOME/.ghcup/bin/ghcup"
-          chmod a+x "$HOME/.ghcup/bin/ghcup"
-          "$HOME/.ghcup/bin/ghcup" install ghc "$HCVER" || (cat "$HOME"/.ghcup/logs/*.* && false)
-          "$HOME/.ghcup/bin/ghcup" install cabal 3.6.2.0 || (cat "$HOME"/.ghcup/logs/*.* && false)
-          apt-get update
-          apt-get install -y libbrotli-dev
+          if [ "${{ matrix.setup-method }}" = ghcup ]; then
+            mkdir -p "$HOME/.ghcup/bin"
+            curl -sL https://downloads.haskell.org/ghcup/0.1.18.0/x86_64-linux-ghcup-0.1.18.0 > "$HOME/.ghcup/bin/ghcup"
+            chmod a+x "$HOME/.ghcup/bin/ghcup"
+            "$HOME/.ghcup/bin/ghcup" install ghc "$HCVER" || (cat "$HOME"/.ghcup/logs/*.* && false)
+            "$HOME/.ghcup/bin/ghcup" install cabal 3.6.2.0 || (cat "$HOME"/.ghcup/logs/*.* && false)
+            apt-get update
+            apt-get install -y libbrotli-dev
+          else
+            apt-add-repository -y 'ppa:hvr/ghc'
+            apt-get update
+            apt-get install -y "$HCNAME" libbrotli-dev
+            mkdir -p "$HOME/.ghcup/bin"
+            curl -sL https://downloads.haskell.org/ghcup/0.1.18.0/x86_64-linux-ghcup-0.1.18.0 > "$HOME/.ghcup/bin/ghcup"
+            chmod a+x "$HOME/.ghcup/bin/ghcup"
+            "$HOME/.ghcup/bin/ghcup" install cabal 3.6.2.0 || (cat "$HOME"/.ghcup/logs/*.* && false)
+          fi
         env:
           HCKIND: ${{ matrix.compilerKind }}
           HCNAME: ${{ matrix.compiler }}
@@ -78,11 +93,20 @@ jobs:
           echo "CABAL_DIR=$HOME/.cabal" >> "$GITHUB_ENV"
           echo "CABAL_CONFIG=$HOME/.cabal/config" >> "$GITHUB_ENV"
           HCDIR=/opt/$HCKIND/$HCVER
-          HC=$HOME/.ghcup/bin/$HCKIND-$HCVER
-          echo "HC=$HC" >> "$GITHUB_ENV"
-          echo "HCPKG=$HOME/.ghcup/bin/$HCKIND-pkg-$HCVER" >> "$GITHUB_ENV"
-          echo "HADDOCK=$HOME/.ghcup/bin/haddock-$HCVER" >> "$GITHUB_ENV"
-          echo "CABAL=$HOME/.ghcup/bin/cabal-3.6.2.0 -vnormal+nowrap" >> "$GITHUB_ENV"
+          if [ "${{ matrix.setup-method }}" = ghcup ]; then
+            HC=$HOME/.ghcup/bin/$HCKIND-$HCVER
+            echo "HC=$HC" >> "$GITHUB_ENV"
+            echo "HCPKG=$HOME/.ghcup/bin/$HCKIND-pkg-$HCVER" >> "$GITHUB_ENV"
+            echo "HADDOCK=$HOME/.ghcup/bin/haddock-$HCVER" >> "$GITHUB_ENV"
+            echo "CABAL=$HOME/.ghcup/bin/cabal-3.6.2.0 -vnormal+nowrap" >> "$GITHUB_ENV"
+          else
+            HC=$HCDIR/bin/$HCKIND
+            echo "HC=$HC" >> "$GITHUB_ENV"
+            echo "HCPKG=$HCDIR/bin/$HCKIND-pkg" >> "$GITHUB_ENV"
+            echo "HADDOCK=$HCDIR/bin/haddock" >> "$GITHUB_ENV"
+            echo "CABAL=$HOME/.ghcup/bin/cabal-3.6.2.0 -vnormal+nowrap" >> "$GITHUB_ENV"
+          fi
+
           HCNUMVER=$(${HC} --numeric-version|perl -ne '/^(\d+)\.(\d+)\.(\d+)(\.(\d+))?$/; print(10000 * $1 + 100 * $2 + ($3 == 0 ? $5 != 1 : $3))')
           echo "HCNUMVER=$HCNUMVER" >> "$GITHUB_ENV"
           if [ $((HCNUMVER >= 90400)) -ne 0 ] ; then echo "ARG_TESTS=--enable-tests" >> "$GITHUB_ENV" ; else echo "ARG_TESTS=--disable-tests" >> "$GITHUB_ENV" ; fi

--- a/.github/workflows/haskell-ci.yml
+++ b/.github/workflows/haskell-ci.yml
@@ -8,9 +8,9 @@
 #
 # For more information, see https://github.com/haskell-CI/haskell-ci
 #
-# version: 0.15.20220822
+# version: 0.15.20221009
 #
-# REGENDATA ("0.15.20220822",["github","hackage-server.cabal"])
+# REGENDATA ("0.15.20221009",["github","hackage-server.cabal"])
 #
 name: Haskell-CI
 on:
@@ -34,6 +34,11 @@ jobs:
     strategy:
       matrix:
         include:
+          - compiler: ghc-9.4.2
+            compilerKind: ghc
+            compilerVersion: 9.4.2
+            setup-method: ghcup
+            allow-failure: false
           - compiler: ghc-9.2.4
             compilerKind: ghc
             compilerVersion: 9.2.4

--- a/.github/workflows/haskell-ci.yml
+++ b/.github/workflows/haskell-ci.yml
@@ -167,7 +167,7 @@ jobs:
           echo "    ghc-options: -Werror=missing-methods" >> cabal.project
           cat >> cabal.project <<EOF
           EOF
-          $HCPKG list --simple-output --names-only | perl -ne 'for (split /\s+/) { print "constraints: $_ installed\n" unless /^(Cabal|hackage-server|parsec|text)$/; }' >> cabal.project.local
+          $HCPKG list --simple-output --names-only | perl -ne 'for (split /\s+/) { print "constraints: $_ installed\n" unless /^(Cabal|hackage-server|parsec|process|text)$/; }' >> cabal.project.local
           cat cabal.project
           cat cabal.project.local
       - name: dump install plan

--- a/.github/workflows/haskell-ci.yml
+++ b/.github/workflows/haskell-ci.yml
@@ -85,7 +85,7 @@ jobs:
           echo "CABAL=$HOME/.ghcup/bin/cabal-3.6.2.0 -vnormal+nowrap" >> "$GITHUB_ENV"
           HCNUMVER=$(${HC} --numeric-version|perl -ne '/^(\d+)\.(\d+)\.(\d+)(\.(\d+))?$/; print(10000 * $1 + 100 * $2 + ($3 == 0 ? $5 != 1 : $3))')
           echo "HCNUMVER=$HCNUMVER" >> "$GITHUB_ENV"
-          echo "ARG_TESTS=--enable-tests" >> "$GITHUB_ENV"
+          if [ $((HCNUMVER >= 90400)) -ne 0 ] ; then echo "ARG_TESTS=--enable-tests" >> "$GITHUB_ENV" ; else echo "ARG_TESTS=--disable-tests" >> "$GITHUB_ENV" ; fi
           echo "ARG_BENCH=--enable-benchmarks" >> "$GITHUB_ENV"
           echo "HEADHACKAGE=false" >> "$GITHUB_ENV"
           echo "ARG_COMPILER=--$HCKIND --with-compiler=$HC" >> "$GITHUB_ENV"
@@ -167,9 +167,7 @@ jobs:
           echo "    ghc-options: -Werror=missing-methods" >> cabal.project
           cat >> cabal.project <<EOF
           EOF
-          cat >> cabal.project.local <<EOF
-          constraints: ghc installed
-          EOF
+          $HCPKG list --simple-output --names-only | perl -ne 'for (split /\s+/) { print "constraints: $_ installed\n" unless /^(Cabal|hackage-server|parsec|text)$/; }' >> cabal.project.local
           cat cabal.project
           cat cabal.project.local
       - name: dump install plan
@@ -194,7 +192,7 @@ jobs:
           $CABAL v2-build $ARG_COMPILER $ARG_TESTS $ARG_BENCH all --write-ghc-environment-files=always
       - name: tests
         run: |
-          $CABAL v2-test $ARG_COMPILER $ARG_TESTS $ARG_BENCH all --test-show-details=direct
+          if [ $((HCNUMVER >= 90400)) -ne 0 ] ; then $CABAL v2-test $ARG_COMPILER $ARG_TESTS $ARG_BENCH all --test-show-details=direct ; fi
       - name: cabal check
         run: |
           cd ${PKGDIR_hackage_server} || false

--- a/.github/workflows/haskell-ci.yml
+++ b/.github/workflows/haskell-ci.yml
@@ -191,7 +191,6 @@ jobs:
           echo "    ghc-options: -Werror=missing-methods" >> cabal.project
           cat >> cabal.project <<EOF
           EOF
-          $HCPKG list --simple-output --names-only | perl -ne 'for (split /\s+/) { print "constraints: $_ installed\n" unless /^(Cabal|hackage-server|parsec|text)$/; }' >> cabal.project.local
           cat cabal.project
           cat cabal.project.local
       - name: dump install plan

--- a/cabal.haskell-ci
+++ b/cabal.haskell-ci
@@ -1,6 +1,6 @@
 branches: master ci*
 
-installed: -all
+installed: -all +ghc
 -- installed: +all -Cabal -text -parsec
 
 -- -- irc-channels works with GHA, but why send to a channel

--- a/cabal.haskell-ci
+++ b/cabal.haskell-ci
@@ -1,6 +1,8 @@
 branches: master ci*
 
-installed: +all -Cabal -text -parsec
+installed: +all -Cabal -text -parsec -process
+  -- Cabal-3.8.1.0 wants process-1.6.14 or newer
+
 -- Did not help to salvage ghc-9.2 and below:
 -- installed: -all +ghc
 

--- a/cabal.haskell-ci
+++ b/cabal.haskell-ci
@@ -1,6 +1,7 @@
 branches: master ci*
 
-installed: +all -Cabal -text -parsec
+installed: -all
+-- installed: +all -Cabal -text -parsec
 
 -- -- irc-channels works with GHA, but why send to a channel
 -- -- when one can subscribe to github notifications?

--- a/cabal.haskell-ci
+++ b/cabal.haskell-ci
@@ -1,11 +1,8 @@
 branches: master ci*
 
-installed: -all +ghc
--- installed: +all -Cabal -text -parsec
-
--- -- irc-channels works with GHA, but why send to a channel
--- -- when one can subscribe to github notifications?
--- irc-channels: irc.libera.chat#hackage
+installed: +all -Cabal -text -parsec
+-- Did not help to salvage ghc-9.2 and below:
+-- installed: -all +ghc
 
 -- Does not work with GHA:
 -- -- allow failures with ghc-7.6 and ghc-7.8
@@ -20,3 +17,8 @@ apt: libbrotli-dev
 -- even though we don't define any library.
 haddock-components: all
   -- since haskell-ci 0.15.20220822
+
+tests: >= 9.4
+  -- parallel-doctest uses the ghc package
+  -- and thus does not build with Cabal-3.8.1.0 below GHC 9.4
+  -- See: https://github.com/haskell/cabal/issues/8554

--- a/cabal.project
+++ b/cabal.project
@@ -11,6 +11,17 @@ packages: .
 
 allow-newer: rss:time, rss:base
 
+-- Andreas, 2022-10-28:  `Cabal-3.8.1.0` wants `process >= 1.6.14`
+-- which is too new for the `ghc < 9.4` package that is pulled in
+-- by `doctest-parallel`.
+-- Since, Cabal-3.8.1.0 has no reason to want such a new version
+-- of process, we can solve the conflict here by allowing
+-- `Cabal` to use the shipped version of `process`.
+-- This workaround can be removed once `Cabal-3.8` drops
+-- its (unreasonable) constraint on `process`.
+-- See: https://github.com/haskell/cabal/issues/8554
+allow-older: Cabal:process
+
 -----------------------------------------------------------------------------
 -- Anti-constraints
 

--- a/hackage-server.cabal
+++ b/hackage-server.cabal
@@ -27,7 +27,7 @@ copyright:    2008-2015 Duncan Coutts,
 license:      BSD-3-Clause
 license-file: LICENSE
 
-tested-with: GHC == { 9.4.2, 9.2.4, 9.0.2, 8.10.7, 8.8.4 }
+tested-with: GHC == { 9.4.2, 9.2.4, 9.0.2, 8.10.7 }
 
 data-dir: datafiles
 data-files:

--- a/hackage-server.cabal
+++ b/hackage-server.cabal
@@ -27,7 +27,7 @@ copyright:    2008-2015 Duncan Coutts,
 license:      BSD-3-Clause
 license-file: LICENSE
 
-tested-with: GHC == { 9.4.2, 9.2.4, 9.0.2, 8.10.7 }
+tested-with: GHC == { 9.4.2, 9.2.4, 9.0.2, 8.10.7, 8.8.4 }
 
 data-dir: datafiles
 data-files:

--- a/hackage-server.cabal
+++ b/hackage-server.cabal
@@ -27,7 +27,7 @@ copyright:    2008-2015 Duncan Coutts,
 license:      BSD-3-Clause
 license-file: LICENSE
 
-tested-with: GHC == { 9.2.4, 9.0.2, 8.10.7, 8.8.4 }
+tested-with: GHC == { 9.4.2, 9.2.4, 9.0.2, 8.10.7, 8.8.4 }
 
 data-dir: datafiles
 data-files:
@@ -99,7 +99,7 @@ common defaults
   -- see `cabal.project.local-ghc-${VERSION}` files
   build-depends:
     , array                  >= 0.5   && < 0.6
-    , base                   >= 4.13  && < 4.17
+    , base                   >= 4.13  && < 4.18
     , binary                 >= 0.8   && < 0.9
     , bytestring             >= 0.10  && < 0.12
     , containers            ^>= 0.6.0
@@ -117,8 +117,8 @@ common defaults
   -- other dependencies shared by most components
   build-depends:
     , aeson                 ^>= 2.0.3.0 || ^>= 2.1.0.0
-    , Cabal                 ^>= 3.6.3.0
-    , Cabal-syntax          ^>= 3.6.0.0
+    , Cabal                 ^>= 3.8.1.0
+    , Cabal-syntax          ^>= 3.8.1.0
         -- Cabal-syntax needs to be bound to constrain hackage-security
         -- see https://github.com/haskell/hackage-server/issues/1130
     , fail                  ^>= 4.9.0
@@ -371,7 +371,7 @@ library lib-server
   -- NB: see also build-depends in `common defaults`!
   build-depends:
     , HStringTemplate       ^>= 0.8
-    , HTTP                  ^>= 4000.3.16
+    , HTTP                  ^>= 4000.3.16 || ^>= 4000.4.1
     , QuickCheck            ^>= 2.14
     , acid-state            ^>= 0.16
     , async                 ^>= 2.2.1

--- a/src/Distribution/Server/Features/BuildReports/BuildReport.hs
+++ b/src/Distribution/Server/Features/BuildReports/BuildReport.hs
@@ -1,9 +1,11 @@
+{-# LANGUAGE CPP #-}
 {-# LANGUAGE ConstraintKinds #-}
 {-# LANGUAGE DeriveDataTypeable #-}
 {-# LANGUAGE FlexibleInstances #-}
 {-# LANGUAGE GeneralizedNewtypeDeriving #-}
 {-# LANGUAGE MultiParamTypeClasses #-}
 {-# LANGUAGE OverloadedStrings #-}
+{-# LANGUAGE PatternSynonyms #-}
 {-# LANGUAGE RecordWildCards #-}
 {-# LANGUAGE TemplateHaskell #-}
 {-# LANGUAGE TypeFamilies #-}
@@ -57,6 +59,10 @@ import Distribution.CabalSpecVersion
          ( CabalSpecVersion(CabalSpecV2_4) )
 import Distribution.Pretty
          ( Pretty(..), pretty, prettyShow )
+#if MIN_VERSION_Cabal(3,7,0)
+import Distribution.Fields.Pretty
+         ( pattern NoComment )
+#endif
 import qualified Text.PrettyPrint as Disp
 
 import Distribution.Parsec
@@ -311,7 +317,13 @@ intPair = do
 -- Pretty-printing
 
 show :: BuildReport -> String
-show = showFields (const []) . prettyFieldGrammar CabalSpecV2_4 fieldDescrs
+show = showFields noComment . prettyFieldGrammar CabalSpecV2_4 fieldDescrs
+  where
+#if MIN_VERSION_Cabal(3,7,0)
+    noComment _ = NoComment
+#else
+    noComment _ = []
+#endif
 
 -- -----------------------------------------------------------------------------
 -- Description of the fields, for parsing/printing

--- a/src/Distribution/Server/Framework/Instances.hs
+++ b/src/Distribution/Server/Framework/Instances.hs
@@ -136,6 +136,7 @@ instance SafeCopy OS where
     putCopy Ghcjs       = contain $ putWord8 14
     putCopy Hurd        = contain $ putWord8 15
     putCopy Android     = contain $ putWord8 16
+    putCopy Wasi        = contain $ putWord8 17
 
     getCopy = contain $ do
       tag <- getWord8
@@ -157,6 +158,7 @@ instance SafeCopy OS where
         14 -> return Ghcjs
         15 -> return Hurd
         16 -> return Android
+        17 -> return Wasi
         _  -> fail "SafeCopy OS getCopy: unexpected tag"
 
 instance SafeCopy  Arch where
@@ -180,6 +182,8 @@ instance SafeCopy  Arch where
     putCopy Vax           = contain $ putWord8 15
     putCopy JavaScript    = contain $ putWord8 16
     putCopy AArch64       = contain $ putWord8 17
+    putCopy S390X         = contain $ putWord8 18
+    putCopy Wasm32        = contain $ putWord8 19
 
     getCopy = contain $ do
       tag <- getWord8
@@ -202,6 +206,8 @@ instance SafeCopy  Arch where
         15 -> return Vax
         16 -> return JavaScript
         17 -> return AArch64
+        18 -> return S390X
+        19 -> return Wasm32
         _  -> fail "SafeCopy Arch getCopy: unexpected tag"
 
 instance SafeCopy CompilerFlavor where


### PR DESCRIPTION
Fix #1120.

Warning!  This PR makes `hackage-server` compile with Cabal-3.8, but does not add any Cabal-3.8 specific features.

Blocked on:
- [x] https://github.com/haskell/cabal/issues/8554