### PR TITLE
Prepare for GHC 9.8 / Cabal 3.11

### DIFF
--- a/.github/workflows/cabal.yml
+++ b/.github/workflows/cabal.yml
@@ -14,14 +14,14 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        ghc: ['9.4.4', '9.2.7', '9.0.2']
-        cabal: ['3.8.1.0']
+        ghc: ['9.6.2', '9.4.5', '9.2.8', '9.0.2']
+        cabal: ['3.10.1.0']
         os: [ubuntu-latest]
     name: Cabal with GHC ${{ matrix.ghc }}
     steps:
       - uses: actions/checkout@v3
       - name: Setup Haskell
-        uses: haskell/actions/setup@v2
+        uses: haskell-actions/setup@v2
         with:
           ghc-version: ${{ matrix.ghc }}
           cabal-version: ${{ matrix.cabal }}
@@ -33,27 +33,30 @@ jobs:
         run: cabal test all --enable-tests
       - name: Haddock
         run: cabal haddock all
-  build_with_mtl_2_3:
-    runs-on: ${{ matrix.os }}
-    strategy:
-      fail-fast: false
-      matrix:
-        ghc: ['9.4.4']
-        cabal: ['3.8.1.0']
-        os: [ubuntu-latest]
-    name: Cabal with GHC ${{ matrix.ghc }} and mtl >= 2.3.1
-    steps:
-      - uses: actions/checkout@v3
-      - name: Setup Haskell
-        uses: haskell/actions/setup@v2
-        with:
-          ghc-version: ${{ matrix.ghc }}
-          cabal-version: ${{ matrix.cabal }}
-      - name: Install dependencies
-        run: sudo apt install -y libbrotli-dev libgd-dev
-      - name: Build dependencies with mtl >= 2.3.1
-        # 2022-12-30: 'transformers >= 0.6' is needed because of happstack-server
-        run: cabal build all --disable-tests --dependencies-only -O0 --constraint 'mtl >= 2.3.1' --constraint 'transformers >= 0.6' --allow-newer='Cabal:mtl' --allow-newer='Cabal:transformers'
-      - name: Build with mtl >= 2.3.1
-        # 2022-12-30: 'transformers >= 0.6' is needed because of happstack-server
-        run: cabal build all --disable-tests -O0 --constraint 'mtl >= 2.3.1' --constraint 'transformers >= 0.6' --allow-newer='Cabal:mtl' --allow-newer='Cabal:transformers'
+
+  ## Andreas, 2023-08-03: mtl-2.3 is covered by GHC 9.6
+  #
+  # build_with_mtl_2_3:
+  #   runs-on: ${{ matrix.os }}
+  #   strategy:
+  #     fail-fast: false
+  #     matrix:
+  #       ghc: ['9.4.4']
+  #       cabal: ['3.8.1.0']
+  #       os: [ubuntu-latest]
+  #   name: Cabal with GHC ${{ matrix.ghc }} and mtl >= 2.3.1
+  #   steps:
+  #     - uses: actions/checkout@v3
+  #     - name: Setup Haskell
+  #       uses: haskell/actions/setup@v2
+  #       with:
+  #         ghc-version: ${{ matrix.ghc }}
+  #         cabal-version: ${{ matrix.cabal }}
+  #     - name: Install dependencies
+  #       run: sudo apt install -y libbrotli-dev libgd-dev
+  #     - name: Build dependencies with mtl >= 2.3.1
+  #       # 2022-12-30: 'transformers >= 0.6' is needed because of happstack-server
+  #       run: cabal build all --disable-tests --dependencies-only -O0 --constraint 'mtl >= 2.3.1' --constraint 'transformers >= 0.6' --allow-newer='Cabal:mtl' --allow-newer='Cabal:transformers'
+  #     - name: Build with mtl >= 2.3.1
+  #       # 2022-12-30: 'transformers >= 0.6' is needed because of happstack-server
+  #       run: cabal build all --disable-tests -O0 --constraint 'mtl >= 2.3.1' --constraint 'transformers >= 0.6' --allow-newer='Cabal:mtl' --allow-newer='Cabal:transformers'

--- a/.github/workflows/haskell-ci.yml
+++ b/.github/workflows/haskell-ci.yml
@@ -8,9 +8,9 @@
 #
 # For more information, see https://github.com/haskell-CI/haskell-ci
 #
-# version: 0.15.20230321
+# version: 0.16.6.20230729
 #
-# REGENDATA ("0.15.20230321",["github","hackage-server.cabal"])
+# REGENDATA ("0.16.6.20230729",["github","hackage-server.cabal"])
 #
 name: Haskell-CI
 on:
@@ -34,19 +34,19 @@ jobs:
     strategy:
       matrix:
         include:
-          - compiler: ghc-9.6.1
+          - compiler: ghc-9.6.2
             compilerKind: ghc
-            compilerVersion: 9.6.1
+            compilerVersion: 9.6.2
             setup-method: ghcup
             allow-failure: false
-          - compiler: ghc-9.4.4
+          - compiler: ghc-9.4.5
             compilerKind: ghc
-            compilerVersion: 9.4.4
+            compilerVersion: 9.4.5
             setup-method: ghcup
             allow-failure: false
-          - compiler: ghc-9.2.7
+          - compiler: ghc-9.2.8
             compilerKind: ghc
-            compilerVersion: 9.2.7
+            compilerVersion: 9.2.8
             setup-method: ghcup
             allow-failure: false
           - compiler: ghc-9.0.2
@@ -71,7 +71,7 @@ jobs:
           apt-get update
           apt-get install -y --no-install-recommends gnupg ca-certificates dirmngr curl git software-properties-common libtinfo5
           mkdir -p "$HOME/.ghcup/bin"
-          curl -sL https://downloads.haskell.org/ghcup/0.1.19.2/x86_64-linux-ghcup-0.1.19.2 > "$HOME/.ghcup/bin/ghcup"
+          curl -sL https://downloads.haskell.org/ghcup/0.1.19.5/x86_64-linux-ghcup-0.1.19.5 > "$HOME/.ghcup/bin/ghcup"
           chmod a+x "$HOME/.ghcup/bin/ghcup"
           "$HOME/.ghcup/bin/ghcup" install ghc "$HCVER" || (cat "$HOME"/.ghcup/logs/*.* && false)
           "$HOME/.ghcup/bin/ghcup" install cabal 3.10.1.0 || (cat "$HOME"/.ghcup/logs/*.* && false)
@@ -142,8 +142,8 @@ jobs:
       - name: install cabal-plan
         run: |
           mkdir -p $HOME/.cabal/bin
-          curl -sL https://github.com/haskell-hvr/cabal-plan/releases/download/v0.6.2.0/cabal-plan-0.6.2.0-x86_64-linux.xz > cabal-plan.xz
-          echo 'de73600b1836d3f55e32d80385acc055fd97f60eaa0ab68a755302685f5d81bc  cabal-plan.xz' | sha256sum -c -
+          curl -sL https://github.com/haskell-hvr/cabal-plan/releases/download/v0.7.3.0/cabal-plan-0.7.3.0-x86_64-linux.xz > cabal-plan.xz
+          echo 'f62ccb2971567a5f638f2005ad3173dba14693a45154c1508645c52289714cb2  cabal-plan.xz' | sha256sum -c -
           xz -d < cabal-plan.xz > $HOME/.cabal/bin/cabal-plan
           rm -f cabal-plan.xz
           chmod a+x $HOME/.cabal/bin/cabal-plan

--- a/hackage-server.cabal
+++ b/hackage-server.cabal
@@ -129,7 +129,7 @@ common defaults
     , scientific
   -- other dependencies shared by most components
   build-depends:
-    , aeson                 ^>= 2.0.3.0 || ^>= 2.1.0.0
+    , aeson                 ^>= 2.2.0.0
     , Cabal                  >= 3.10.1.0 && < 3.12
     , Cabal-syntax           >= 3.10.1.0 && < 3.12
         -- Cabal-syntax needs to be bound to constrain hackage-security
@@ -547,6 +547,7 @@ test-suite HighLevelTest
   build-depends:
     -- version constraints inherited from lib-server
     , HTTP
+    , attoparsec-aeson ^>= 2.2.0.0
     , base64-bytestring
     , random
       -- component-specific dependencies

--- a/hackage-server.cabal
+++ b/hackage-server.cabal
@@ -111,11 +111,11 @@ common defaults
   -- see `cabal.project.local-ghc-${VERSION}` files
   build-depends:
     , array                  >= 0.5   && < 0.6
-    , base                   >= 4.13  && < 4.19
+    , base                   >= 4.13  && < 4.20
     , binary                 >= 0.8   && < 0.9
     , bytestring             >= 0.10  && < 0.12
     , containers            ^>= 0.6.0
-    , deepseq                >= 1.4   && < 1.5
+    , deepseq                >= 1.4   && < 1.6
     , directory              >= 1.3   && < 1.4
     , filepath               >= 1.4   && < 1.5
     , mtl                    >= 2.2.1 && < 2.4
@@ -564,7 +564,7 @@ test-suite ReverseDependenciesTest
     , tasty        ^>= 1.4
     , tasty-hunit  ^>= 0.10
     , HUnit        ^>= 1.6
-    , hedgehog     ^>= 1.2
+    , hedgehog     ^>= 1.3
     , exceptions
     , bimap
   other-modules: RevDepCommon

--- a/hackage-server.cabal
+++ b/hackage-server.cabal
@@ -27,7 +27,13 @@ copyright:    2008-2015 Duncan Coutts,
 license:      BSD-3-Clause
 license-file: LICENSE
 
-tested-with: GHC == { 9.6.1, 9.4.4, 9.2.7, 9.0.2, 8.10.7, 8.8.4 }
+tested-with:
+  GHC == 9.6.2
+  GHC == 9.4.5
+  GHC == 9.2.8
+  GHC == 9.0.2
+  GHC == 8.10.7
+  GHC == 8.8.4
 
 data-dir: datafiles
 data-files:

--- a/hackage-server.cabal
+++ b/hackage-server.cabal
@@ -130,8 +130,8 @@ common defaults
   -- other dependencies shared by most components
   build-depends:
     , aeson                 ^>= 2.0.3.0 || ^>= 2.1.0.0
-    , Cabal                 ^>= 3.10.1.0
-    , Cabal-syntax          ^>= 3.10.1.0
+    , Cabal                  >= 3.10.1.0 && < 3.12
+    , Cabal-syntax           >= 3.10.1.0 && < 3.12
         -- Cabal-syntax needs to be bound to constrain hackage-security
         -- see https://github.com/haskell/hackage-server/issues/1130
     , fail                  ^>= 4.9.0

--- a/tests/HttpUtils.hs
+++ b/tests/HttpUtils.hs
@@ -27,7 +27,8 @@ import Control.Monad
 import Data.Maybe
 import Network.HTTP hiding (user)
 import Network.HTTP.Auth
-import Data.Aeson (Result(..), Value(..), FromJSON(..), (.:), fromJSON, json')
+import Data.Aeson (Result(..), Value(..), FromJSON(..), (.:), fromJSON)
+import Data.Aeson.Parser (json')
 import System.Exit (die)
 
 import qualified Network.Http.Client as HC


### PR DESCRIPTION
Prepare for GHC 9.8.  Commits:
- haiku: add as known platform
- Bump aeson to ^>= 2.2.0.0, use attoparsec-aeson
- Bumps, to allow building with GHC 9.8.1-alpha1
- CI: bump haskell-ci.yml to GHCs 9.6.2 9.4.5 9.2.8
- CI: bump cabal.yml to GHC 9.6.2 and cabal 3.10.1.0

Subsumes:
- #1217
- #1221 

Tested on GHC 9.8.1-alpha1 locally.  Needed these settings in a `cabal.project.local`:
```
write-ghc-environment-files: always

constraints: Cabal-syntax >= 3.11
constraints: Cabal >= 3.11
constraints: th-abstraction >= 0.6
constraints: aeson >= 2.2.0.0

allow-newer: *:base
allow-newer: *:template-haskell
allow-newer: *:ghc-prim
allow-newer: *:Cabal-syntax
allow-newer: *:Cabal
allow-newer: *:deepseq
allow-newer: *:th-abstraction

constraints: array            installed
constraints: base             installed
constraints: binary           installed
constraints: bytestring       installed
constraints: containers       installed
constraints: deepseq          installed
constraints: directory        installed
constraints: filepath         installed
constraints: ghc              installed
constraints: ghc-boot         installed
constraints: ghc-boot-th      installed
constraints: ghc-heap         installed
constraints: ghc-prim         installed
constraints: ghci             installed
constraints: hpc              installed
constraints: integer-gmp      installed
constraints: mtl              installed
constraints: pretty           installed
constraints: process          installed
constraints: rts              installed
constraints: stm              installed
constraints: template-haskell installed
constraints: terminfo         installed
constraints: time             installed
constraints: transformers     installed
constraints: unix             installed
constraints: xhtml            installed

source-repository-package
  type:     git
  location: https://github.com/TeofilC/aeson
  tag:      d79464b0e1b3f1796325528ec253bb05685acf5c

source-repository-package
  type:     git
  location: https://github.com/TeofilC/aeson
  tag:      d79464b0e1b3f1796325528ec253bb05685acf5c
  subdir:   attoparsec-aeson

source-repository-package
  type:     git
  location: https://github.com/acid-state/acid-state
  tag:      479e3be5258e310b93d19d92fcd0c74f19c08623
```
