### PR TITLE
disable macOS in Nix Flake GitHub Action

### DIFF
--- a/.github/workflows/nix-flake.yml
+++ b/.github/workflows/nix-flake.yml
@@ -13,7 +13,7 @@ jobs:
       matrix:
         os:
         - ubuntu-latest
-        - macos-latest
+        # - macos-latest
     name: Nix on ${{ matrix.os }}
     runs-on: ${{ matrix.os }}
     steps:


### PR DESCRIPTION
Disabling Mac build in the Nix Flake GitHub Action until we are sure about the usage limits
https://docs.github.com/en/billing/managing-billing-for-github-actions/about-billing-for-github-actions