### PR TITLE
cleanup buncha partial functions for revdeps, elim use of MonadThrow

### DIFF
--- a/benchmarks/RevDeps.hs
+++ b/benchmarks/RevDeps.hs
@@ -62,7 +62,7 @@ main :: IO ()
 main = do
   packs :: Vector.Vector (Package TestPackage) <- randomPacks globalStdGen 20000 mempty
   let idx = PackageIndex.fromList $ map packToPkgInfo (Vector.toList packs)
-  Right revs <- pure $ constructReverseIndex idx
+  let revs = constructReverseIndex idx
   let numPacks = length packs
   defaultMain $
     (:[]) $
@@ -70,7 +70,7 @@ main = do
     flip nfAppIO revs $ \revs' -> do
       select <- uniformRM (0, numPacks - 1) globalStdGen
       -- TODO why are there so many transitive deps?
-      length <$>
+      pure $ length $
         getDependenciesFlat
         (packageName $ packToPkgInfo (packs Vector.! select))
         revs'

--- a/datafiles/templates/Html/maintain.html.st
+++ b/datafiles/templates/Html/maintain.html.st
@@ -48,7 +48,7 @@ package after its been released.
 
 <dt>Test settings</dt>
   <dd>If your package contains tests that can't run on hackage, you can disable them here.
-  <p>$versions:{pkgid|<a href="/package/$pkgid$/reports/test">$pkgid$</a>}; separator=", "$</p>
+  <p>$versions:{pkgid|<a href="/package/$pkgid$/reports/testsEnabled">$pkgid$</a>}; separator=", "$</p>
   </dd>
 
 <dt>Trigger rebuild</dt>

--- a/src/Distribution/Server/Features/Html.hs
+++ b/src/Distribution/Server/Features/Html.hs
@@ -232,7 +232,7 @@ htmlFeature :: ServerEnv
             -> AsyncCache Response
             -> AsyncCache Response
             -> Templates
-            -> RecentPackagesFeature 
+            -> RecentPackagesFeature
             -> (HtmlFeature, IO Response, IO Response)
 
 htmlFeature env@ServerEnv{..}
@@ -526,7 +526,7 @@ mkHtmlCore ServerEnv{serverBaseURI, serverBlobStore}
           }
       ]
 
-    readParamWithDefaultAndValid :: (Read a, HasRqData m, Monad m, Functor m, Alternative m) => 
+    readParamWithDefaultAndValid :: (Read a, HasRqData m, Monad m, Functor m, Alternative m) =>
       a -> (a -> Bool) -> String -> m a
     readParamWithDefaultAndValid n f queryParam = do
         m <- optional (look queryParam)
@@ -550,7 +550,7 @@ mkHtmlCore ServerEnv{serverBaseURI, serverBlobStore}
       pageSize <- lookupPageSize 20
 
       let conf = Paging.createConf page pageSize recentPackages
-      
+
       return . toResponse $ Pages.recentPage conf users recentPackages
 
     serveRecentRSS :: DynamicPath -> ServerPartE Response
@@ -560,9 +560,9 @@ mkHtmlCore ServerEnv{serverBaseURI, serverBlobStore}
       page <-  lookupPage 1
       pageSize <- lookupPageSize 20
       now   <- liftIO getCurrentTime
-      
+
       let conf = Paging.createConf page pageSize recentPackages
-      
+
       return . toResponse $ Pages.recentFeed conf users serverBaseURI now recentPackages
 
     serveRevisionPage :: DynamicPath -> ServerPartE Response
@@ -571,7 +571,7 @@ mkHtmlCore ServerEnv{serverBaseURI, serverBlobStore}
       users <- queryGetUserDb
       page <-  lookupPage 1
       pageSize <- lookupPageSize 40
-      
+
       let conf = Paging.createConf page pageSize revisions
 
       return . toResponse $ Pages.revisionsPage conf users revisions
@@ -583,7 +583,7 @@ mkHtmlCore ServerEnv{serverBaseURI, serverBlobStore}
       page <-  lookupPage 1
       pageSize <- lookupPageSize 40
       now   <- liftIO getCurrentTime
-      
+
       let conf = Paging.createConf page pageSize revisions
 
       return . toResponse $ Pages.recentRevisionsFeed conf users serverBaseURI now revisions
@@ -614,7 +614,7 @@ mkHtmlCore ServerEnv{serverBaseURI, serverBlobStore}
 
     serveGraphJSON :: DynamicPath -> ServerPartE Response
     serveGraphJSON _ = do
-        graph <- revJSON
+        graph <- liftIO revJSON
         --TODO: use proper type for graph with ETag
         cacheControl [Public, maxAgeMinutes 30] (etagFromHash graph)
         ok . toResponse $ graph
@@ -2178,7 +2178,7 @@ mkHtmlReverse HtmlUtilities{..}
         let pkgname = pkgName pkg
         pkgids <- lookupPackageName pkgname
         revCount <- revPackageStats pkgname
-        versions <- revForEachVersion pkgname
+        versions <- liftIO $ revForEachVersion pkgname
         return $ toResponse $ Resource.XHtml $ hackagePage (display pkgname ++ " - Reverse dependency statistics") $
             reverseVerboseRender pkgname (map packageVersion pkgids) (corePackageIdUri "") revCount versions
 


### PR DESCRIPTION
resolves https://github.com/haskell/hackage-server/issues/1155

also bundles up a fix to the maintainer template to link to the test enable page properly.