### PR TITLE
Notify maintainers when dependency is out of range

### DIFF
--- a/datafiles/templates/UserNotify/user-notify-form.html.st
+++ b/datafiles/templates/UserNotify/user-notify-form.html.st
@@ -10,6 +10,12 @@ td {
 label {
   align-items: center;
 }
+.expandable {
+  visibility: visible;
+}
+#notifyDependencyForMaintainedFalse:checked ~ .expandable {
+  visibility: collapse;
+}
 </style>
 </head>
 
@@ -56,11 +62,24 @@ $endif$
 
     <tr>
       <td><label>Notify when a dependency is updated for any of my maintained packages:
-      <td>$notifyDependencyForMaintained$
-          <p>trigger:
-          $notifyDependencyTriggerBounds$
-          <p>There must be at least <input value=$notifyDependencyMinimumUploads$ style=width:3em name=notifyDependencyMinimumUploads=%s type=number min=0> releases in the major series, including the new release.
-          <p>The oldest release must be at least <input value=$notifyDependencyMinimumAgeDays$ style=width:3em name=notifyDependencyMinimumAgeDays=%s type=number min=0> days old.
+      <td>
+        <input $notifyDependencyForMaintainedTrueChecked$ type="radio" name="notifyDependencyForMaintained=%s" value="true" id="notifyDependencyForMaintainedTrue">
+        <label for="notifyDependencyForMaintainedTrue">Yes</label>
+        <input $notifyDependencyForMaintainedFalseChecked$ type="radio" name="notifyDependencyForMaintained=%s" value="false" id="notifyDependencyForMaintainedFalse">
+        <label for="notifyDependencyForMaintainedFalse">No</label>
+        <p class="expandable">
+          trigger:
+          <label style="display:flex">
+            <input $notifyDependencyTriggerBoundsAlwaysChecked$ type="radio" name="notifyDependencyTriggerBounds=%s" value="Always">
+            always
+          </label>
+          <label style="display:flex">
+            <input $notifyDependencyTriggerBoundsBoundsOutOfRangeChecked$ type="radio" name="notifyDependencyTriggerBounds=%s" value="BoundsOutOfRange">
+            my maintained package doesn't accept the version of the newly uploaded or revised dependency
+          </label>
+        </p>
+      </td>
+    </tr>
   </table>
   <input type="submit" value="Save notify preference" />
 </form>

--- a/datafiles/templates/UserNotify/user-notify-form.html.st
+++ b/datafiles/templates/UserNotify/user-notify-form.html.st
@@ -3,6 +3,14 @@
 <head>
 $hackageCssTheme()$
 <title>Set user notification preferences | Hackage</title>
+<style>
+td {
+  vertical-align: top;
+}
+label {
+  align-items: center;
+}
+</style>
 </head>
 
 <body>
@@ -45,6 +53,14 @@ $endif$
     <tr>
       <td><label>Notify on maintained package pending proposed tags:
       <td>$notifyPendingTags$
+
+    <tr>
+      <td><label>Notify when a dependency is updated for any of my maintained packages:
+      <td>$notifyDependencyForMaintained$
+          <p>trigger:
+          $notifyDependencyTriggerBounds$
+          <p>There must be at least <input value=$notifyDependencyMinimumUploads$ style=width:3em name=notifyDependencyMinimumUploads=%s type=number min=0> releases in the major series, including the new release.
+          <p>The oldest release must be at least <input value=$notifyDependencyMinimumAgeDays$ style=width:3em name=notifyDependencyMinimumAgeDays=%s type=number min=0> days old.
   </table>
   <input type="submit" value="Save notify preference" />
 </form>

--- a/datafiles/templates/UserNotify/user-notify-form.html.st
+++ b/datafiles/templates/UserNotify/user-notify-form.html.st
@@ -77,6 +77,11 @@ $endif$
             <input $notifyDependencyTriggerBoundsBoundsOutOfRangeChecked$ type="radio" name="notifyDependencyTriggerBounds=%s" value="BoundsOutOfRange">
             my maintained package doesn't accept the version of the newly uploaded or revised dependency
           </label>
+          <label style="display:flex">
+            <input $newIncompatibilityChecked$ type="radio" name="notifyDependencyTriggerBounds=%s" value="NewIncompatibility">
+            my maintained package doesn't accept the version of the newly uploaded or revised dependency
+            and my package does accept the second highest version of said dependency
+          </label>
         </p>
       </td>
     </tr>

--- a/src/Distribution/Server/Features.hs
+++ b/src/Distribution/Server/Features.hs
@@ -352,6 +352,7 @@ initHackageFeatures env@ServerEnv{serverVerbosity = verbosity} = do
                            userDetailsFeature
                            reportsCoreFeature
                            tagsFeature
+                           reverseFeature
 
     packageFeedFeature <- mkPackageFeedFeature
                             coreFeature

--- a/src/Distribution/Server/Features/ReverseDependencies.hs
+++ b/src/Distribution/Server/Features/ReverseDependencies.hs
@@ -54,7 +54,8 @@ data ReverseFeature = ReverseFeature {
     revCountForAllPackages :: forall m. MonadIO m => m [(PackageName, ReverseCount)],
     revJSON :: IO ByteString,
     revDisplayInfo :: forall m. MonadIO m => m VersionIndex,
-    revForEachVersion :: PackageName -> IO (Map.Map Version (Set PackageIdentifier))
+    revForEachVersion :: PackageName -> IO (Map.Map Version (Set PackageIdentifier)),
+    queryReverseIndex :: forall m. MonadIO m => m ReverseIndex
 }
 
 instance IsHackageFeature ReverseFeature where

--- a/src/Distribution/Server/Features/ReverseDependencies/State.hs
+++ b/src/Distribution/Server/Features/ReverseDependencies/State.hs
@@ -3,7 +3,8 @@
 {-# LANGUAGE TupleSections #-}
 
 module Distribution.Server.Features.ReverseDependencies.State
-  ( ReverseIndex(..)
+  ( NodeId
+  , ReverseIndex(..)
   , ReverseDisplay
   , ReverseCount(..)
   , VersionIndex

--- a/src/Distribution/Server/Features/UserNotify.hs
+++ b/src/Distribution/Server/Features/UserNotify.hs
@@ -456,6 +456,12 @@ dependencyReleaseEmails
   -> (UserId -> m (Maybe NotifyPref))
   -> PackageIdentifier
   -> m (Map.Map (UserId, PackageId) [PackageId])
+dependencyReleaseEmails _ index _ _ pkgId
+  | let versionsForNewRelease = packageVersion <$> PackageIndex.lookupPackageName index (pkgName pkgId)
+  , pkgVersion pkgId /= maximum versionsForNewRelease
+  -- If e.g. a minor bugfix release is made for an old release series, never notify maintainers.
+  -- Only start checking if the new version is the highest.
+  = pure mempty
 dependencyReleaseEmails userSetIdForPackage index (ReverseIndex revs nodemap dependencies) queryGetUserNotifyPref pkgId =
   case lookup (pkgName pkgId) nodemap :: Maybe NodeId of
     Nothing -> pure mempty

--- a/src/Distribution/Server/Features/UserNotify.hs
+++ b/src/Distribution/Server/Features/UserNotify.hs
@@ -175,7 +175,13 @@ $(deriveSafeCopy 0 'base ''NotifyPref_v0)
 instance Migrate NotifyPref where
   type MigrateFrom NotifyPref = NotifyPref_v0
   migrate (NotifyPref_v0 f0 f1 f2 f3 f4 f5) =
-    NotifyPref f0 f1 f2 f3 f4 f5 True BoundsOutOfRange
+    NotifyPref f0 f1 f2 f3 f4 f5
+      False -- Users that already have opted in to notifications
+            -- did so at at a time when it did not include
+            -- reverse dependency emails.
+            -- So let's assume they don't want these.
+            -- Note that this differs from defaultNotifyPrefs.
+      BoundsOutOfRange
 
 $(deriveSafeCopy 1 'extension ''NotifyPref)
 $(deriveSafeCopy 0 'base ''NotifyData)

--- a/src/Distribution/Server/Features/UserNotify.hs
+++ b/src/Distribution/Server/Features/UserNotify.hs
@@ -6,12 +6,16 @@
 {-# LANGUAGE ScopedTypeVariables #-}
 {-# OPTIONS_GHC -fno-warn-incomplete-uni-patterns #-}
 module Distribution.Server.Features.UserNotify (
+    NotifyData(..),
     NotifyPref(..),
+    NotifyRevisionRange,
     NotifyTriggerBounds(..),
     UserNotifyFeature(..),
     defaultNotifyPrefs,
     dependencyReleaseEmails,
-    initUserNotifyFeature
+    importNotifyPref,
+    initUserNotifyFeature,
+    notifyDataToCSV,
   ) where
 
 import Prelude hiding (lookup)
@@ -131,7 +135,7 @@ defaultNotifyPrefs = NotifyPref {
                        notifyDependencyTriggerBounds = NewIncompatibility
                      }
 
-data NotifyRevisionRange = NotifyAllVersions | NotifyNewestVersion | NoNotifyRevisions deriving (Eq, Enum, Read, Show, Typeable)
+data NotifyRevisionRange = NotifyAllVersions | NotifyNewestVersion | NoNotifyRevisions deriving (Bounded, Enum, Eq, Read, Show, Typeable)
 instance MemSize NotifyRevisionRange where
   memSize _ = 1
 
@@ -148,7 +152,7 @@ data NotifyTriggerBounds
   = Always
   | BoundsOutOfRange
   | NewIncompatibility
-  deriving (Eq, Enum, Read, Show, Typeable)
+  deriving (Bounded, Enum, Eq, Read, Show, Typeable)
 
 instance MemSize NotifyTriggerBounds where
   memSize _ = 1

--- a/src/Distribution/Server/Features/UserNotify.hs
+++ b/src/Distribution/Server/Features/UserNotify.hs
@@ -659,7 +659,13 @@ userNotifyFeature ServerEnv{serverBaseURI, serverCron}
                   ++ map display revDeps
         dependencyEmailTextMaps <- Map.mapKeys fst <$> Map.traverseWithKey emailText dependencyEmailMap
 
-        mapM_ (sendNotifyEmail users) . Map.toList $ foldr1 (Map.unionWith (++)) $ [revisionUploadEmails, groupActionEmails, docReportEmails, tagProposalEmails, dependencyEmailTextMaps]
+        -- Concat the constituent email parts such that only one email is sent per user
+        mapM_ (sendNotifyEmail users) . Map.toList $ foldr1 (Map.unionWith (++)) $ [revisionUploadEmails, groupActionEmails, docReportEmails, tagProposalEmails]
+
+        -- Dependency email notifications consist of multiple paragraphs, so it would be confusing if concatenated.
+        -- So they're sent independently.
+        mapM_ (sendNotifyEmail users) . Map.toList $ dependencyEmailTextMaps
+
         updateState notifyState (SetNotifyTime now)
 
     formatTimeUser users t u =

--- a/src/Distribution/Server/Framework/BackupRestore.hs
+++ b/src/Distribution/Server/Framework/BackupRestore.hs
@@ -35,6 +35,7 @@ module Distribution.Server.Framework.BackupRestore (
     restoreAddBlob,
     restoreGetBlob,
     restoreFindBlob,
+    runRestore,
 
     AbstractRestoreBackup(..),
     abstractRestoreBackup

--- a/tests/ReverseDependenciesTest.hs
+++ b/tests/ReverseDependenciesTest.hs
@@ -56,6 +56,14 @@ newBaseReleased =
   , mkPackage "mtl" [2,3] ["base < 4.15"]
   ]
 
+newVersionOfOldBase :: [PkgInfo]
+newVersionOfOldBase =
+  [ mkPackage "base" [4,14] []
+  , mkPackage "base" [4,14,1] []
+  , mkPackage "base" [4,15] []
+  , mkPackage "mtl" [2,3] ["base >= 4.15"]
+  ]
+
 twoNewBasesReleased :: [PkgInfo]
 twoNewBasesReleased =
   [ mkPackage "base" [4,14] []
@@ -177,6 +185,7 @@ allTests = testGroup "ReverseDependenciesTest"
               )
             ]
           base4_14 = PackageIdentifier "base" (mkVersion [4,14])
+          base4_14_1 = PackageIdentifier "base" (mkVersion [4,14,1])
           base4_15 = PackageIdentifier "base" (mkVersion [4,15])
           base4_16 = PackageIdentifier "base" (mkVersion [4,16])
           runWithPref preferences index pkg = runIdentity $
@@ -201,6 +210,10 @@ allTests = testGroup "ReverseDependenciesTest"
         "dependencyReleaseEmails(trigger=BoundsOutOfRange) should generate a notification when package is two base versions behind"
         (refNotification base4_16)
         (runWithPref (pref BoundsOutOfRange) (PackageIndex.fromList twoNewBasesReleased) base4_16)
+      assertEqual
+        "dependencyReleaseEmails(trigger=BoundsOutOfRange) shouldn't generate a notification when the new package is for an old release series"
+        mempty
+        (runWithPref (pref BoundsOutOfRange) (PackageIndex.fromList newVersionOfOldBase) base4_14_1)
   , testCase "hedgehogTests" $ do
       res <- hedgehogTests
       assertEqual "hedgehog test pass" True res

--- a/tests/ReverseDependenciesTest.hs
+++ b/tests/ReverseDependenciesTest.hs
@@ -199,10 +199,6 @@ allTests = testGroup "ReverseDependenciesTest"
         "dependencyReleaseEmails(trigger=BoundsOutOfRange) should generate a notification when package is two base versions behind"
         (refNotification base4_16)
         (runWithPref (pref BoundsOutOfRange) (PackageIndex.fromList twoNewBasesReleased) base4_16)
-      assertEqual
-        "dependencyReleaseEmails(trigger=NewIncompatibility) should generate a notification when package is a single base version behind"
-        (refNotification base4_15)
-        (runWithPref (pref NewIncompatibility) (PackageIndex.fromList newBaseReleased) base4_15)
   , testCase "hedgehogTests" $ do
       res <- hedgehogTests
       assertEqual "hedgehog test pass" True res


### PR DESCRIPTION
Tested by:
1. lowering limits as explained in `UserNotify.hs` to 1 minute
2. installing postfix, configuring it for "Localhost delivery only" and changing my Hackage user's email to `janus@myhostname.local.domain`
3. enable the notification on the preferences page, opt in to notifications
4. uploading transformers-0.5.6.2 (with patches to fix stricter cabal file validation)
5. uploading servant-0.19.1 (which doesn't accept transformers-0.6)
6. uploading transformers-0.6.0.6
7. after a minute, verified using `mail(1)` from the package `bsd-mailx` that the mail was delivered and the link works