### PR TITLE
disable Basic Auth to remove dependency on deprecated `crypt` library

### DIFF
--- a/hackage-server.cabal
+++ b/hackage-server.cabal
@@ -441,9 +441,6 @@ library lib-server
   if flag(cabal-parsers)
     build-depends: cabal-parsers ^>= 0
 
-  if !os(darwin)
-    extra-libraries: crypt
-
 ----------------------------------------------------------------------------
 
 common exe-defaults


### PR DESCRIPTION
Closes: https://github.com/haskell/hackage-server/issues/1153

This PR disables Basic Auth, per this comment: https://github.com/haskell/hackage-server/issues/1153#issuecomment-1370308832 Basic Auth is disabled in the simplest possible way, by returning a `UnrecognizedAuthError`. More could be done to completely delete Basic Auth. Is this sufficient for now?

`hackage-server` builds successfully without the `crypt` library.

I have barely tested this; I am able to log in with the "admin" account on Hackage running locally.
