### PR TITLE
Fix package list when user has multiple packages

### DIFF
--- a/src/Distribution/Server/Features/UserNotify.hs
+++ b/src/Distribution/Server/Features/UserNotify.hs
@@ -473,7 +473,7 @@ dependencyReleaseEmails userSetIdForPackage index (ReverseIndex revs nodemap dep
         revDepNames = mapMaybe (`lookupR` nodemap) (Set.toList vertices)
       toNotify <- traverse maintainersToNotify revDepNames
       pure $
-        Map.fromList
+        Map.fromListWith (++)
           [ ( (maintainerId, pkgId), [ packageId latestRevDep ] )
           | (ids, latestRevDep) <- toNotify
           , maintainerId <- ids


### PR DESCRIPTION
This fixes an issue @AndreasAbel encountered where you'd only get notified for one of the packages that you maintain, instead of all of them, as you'd expect.

Greetings from MuniHac!