### PR TITLE
update `doctest-parallel`

### DIFF
--- a/hackage-server.cabal
+++ b/hackage-server.cabal
@@ -651,5 +651,5 @@ test-suite DocTests
 
   build-depends:
     , lib-server
-    , doctest-parallel ^>= 0.2.2
+    , doctest-parallel >= 0.3.0
         -- doctest-parallel-0.2.2 is the first to filter out autogen-modules


### PR DESCRIPTION
Attempting to use https://hackage.haskell.org/package/doctest-parallel-0.3.0

It works fine with GHC 9.4.

With GHC 9.0 and 9.2, there appear to be some intermittent errors.

```
[ERROR  ] [ThreadId 240] Could not import module: Distribution.Server.Util.Markdown. This can be caused by a number of issues: 

[ERROR  ] [ThreadId 240]  1. A module found by GHC contained tests, but was not in 'exposed-modules'. If you want
[ERROR  ] [ThreadId 240]     to test non-exposed modules follow the instructions here:
[ERROR  ] [ThreadId 240]     https://github.com/martijnbastiaan/doctest-parallel#test-non-exposed-modules

[ERROR  ] [ThreadId 240]  2. For Cabal users: Cabal did not generate a GHC environment file. Either:
[ERROR  ] [ThreadId 240]    * Run with '--write-ghc-environment-files=always'
[ERROR  ] [ThreadId 240]    * Add 'write-ghc-environment-files: always' to your cabal.project

[ERROR  ] [ThreadId 240]  3. For Cabal users: Cabal did not generate a GHC environment file in time. This
[ERROR  ] [ThreadId 240]     can happen if you use 'cabal test' instead of 'cabal run doctests'. See
[ERROR  ] [ThreadId 240]     https://github.com/martijnbastiaan/doctest-parallel/issues/22.

[ERROR  ] [ThreadId 240]  4. The testsuite executable does not have a dependency on your project library. Please
[ERROR  ] [ThreadId 240]     add it to the 'build-depends' section of the testsuite executable.

[ERROR  ] [ThreadId 240] See the example project at https://github.com/martijnbastiaan/doctest-parallel/blob/main/example/README.md for more information.

```

I believe I've checked all 4 suggestions.

Suggestion 1, module is exposed:
https://github.com/haskell/hackage-server/blob/ddad0f500f357aa4388842140f75c827b6401d32/hackage-server.cabal#L268

Suggestion 2: 
https://github.com/haskell/hackage-server/blob/ddad0f500f357aa4388842140f75c827b6401d32/cabal.project#L71

Suggestion 3 does not appear to solve it: https://github.com/martijnbastiaan/doctest-parallel/issues/22

Suggestion 4, dependency is correct:
https://github.com/haskell/hackage-server/blob/ddad0f500f357aa4388842140f75c827b6401d32/hackage-server.cabal#L646-L654
