### PR TITLE
Allow mtl-2.3 and transformers-0.6

### DIFF
--- a/.github/workflows/cabal-mtl-2.3.yml
+++ b/.github/workflows/cabal-mtl-2.3.yml
@@ -1,0 +1,53 @@
+name: Cabal build with mtl-2.3
+on:
+  push:
+    branches:
+      - master
+      - ci*
+  pull_request:
+    branches:
+      - master
+      - ci*
+
+defaults:
+  run:
+    shell: bash
+
+jobs:
+  build:
+    name: Build with mtl-2.3
+    runs-on: ubuntu-latest
+    timeout-minutes: 60
+
+    steps:
+
+    - name: Environment settings based on the Haskell setup
+      run: |
+        GHC_VER=$(ghc --numeric-version)
+        CABAL_VER=$(cabal --numeric-version)
+        echo "GHC_VER   = ${GHC_VER}"
+        echo "CABAL_VER = ${CABAL_VER}"
+        echo "GHC_VER=${GHC_VER}"       >> "${GITHUB_ENV}"
+        echo "CABAL_VER=${CABAL_VER}"   >> "${GITHUB_ENV}"
+
+    - name: Install the brotli library
+      run: |
+        sudo apt-get update
+        sudo apt-get install -y libbrotli-dev
+
+    - uses: actions/checkout@v3
+
+    - name: Cache build
+      uses: actions/cache@v3
+      with:
+        path: |
+          ~/.cabal
+          dist-newstyle
+        key: cabal-${{ env.CABAL_VER }}-ghc-${{ env.GHC_VER }}-commit-${{ github.sha }}
+        restore-keys: |
+          cabal-${{ env.CABAL_VER }}-ghc-${{ env.GHC_VER }}-commit-
+
+    - name: Build w/o tests with mtl-2.3
+      # 2022-12-30: 'transformers >= 0.6' is needed because of happstack-server
+      run: |
+        cabal build -O0 --disable-tests -c 'mtl >= 2.3.1' -c 'transformers >= 0.6' --allow-newer='Cabal:mtl' --allow-newer='Cabal:transformers'

--- a/.github/workflows/cabal-mtl-2.3.yml
+++ b/.github/workflows/cabal-mtl-2.3.yml
@@ -50,4 +50,4 @@ jobs:
     - name: Build w/o tests with mtl-2.3
       # 2022-12-30: 'transformers >= 0.6' is needed because of happstack-server
       run: |
-        cabal build -O0 --disable-tests -c 'mtl >= 2.3.1' -c 'transformers >= 0.6' --allow-newer='Cabal:mtl' --allow-newer='Cabal:transformers'
+        cabal build -O0 --disable-tests --constraint 'mtl >= 2.3.1' --constraint 'transformers >= 0.6' --allow-newer='Cabal:mtl' --allow-newer='Cabal:transformers'

--- a/.github/workflows/cabal-mtl-2.3.yml
+++ b/.github/workflows/cabal-mtl-2.3.yml
@@ -30,10 +30,11 @@ jobs:
         echo "GHC_VER=${GHC_VER}"       >> "${GITHUB_ENV}"
         echo "CABAL_VER=${CABAL_VER}"   >> "${GITHUB_ENV}"
 
-    - name: Install the brotli library
-      run: |
-        sudo apt-get update
-        sudo apt-get install -y libbrotli-dev
+    # Brotli is already installed on ubuntu-22.04
+    # - name: Install the brotli library
+    #   run: |
+    #     sudo apt-get update
+    #     sudo apt-get install -y libbrotli-dev
 
     - uses: actions/checkout@v3
 
@@ -50,6 +51,11 @@ jobs:
     - name: Prepare cabal
       run: |
         cabal update
+
+    - name: Build dependencies w/o tests with mtl-2.3
+      # 2022-12-30: 'transformers >= 0.6' is needed because of happstack-server
+      run: |
+        cabal build --dependencies-only -O0 --disable-tests --constraint 'mtl >= 2.3.1' --constraint 'transformers >= 0.6' --allow-newer='Cabal:mtl' --allow-newer='Cabal:transformers'
 
     - name: Build w/o tests with mtl-2.3
       # 2022-12-30: 'transformers >= 0.6' is needed because of happstack-server

--- a/.github/workflows/cabal-mtl-2.3.yml
+++ b/.github/workflows/cabal-mtl-2.3.yml
@@ -47,6 +47,10 @@ jobs:
         restore-keys: |
           cabal-${{ env.CABAL_VER }}-ghc-${{ env.GHC_VER }}-commit-
 
+    - name: Prepare cabal
+      run: |
+        cabal update
+
     - name: Build w/o tests with mtl-2.3
       # 2022-12-30: 'transformers >= 0.6' is needed because of happstack-server
       run: |

--- a/hackage-server.cabal
+++ b/hackage-server.cabal
@@ -106,12 +106,12 @@ common defaults
     , deepseq                >= 1.4   && < 1.5
     , directory              >= 1.3   && < 1.4
     , filepath               >= 1.4   && < 1.5
-    , mtl                   ^>= 2.2.1
+    , mtl                    >= 2.2.1 && < 2.4
     , pretty                 >= 1.1   && < 1.2
     , process                >= 1.6   && < 1.7
     , text                  ^>= 1.2.5.0 || ^>= 2.0
     , time                   >= 1.9   && < 1.13
-    , transformers           >= 0.5   && < 0.6
+    , transformers           >= 0.5   && < 0.7
     , unix                   >= 2.7   && < 2.8
     , scientific
   -- other dependencies shared by most components

--- a/src/Distribution/Server/Features/Browse.hs
+++ b/src/Distribution/Server/Features/Browse.hs
@@ -1,7 +1,8 @@
 {-# LANGUAGE BlockArguments, NamedFieldPuns #-}
 module Distribution.Server.Features.Browse (initBrowseFeature, PaginationConfig(..), StartIndex(..), NumElems(..), paginate) where
 
-import Control.Monad.Except (ExceptT, liftIO, throwError)
+import Control.Monad.Except (ExceptT, throwError)
+import Control.Monad.IO.Class (liftIO)
 import Control.Monad.Trans.Class (lift)
 import qualified Data.Map as Map
 import Data.Maybe (isJust)

--- a/src/Distribution/Server/Features/Core/Backup.hs
+++ b/src/Distribution/Server/Features/Core/Backup.hs
@@ -40,7 +40,7 @@ import qualified Data.Foldable as Foldable
 import Data.List
 import Data.List.NonEmpty (toList)
 import Data.Ord (comparing)
-import Control.Monad.State
+import Control.Monad
 import qualified Distribution.Server.Util.GZip as GZip
 import qualified Data.ByteString.Lazy as BS
 import qualified Data.ByteString.Lazy.Char8 as BSC

--- a/src/Distribution/Server/Features/Security/Backup.hs
+++ b/src/Distribution/Server/Features/Security/Backup.hs
@@ -6,7 +6,7 @@ module Distribution.Server.Features.Security.Backup (
   ) where
 
 -- stdlib
-import Control.Monad.State
+import Control.Monad.State (StateT, execStateT, modify)
 import Data.Time
 import Data.Version (Version(..), showVersion)
 import Text.CSV hiding (csv)
@@ -224,7 +224,7 @@ import_v1 = mapM_ fromRecord
     fromInfoRecord [strFileLength, strSHA256, strMD5] = do
       fileInfoLength <- parseRead "file length" strFileLength
       fileInfoSHA256 <- parseSHA "file SHA256" strSHA256
-      fileInfoMD5    <- Just `liftM` parseMD5  "file MD5" strMD5
+      fileInfoMD5    <- Just <$> parseMD5  "file MD5" strMD5
       return FileInfo{..}
     fromInfoRecord otherRecord =
       fail $ "Unexpected info record: " ++ show otherRecord

--- a/src/Distribution/Server/Features/Security/State.hs
+++ b/src/Distribution/Server/Features/Security/State.hs
@@ -7,7 +7,8 @@
 module Distribution.Server.Features.Security.State where
 
 -- stdlib
-import Control.Monad.Reader
+import Control.Monad
+import Control.Monad.Reader (ask, asks)
 import Data.Acid
 import Data.Maybe
 import Data.SafeCopy

--- a/src/Distribution/Server/Framework/BackupRestore.hs
+++ b/src/Distribution/Server/Framework/BackupRestore.hs
@@ -51,8 +51,8 @@ import Distribution.Server.Features.Security.SHA256
 import qualified Codec.Archive.Tar as Tar
 import qualified Codec.Archive.Tar.Entry as Tar
 import Distribution.Server.Util.GZip (decompressNamed)
-import Control.Monad.State
-import Control.Monad.Except
+import Control.Monad.State (StateT, evalStateT, MonadState, get, gets, put)
+import Control.Monad.Except (ExceptT, runExceptT, MonadError(..))
 import Data.Time (UTCTime)
 import qualified Data.Time as Time
 import Data.Time.Format (defaultTimeLocale)

--- a/src/Distribution/Server/Util/Markdown.hs
+++ b/src/Distribution/Server/Util/Markdown.hs
@@ -22,7 +22,7 @@ import qualified Data.Text.Encoding.Error as T (lenientDecode)
 import qualified Data.Text.Lazy as TL
 import Data.Typeable (Typeable)
 import Network.URI (isRelativeReference)
-import Control.Monad.Identity
+import Control.Monad.Identity (runIdentity)
 import Text.HTML.SanitizeXSS as XSS
 import System.FilePath.Posix  (takeExtension)
 import qualified Data.ByteString.Lazy as BS (ByteString, toStrict)


### PR DESCRIPTION
Allow `mtl-2.3` and `transformers-0.6`.

Some import statements have to be changed to accommodate the breaking changes of `mtl >= 2.3`.  In case of `liftM`, I opted for the more modern `<$>`.

We also contribute a new CI workflow that tests building with `mtl >= 2.3.1` so that `mtl-2.3` compatibility does not bit-rot.