### PR TITLE
Update link to CLC on the main page

### DIFF
--- a/datafiles/templates/index.html.st
+++ b/datafiles/templates/index.html.st
@@ -78,7 +78,7 @@ command.</li>
 <li><a href="https://wiki.haskell.org/Taking_over_a_package">Taking over a package</a></li>
 <li><a href="https://wiki.haskell.org/Abandoning_a_package">Abandoning a package</a></li>
 <li><a href="https://wiki.haskell.org/Hackage_trustees">Hackage trustees</a> and what they do</li>
-<li><a href="https://github.com/haskell/core-libraries-committee/blob/main/PROPOSALS.md">Submitting  changes</a> for the core libraries</li>
+<li><a href="https://github.com/haskell/core-libraries-committee/blob/main/PROPOSALS.md">Submitting  changes</a> for the base library</li>
 </ul>
 
 <h2 id="reporting-problems">Reporting problems</h2>

--- a/datafiles/templates/index.html.st
+++ b/datafiles/templates/index.html.st
@@ -78,7 +78,7 @@ command.</li>
 <li><a href="https://wiki.haskell.org/Taking_over_a_package">Taking over a package</a></li>
 <li><a href="https://wiki.haskell.org/Abandoning_a_package">Abandoning a package</a></li>
 <li><a href="https://wiki.haskell.org/Hackage_trustees">Hackage trustees</a> and what they do</li>
-<li><a href="https://wiki.haskell.org/Library_submissions">Submitting  changes</a> for the core libraries</li>
+<li><a href="https://github.com/haskell/core-libraries-committee/blob/main/PROPOSALS.md">Submitting  changes</a> for the core libraries</li>
 </ul>
 
 <h2 id="reporting-problems">Reporting problems</h2>


### PR DESCRIPTION
The `Submitting changes for the core libraries` links to an outdated wiki page which redirects to the CLC GitHub repository.

I propose to link directly to the CLC repository

Links in question:

* https://wiki.haskell.org/Library_submissions
* https://github.com/haskell/core-libraries-committee/blob/main/PROPOSALS.md