### PR TITLE
fix `flake.nix` for Linux

### DIFF
--- a/.github/workflows/nix-flake.yml
+++ b/.github/workflows/nix-flake.yml
@@ -9,7 +9,7 @@ on:
 jobs:
   nix:
     strategy:
-      fail-fast: true
+      fail-fast: false
       matrix:
         os:
         - ubuntu-latest

--- a/flake.lock
+++ b/flake.lock
@@ -48,94 +48,6 @@
         "type": "github"
       }
     },
-    "hls-floskell-plugin": {
-      "flake": false,
-      "locked": {
-        "dir": "plugins/hls-floskell-plugin",
-        "lastModified": 1682176345,
-        "narHash": "sha256-WmkHsjI0HgdAK+EY45pHsPUAOAoyDSTj+bpB3v3T+/g=",
-        "owner": "haskell",
-        "repo": "haskell-language-server",
-        "rev": "6640ebf33eeb8a62ccd094e2f47f69106acfd200",
-        "type": "github"
-      },
-      "original": {
-        "dir": "plugins/hls-floskell-plugin",
-        "owner": "haskell",
-        "repo": "haskell-language-server",
-        "type": "github"
-      }
-    },
-    "hls-graph": {
-      "flake": false,
-      "locked": {
-        "dir": "hls-graph",
-        "lastModified": 1682176345,
-        "narHash": "sha256-WmkHsjI0HgdAK+EY45pHsPUAOAoyDSTj+bpB3v3T+/g=",
-        "owner": "haskell",
-        "repo": "haskell-language-server",
-        "rev": "6640ebf33eeb8a62ccd094e2f47f69106acfd200",
-        "type": "github"
-      },
-      "original": {
-        "dir": "hls-graph",
-        "owner": "haskell",
-        "repo": "haskell-language-server",
-        "type": "github"
-      }
-    },
-    "hls-hlint-plugin": {
-      "flake": false,
-      "locked": {
-        "dir": "plugins/hls-hlint-plugin",
-        "lastModified": 1682176345,
-        "narHash": "sha256-WmkHsjI0HgdAK+EY45pHsPUAOAoyDSTj+bpB3v3T+/g=",
-        "owner": "haskell",
-        "repo": "haskell-language-server",
-        "rev": "6640ebf33eeb8a62ccd094e2f47f69106acfd200",
-        "type": "github"
-      },
-      "original": {
-        "dir": "plugins/hls-hlint-plugin",
-        "owner": "haskell",
-        "repo": "haskell-language-server",
-        "type": "github"
-      }
-    },
-    "hls-ormolu-plugin": {
-      "flake": false,
-      "locked": {
-        "dir": "plugins/hls-ormolu-plugin",
-        "lastModified": 1682176345,
-        "narHash": "sha256-WmkHsjI0HgdAK+EY45pHsPUAOAoyDSTj+bpB3v3T+/g=",
-        "owner": "haskell",
-        "repo": "haskell-language-server",
-        "rev": "6640ebf33eeb8a62ccd094e2f47f69106acfd200",
-        "type": "github"
-      },
-      "original": {
-        "dir": "plugins/hls-ormolu-plugin",
-        "owner": "haskell",
-        "repo": "haskell-language-server",
-        "type": "github"
-      }
-    },
-    "linear-generics": {
-      "flake": false,
-      "locked": {
-        "lastModified": 1679794303,
-        "narHash": "sha256-2PtZRHVvS0aP2xKV68VE5NmwjK7g/xVIW7gZ0jiulgg=",
-        "owner": "linear-generics",
-        "repo": "linear-generics",
-        "rev": "b3ed84a5c2438f6c000496322a4aa707363c4c7d",
-        "type": "github"
-      },
-      "original": {
-        "owner": "linear-generics",
-        "repo": "linear-generics",
-        "type": "github"
-      }
-    },
     "mission-control": {
       "locked": {
         "lastModified": 1682001320,
@@ -153,16 +65,16 @@
     },
     "nixpkgs": {
       "locked": {
-        "lastModified": 1682109806,
-        "narHash": "sha256-d9g7RKNShMLboTWwukM+RObDWWpHKaqTYXB48clBWXI=",
+        "lastModified": 1691885509,
+        "narHash": "sha256-MCKEstJdWdlUnh3V34SpOZTQj4bOeada+xhDh9U/0y8=",
         "owner": "nixos",
         "repo": "nixpkgs",
-        "rev": "2362848adf8def2866fabbffc50462e929d7fffb",
+        "rev": "163a5a5675d7e95d3856cf6ae2a26227f25a96f8",
         "type": "github"
       },
       "original": {
         "owner": "nixos",
-        "ref": "nixpkgs-unstable",
+        "ref": "haskell-updates",
         "repo": "nixpkgs",
         "type": "github"
       }
@@ -216,54 +128,15 @@
         "type": "github"
       }
     },
-    "nothunks": {
-      "flake": false,
-      "locked": {
-        "lastModified": 1680263759,
-        "narHash": "sha256-LhEmrkKcUk84PoKmeS4HhZjwTbRbKKEZB0O2hAxLkEQ=",
-        "owner": "input-output-hk",
-        "repo": "nothunks",
-        "rev": "006536813c1bfbd1db8f2755734540e654baca05",
-        "type": "github"
-      },
-      "original": {
-        "owner": "input-output-hk",
-        "repo": "nothunks",
-        "type": "github"
-      }
-    },
     "root": {
       "inputs": {
         "flake-parts": "flake-parts",
         "flake-root": "flake-root",
         "haskell-flake": "haskell-flake",
-        "hls-floskell-plugin": "hls-floskell-plugin",
-        "hls-graph": "hls-graph",
-        "hls-hlint-plugin": "hls-hlint-plugin",
-        "hls-ormolu-plugin": "hls-ormolu-plugin",
-        "linear-generics": "linear-generics",
         "mission-control": "mission-control",
         "nixpkgs": "nixpkgs",
         "nixpkgs-140774-workaround": "nixpkgs-140774-workaround",
-        "nothunks": "nothunks",
-        "stylish-haskell": "stylish-haskell",
         "treefmt-nix": "treefmt-nix"
-      }
-    },
-    "stylish-haskell": {
-      "flake": false,
-      "locked": {
-        "lastModified": 1678437708,
-        "narHash": "sha256-XO4HCG1hWwEVr765GjfJwvLOCwICOZ/MkCj1xP2b/w8=",
-        "owner": "haskell",
-        "repo": "stylish-haskell",
-        "rev": "13f1db77f28b62ac6da6abb3c82244d5e740503b",
-        "type": "github"
-      },
-      "original": {
-        "owner": "haskell",
-        "repo": "stylish-haskell",
-        "type": "github"
       }
     },
     "treefmt-nix": {

--- a/flake.nix
+++ b/flake.nix
@@ -1,43 +1,12 @@
 {
   inputs = {
-    nixpkgs.url = "github:nixos/nixpkgs/nixpkgs-unstable";
+    nixpkgs.url = "github:nixos/nixpkgs/haskell-updates";
     flake-parts.url = "github:hercules-ci/flake-parts";
     haskell-flake.url = "github:srid/haskell-flake";
     treefmt-nix.url = "github:numtide/treefmt-nix";
     flake-root.url = "github:srid/flake-root";
     mission-control.url = "github:Platonic-Systems/mission-control";
 
-    linear-generics = {
-      url = "github:linear-generics/linear-generics";
-      flake = false;
-    };
-
-    stylish-haskell = {
-      url = "github:haskell/stylish-haskell";
-      flake = false;
-    };
-
-    nothunks = {
-      url = "github:input-output-hk/nothunks";
-      flake = false;
-    };
-
-    hls-hlint-plugin = {
-      url = "github:haskell/haskell-language-server?dir=plugins/hls-hlint-plugin";
-      flake = false;
-    };
-    hls-floskell-plugin = {
-      url = "github:haskell/haskell-language-server?dir=plugins/hls-floskell-plugin";
-      flake = false;
-    };
-    hls-ormolu-plugin = {
-      url = "github:haskell/haskell-language-server?dir=plugins/hls-ormolu-plugin";
-      flake = false;
-    };
-    hls-graph = {
-      url = "github:haskell/haskell-language-server?dir=hls-graph";
-      flake = false;
-    };
     nixpkgs-140774-workaround.url = "github:srid/nixpkgs-140774-workaround";
   };
 
@@ -59,45 +28,10 @@
             inputs.nixpkgs-140774-workaround.haskellFlakeProjectModules.default
           ];
           packages.hackage-server.root = ./.;  # Auto-discovered by haskell-flake
+
           overrides = self: super: {
             Cabal = super.Cabal_3_10_1_0;
             Cabal-syntax = super.Cabal-syntax_3_10_1_0;
-            doctest-parallel = super.doctest-parallel_0_3_0_1;
-
-            ghc-lib-parser = super.ghc-lib-parser_9_4_4_20221225;
-            ghc-lib-parser-ex = super.ghc-lib-parser-ex_9_4_0_0;
-            text = super.text_2_0_2;
-            parsec = self.callHackage "parsec" "3.1.16.1" {};
-
-            chell = pkgs.haskell.lib.doJailbreak (self.callHackage "chell" "0.5.0.1" {});
-            ghc-boot-th = self.callHackage "ghc-boot-th" "9.2.1" {};
-            hedgehog = self.callHackage "hedgehog" "1.2" {};
-            tasty-hedgehog = self.callHackage "tasty-hedgehog" "1.4.0.0" {};
-            optparse-applicative = pkgs.haskell.lib.doJailbreak (super.optparse-applicative_0_15_1_0);
-            haddock-library = pkgs.haskell.lib.doJailbreak (self.callHackage "haddock-library" "1.11.0" {});
-
-            th-abstraction = self.callHackage "th-abstraction" "0.4.5.0" {};
-            stylish-haskell = super.callCabal2nix "stylish-haskell" inputs.stylish-haskell {};
-
-            nothunks = super.callCabal2nix "nothunks" inputs.nothunks {};
-
-            # requirements of HLS
-            # TODO: fix HLS https://github.com/haskell/haskell-language-server/issues/3518
-            ormolu = self.callHackage "ormolu" "0.5.3.0" {};
-            fourmolu = pkgs.haskell.lib.dontCheck (self.callHackage "fourmolu" "0.10.1.0" {});
-            # hls-floskell-plugin = pkgs.haskell.lib.dontCheck (self.callHackage "hls-floskell-plugin" "1.0.2.0" {});
-            # hls-floskell-plugin = self.callCabal2nix "hls-floskell-plugin" inputs.hls-floskell-plugin {};
-            # hls-graph = self.callCabal2nix "hls-graph" inputs.hls-graph {};
-            # hls-graph = self.callHackage "hls-graph" "1.9.0.0" {};
-            # hls-hlint-plugin = self.callCabal2nix "hls-hlint-plugin" inputs.hls-hlint-plugin {};
-            # hls-hlint-plugin = self.callHackage "hls-hlint-plugin" "1.1.2.0" {};
-            # hls-ormolu-plugin = self.callCabal2nix "hls-ormolu-plugin" inputs.hls-ormolu-plugin {};
-            # hls-ormolu-plugin = self.callHackage "hls-ormolu-plugin" "1.0.2.2" {};
-            # hls-ormolu-plugin = self.callHackage "hls-ormolu-plugin" "1.0.3.0" {};
-            # hls-plugin-api = self.callHackage "hls-plugin-api" "1.6.0.0" {};
-            # hls-test-utils = self.callHackage "hls-test-utils" "1.5.0.0" {};
-
-            hlint = self.callHackage "hlint" "3.5" {};
 
             ghcide = pkgs.haskell.lib.dontCheck (self.callHackage "ghcide" "1.9.0.0" {});
           };

--- a/flake.nix
+++ b/flake.nix
@@ -34,6 +34,9 @@
             Cabal-syntax = super.Cabal-syntax_3_10_1_0;
 
             ghcide = pkgs.haskell.lib.dontCheck (self.callHackage "ghcide" "1.9.0.0" {});
+
+            streamly = self.callHackage "streamly" "0.9.0" {};
+            streamly_0_9_0 = self.callHackage "streamly" "0.9.0" {};
           };
           devShell = {
             hlsCheck.enable = false;

--- a/hackage-server.cabal
+++ b/hackage-server.cabal
@@ -135,7 +135,7 @@ common defaults
     , scientific
   -- other dependencies shared by most components
   build-depends:
-    , aeson                  >= 2.1.0.0
+    , aeson                  >= 2.1.0.0 && < 2.3
     , Cabal                  >= 3.10.1.0 && < 3.12
     , Cabal-syntax           >= 3.10.1.0 && < 3.12
         -- Cabal-syntax needs to be bound to constrain hackage-security
@@ -553,7 +553,7 @@ test-suite HighLevelTest
   build-depends:
     -- version constraints inherited from lib-server
     , HTTP
-    , attoparsec-aeson >= 2.1.0.0
+    , attoparsec-aeson >= 2.1.0.0 && < 2.3
     , base64-bytestring
     , random
       -- component-specific dependencies

--- a/hackage-server.cabal
+++ b/hackage-server.cabal
@@ -135,7 +135,7 @@ common defaults
     , scientific
   -- other dependencies shared by most components
   build-depends:
-    , aeson                 ^>= 2.2.0.0
+    , aeson                  >= 2.1.0.0
     , Cabal                  >= 3.10.1.0 && < 3.12
     , Cabal-syntax           >= 3.10.1.0 && < 3.12
         -- Cabal-syntax needs to be bound to constrain hackage-security
@@ -553,7 +553,7 @@ test-suite HighLevelTest
   build-depends:
     -- version constraints inherited from lib-server
     , HTTP
-    , attoparsec-aeson ^>= 2.2.0.0
+    , attoparsec-aeson >= 2.1.0.0
     , base64-bytestring
     , random
       -- component-specific dependencies


### PR DESCRIPTION
All of these should work now:

- `nix develop`
- `nix build`
- `nix flake check`

https://github.com/haskell/hackage-server/issues/1237

The only risky change is this PR is lowering the lower bound on `aeson` from `2.2.*` to `2.1.*`.  
It's necessary because Nix is still on `aeson` 2.1. This is true for both `nixpkgs-unstable` and the newer branch `haskell-updates`: https://github.com/NixOS/nixpkgs/tree/haskell-updates

Is this okay? 


---------------

The Flake is still broken on Mac. This looks more complicated to fix. I'll try to fix that in a subsequent PR.
