### PR TITLE
enable  Mac build in GitHub Action

### DIFF
--- a/.github/workflows/nix-flake.yml
+++ b/.github/workflows/nix-flake.yml
@@ -17,8 +17,8 @@ jobs:
     name: Nix on ${{ matrix.os }}
     runs-on: ${{ matrix.os }}
     steps:
-    - uses: actions/checkout@v3.1.0
-    - uses: cachix/install-nix-action@v21
+    - uses: actions/checkout@v3.5.3
+    - uses: cachix/install-nix-action@v22
       with:
         extra_nix_config: |
           trusted-public-keys = hydra.iohk.io:f/Ea+s+dFdN+3Y/G+FDgSq+a5NEWhJGzdjvKNGv0/EQ= cache.nixos.org-1:6NCHdD59X431o0gWypbMrAURkbJ16ZPMQFGspcDShjY= hackage-server.cachix.org-1:iw0iRh6+gsFIrxROFaAt5gKNgIHejKjIfyRdbpPYevY=

--- a/.github/workflows/nix-flake.yml
+++ b/.github/workflows/nix-flake.yml
@@ -29,4 +29,4 @@ jobs:
         name: hackage-server
         authToken: '${{ secrets.CACHIX_AUTH_TOKEN }}'
     - run: nix build
-    - run: nix flake check
+    # - run: nix flake check

--- a/.github/workflows/nix-flake.yml
+++ b/.github/workflows/nix-flake.yml
@@ -13,7 +13,7 @@ jobs:
       matrix:
         os:
         - ubuntu-latest
-        # - macos-latest
+        - macos-latest
     name: Nix on ${{ matrix.os }}
     runs-on: ${{ matrix.os }}
     steps:
@@ -29,4 +29,4 @@ jobs:
         name: hackage-server
         authToken: '${{ secrets.CACHIX_AUTH_TOKEN }}'
     - run: nix build
-    # - run: nix flake check
+    - run: nix flake check


### PR DESCRIPTION
https://github.com/haskell/hackage-server/issues/1193

`nix flake check` restricted to current system in latest Nix version, so there should be no error "Mac required but I am a Linux", or vice versa