### PR TITLE
Sorted table column background color

### DIFF
--- a/datafiles/templates/Html/candidate-index.html.st
+++ b/datafiles/templates/Html/candidate-index.html.st
@@ -2,9 +2,9 @@
 <html>
 
     <head>
-        $hackageCssTheme()$
         <script src="/static/jquery.min.js"></script>
         <link rel="stylesheet" type="text/css" href="https://cdn.datatables.net/v/dt/dt-1.11.4/sp-1.4.0/datatables.min.css"/>
+        $hackageCssTheme()$
 
         <script type="text/javascript" src="https://cdn.datatables.net/v/dt/dt-1.11.4/sp-1.4.0/datatables.min.js"></script>
         <title>Package candidates | Hackage</title>

--- a/datafiles/templates/Html/table-interface.html.st
+++ b/datafiles/templates/Html/table-interface.html.st
@@ -2,13 +2,13 @@
 <html>
 
     <head>
-        $hackageCssTheme()$
         $if(!noDatatable)$
         <script src="/static/jquery.min.js"></script>
         <link rel="stylesheet" type="text/css" href="https://cdn.datatables.net/v/dt/dt-1.11.4/sp-1.4.0/datatables.min.css"/>
 
         <script type="text/javascript" src="https://cdn.datatables.net/v/dt/dt-1.11.4/sp-1.4.0/datatables.min.js"></script>
         $endif$
+        $hackageCssTheme()$
         <title>All packages by name | Hackage</title>
     </head>
 


### PR DESCRIPTION
https://github.com/haskell/hackage-server/issues/1199

The issue was that `datatables.min.css` took precedence over `hackage.css`. I have reversed this. I have not yet checked for other problems that may be caused by this change.

![Screenshot 2023-05-21 at 14-48-11 All packages by name Hackage](https://github.com/haskell/hackage-server/assets/6315338/cde831c8-cf0c-4ed1-b9e5-8e5110984a29)


TODO fix the other issues mentioned
In a different PR