### PR TITLE
Fix lastVersion update in listings

### DIFF
--- a/src/Distribution/Server/Features/PackageList.hs
+++ b/src/Distribution/Server/Features/PackageList.hs
@@ -134,7 +134,10 @@ initListFeature _env = do
 
       registerHookJust packageChangeHook isPackageAdd $ \pkg -> do
         let pkgname = packageName . packageId $ pkg
-        modifyItem pkgname (\x -> x {itemLastUpload = fst (pkgOriginalUploadInfo pkg)})
+        modifyItem pkgname $ \x -> x
+          {itemLastUpload = fst (pkgOriginalUploadInfo pkg)
+          ,itemLastVersion = prettyShow $ pkgVersion $ pkgInfoId pkg
+          }
         runHook_ itemUpdate (Set.singleton pkgname)
 
       registerHook groupChangedHook $ \(gd,_,_,_,_) ->


### PR DESCRIPTION
Following my PR Adding lastVersion inlistings (#1140), [@ysangkok noticed they didn't update as new version get published](https://github.com/haskell/hackage-server/pull/1140#issuecomment-1409707808).

This PR attempts to fix it.

Before:

![image](https://user-images.githubusercontent.com/1362807/218324076-e151f83c-e07d-4aa6-a5c4-97dedc77aa5a.png)

After:

![image](https://user-images.githubusercontent.com/1362807/218324128-17040c3c-dd07-443a-8fd9-48c83e22e2af.png)

Thanks again @ysangkok 
