### PR TITLE
fix `incomplete-uni-patterns` warnings

### DIFF
--- a/exes/Main.hs
+++ b/exes/Main.hs
@@ -1,3 +1,4 @@
+{-# OPTIONS_GHC -fno-warn-incomplete-uni-patterns #-}
 module Main where
 
 import qualified Distribution.Server as Server
@@ -357,19 +358,15 @@ runAction opts = do
                -> return n
       _        -> fail $ "bad port number " ++ show str
 
-    checkHostURI :: ServerConfig -> Maybe String -> Int -> IO URI
     checkHostURI defaults Nothing port = do
       let guessURI       = confHostUri defaults
-      case uriAuthority guessURI of
-        Nothing -> fail "No URI Authority"
-        Just authority -> let
+          Just authority = uriAuthority guessURI
           portStr | port == 80 = ""
                   | otherwise  = ':' : show port
           guessURI' = guessURI { uriAuthority = Just authority { uriPort = portStr } }
-          in do
-          lognotice verbosity $ "Guessing public URI as " ++ show guessURI'
+      lognotice verbosity $ "Guessing public URI as " ++ show guessURI'
                         ++ "\n(you can override with the --base-uri= flag)"
-          return guessURI'
+      return guessURI'
 
     checkHostURI _        (Just str) _ = case parseAbsoluteURI str of
       Nothing -> fail $ "Cannot parse as a URI: " ++ str ++ "\n"

--- a/exes/Main.hs
+++ b/exes/Main.hs
@@ -357,15 +357,19 @@ runAction opts = do
                -> return n
       _        -> fail $ "bad port number " ++ show str
 
+    checkHostURI :: ServerConfig -> Maybe String -> Int -> IO URI
     checkHostURI defaults Nothing port = do
       let guessURI       = confHostUri defaults
-          Just authority = uriAuthority guessURI
+      case uriAuthority guessURI of
+        Nothing -> fail "No URI Authority"
+        Just authority -> let
           portStr | port == 80 = ""
                   | otherwise  = ':' : show port
           guessURI' = guessURI { uriAuthority = Just authority { uriPort = portStr } }
-      lognotice verbosity $ "Guessing public URI as " ++ show guessURI'
+          in do
+          lognotice verbosity $ "Guessing public URI as " ++ show guessURI'
                         ++ "\n(you can override with the --base-uri= flag)"
-      return guessURI'
+          return guessURI'
 
     checkHostURI _        (Just str) _ = case parseAbsoluteURI str of
       Nothing -> fail $ "Cannot parse as a URI: " ++ str ++ "\n"

--- a/src/Distribution/Server/Features/AdminFrontend.hs
+++ b/src/Distribution/Server/Features/AdminFrontend.hs
@@ -1,4 +1,5 @@
 {-# OPTIONS_GHC -fno-warn-orphans #-}
+{-# OPTIONS_GHC -fno-warn-incomplete-uni-patterns #-}
 {-# LANGUAGE NamedFieldPuns, RecordWildCards #-}
 module Distribution.Server.Features.AdminFrontend (
     initAdminFrontendFeature
@@ -190,7 +191,8 @@ adminFrontendFeature _env templates
         ok $ toResponse $ template
           [ "resets" $= [ resetRequestToTemplate resetInfo uinfo
                         | resetInfo@ResetInfo {resetUserId} <- allResetInfo
-                        , let Just uinfo = Users.lookupUserId resetUserId usersdb ]
+                        , let Just uinfo = Users.lookupUserId resetUserId usersdb
+                        ]
           ]
 
     serveAdminLegacyGet :: DynamicPath -> ServerPartE Response
@@ -203,7 +205,8 @@ adminFrontendFeature _env templates
         ok $ toResponse $ template
           [ "accounts" $= [ accountBasicInfoToTemplate uid uinfo
                           | uid <- legacyUsers
-                          , let Just uinfo = Users.lookupUserId uid usersdb ]
+                          , let Just uinfo = Users.lookupUserId uid usersdb
+                          ]
           ]
 
     resetRequestToTemplate :: SignupResetInfo -> UserInfo -> TemplateVal

--- a/src/Distribution/Server/Features/UserSignup.hs
+++ b/src/Distribution/Server/Features/UserSignup.hs
@@ -1,3 +1,4 @@
+{-# OPTIONS_GHC -fno-warn-incomplete-uni-patterns #-}
 {-# LANGUAGE DeriveDataTypeable, GeneralizedNewtypeDeriving,
              TypeFamilies, TemplateHaskell,
              RankNTypes, NamedFieldPuns, RecordWildCards, BangPatterns #-}


### PR DESCRIPTION
the `flake.nix` build fails on these warnings: https://github.com/haskell/hackage-server/pull/1154

No effective changes in this PR