### PR TITLE
Case-insensitive changelog & readme file extension check

### DIFF
--- a/src/Distribution/Server/Packages/ChangeLog.hs
+++ b/src/Distribution/Server/Packages/ChangeLog.hs
@@ -8,9 +8,9 @@ import Data.Char as Char
 
 
 isChangeLogFile :: FilePath -> Bool
-isChangeLogFile fname = map Char.toLower base `elem` basenames
+isChangeLogFile fname = base `elem` basenames
                         && ext `elem` extensions
   where
-    (base, ext) = splitExtension fname
+    (base, ext) = splitExtension (map Char.toLower fname)
     basenames  = ["news", "changelog", "change_log", "changes"]
     extensions = ["", ".txt", ".md", ".markdown"]

--- a/src/Distribution/Server/Packages/Readme.hs
+++ b/src/Distribution/Server/Packages/Readme.hs
@@ -6,9 +6,9 @@ import System.FilePath (splitExtension)
 import Data.Char as Char
 
 isReadmeFile :: FilePath -> Bool
-isReadmeFile fname = map Char.toLower base `elem` basenames
-                        && ext `elem` extensions
+isReadmeFile fname = base `elem` basenames
+                     && ext `elem` extensions
   where
-    (base, ext) = splitExtension fname
+    (base, ext) = splitExtension (map Char.toLower fname)
     basenames  = ["readme"]
     extensions = ["", ".txt", ".html", ".md", ".markdown"]


### PR DESCRIPTION
It is not uncommon to have files like README.TXT or NEWS.TXT.