### PR TITLE
Fix #1102: remove "." from "Deprecated. in favour of FOO"

### DIFF
--- a/datafiles/templates/Html/package-page.html.st
+++ b/datafiles/templates/Html/package-page.html.st
@@ -36,7 +36,7 @@
 
     $if(isDeprecated)$
     <div id="deprecated">
-      <span style="color:#D00B3C">Deprecated.</span>
+      <span style="color:#D00B3C">Deprecated</span>
       $deprecatedMsg$
     </div>
     $else$


### PR DESCRIPTION
Fix #1102: remove "." from "Deprecated. in favour of FOO"