### PR TITLE
Provide both plain text + HTML versions for notification emails

### DIFF
--- a/README.md
+++ b/README.md
@@ -89,6 +89,33 @@ You'll need to do the following to get `hackage-server`'s dependency `hs-captcha
 
         nix-shell --packages zlib
 
+#### Mac OS X
+
+In addition to the above commands, you'll need to run
+
+```bash
+brew install pkg-config
+```
+
+After running the above `brew install` commands, you also need to update `cabal.project.local` with the following:
+
+```bash
+cat >> cabal.project.local <<EOF
+package gd
+  extra-include-dirs:
+    $(echo $(brew --prefix)/Cellar/gd/*/include)
+  extra-lib-dirs:
+    $(echo $(brew --prefix)/Cellar/gd/*/lib)
+    $(echo $(brew --prefix)/Cellar/libpng/*/lib)
+    $(echo $(brew --prefix)/Cellar/jpeg-turbo/*/lib)
+    $(echo $(brew --prefix)/Cellar/fontconfig/*/lib)
+    $(echo $(brew --prefix)/Cellar/freetype/*/lib)
+
+constraints:
+  , HsOpenSSL +use-pkg-config
+EOF
+```
+
 
 ## Setting up security infrastructure
 

--- a/hackage-server.cabal
+++ b/hackage-server.cabal
@@ -52,6 +52,17 @@ data-files:
   TUF/timestamp.private
 
 extra-source-files:
+  tests/golden/ReverseDependenciesTest/getNotificationEmails-NotifyNewVersion.golden
+  tests/golden/ReverseDependenciesTest/getNotificationEmails-NotifyNewRevision.golden
+  tests/golden/ReverseDependenciesTest/getNotificationEmails-NotifyMaintainerUpdate-MaintainerAdded.golden
+  tests/golden/ReverseDependenciesTest/getNotificationEmails-NotifyMaintainerUpdate-MaintainerRemoved.golden
+  tests/golden/ReverseDependenciesTest/getNotificationEmails-NotifyDocsBuild-success.golden
+  tests/golden/ReverseDependenciesTest/getNotificationEmails-NotifyDocsBuild-failure.golden
+  tests/golden/ReverseDependenciesTest/getNotificationEmails-NotifyUpdateTags.golden
+  tests/golden/ReverseDependenciesTest/getNotificationEmails-NotifyDependencyUpdate-Always.golden
+  tests/golden/ReverseDependenciesTest/getNotificationEmails-NotifyDependencyUpdate-NewIncompatibility.golden
+  tests/golden/ReverseDependenciesTest/getNotificationEmails-NotifyDependencyUpdate-BoundsOutOfRange.golden
+  tests/golden/ReverseDependenciesTest/getNotificationEmails-batched.golden
   tests/permissions-tarballs/*.tar.gz
   tests/unpack-checks/correct-package-0.1.0.0/LICENSE
   tests/unpack-checks/correct-package-0.1.0.0/Main.hs
@@ -569,11 +580,16 @@ test-suite ReverseDependenciesTest
   build-tool-depends: hackage-server:hackage-server
   build-depends:
     , tasty        ^>= 1.4
+    , tasty-golden ^>= 2.3
+    , tasty-hedgehog ^>= 1.4
     , tasty-hunit  ^>= 0.10
     , HUnit        ^>= 1.6
     , hedgehog     ^>= 1.3
     , exceptions
     , bimap
+    , mime-mail
+    , random
+    , transformers
   other-modules: RevDepCommon
 
 benchmark RevDeps

--- a/hackage-server.cabal
+++ b/hackage-server.cabal
@@ -265,6 +265,7 @@ library lib-server
     Distribution.Server.Util.CountingMap
     Distribution.Server.Util.CabalRevisions
     Distribution.Server.Util.DocMeta
+    Distribution.Server.Util.Email
     Distribution.Server.Util.Parse
     Distribution.Server.Util.ServeTarball
     Distribution.Server.Util.Validators

--- a/src/Distribution/Server/Features/UserNotify.hs
+++ b/src/Distribution/Server/Features/UserNotify.hs
@@ -702,10 +702,8 @@ userNotifyFeature ServerEnv{serverBaseURI, serverCron}
           genEmails :: PackageIdentifier -> IO (Map.Map (UserId, PackageId) [PackageId])
           genEmails =
             dependencyReleaseEmails (queryUserGroup . maintainersGroup) idx revIdx queryGetUserNotifyPref
-        dependencyEmailMaps <- traverse (genEmails . pkgInfoToPkgId) revisionsAndUploads
+        dependencyEmailMap <- Map.unionsWith (++) <$> traverse (genEmails . pkgInfoToPkgId) revisionsAndUploads
         let
-          dependencyEmailMap :: Map.Map (UserId, PackageId) [PackageId]
-          dependencyEmailMap = Map.unionsWith (++) dependencyEmailMaps
           emailText :: MonadIO m => (UserId, PackageId) -> [PackageId] -> m [String]
           emailText (uId, dep) revDeps = do
             mPrefs <- queryGetUserNotifyPref uId

--- a/src/Distribution/Server/Features/UserNotify.hs
+++ b/src/Distribution/Server/Features/UserNotify.hs
@@ -858,7 +858,8 @@ userNotifyFeature serverEnv@ServerEnv{serverCron}
       -- TODO: if we need any configuration of sendmail stuff, has to go here
       renderSendMail email
 
-      -- delay sending out emails, because ???
+      -- delay sending out emails, to avoid spamming people if we accidentally
+      -- send out too many emails
       threadDelay 250000
 
 data Notification

--- a/src/Distribution/Server/Features/UserNotify.hs
+++ b/src/Distribution/Server/Features/UserNotify.hs
@@ -9,7 +9,7 @@
 module Distribution.Server.Features.UserNotify (
     NotifyData(..),
     NotifyPref(..),
-    NotifyRevisionRange,
+    NotifyRevisionRange(..),
     NotifyTriggerBounds(..),
     UserNotifyFeature(..),
     defaultNotifyPrefs,
@@ -17,6 +17,11 @@ module Distribution.Server.Features.UserNotify (
     importNotifyPref,
     initUserNotifyFeature,
     notifyDataToCSV,
+
+    -- * getNotificationEmails
+    Notification(..),
+    NotifyMaintainerUpdateType(..),
+    getNotificationEmails,
   ) where
 
 import Prelude hiding (lookup)
@@ -887,8 +892,10 @@ data Notification
       , notifyWatchedPackages :: [PackageId]
         -- ^ Packages maintained by user that depend on updated dep
       }
+  deriving (Show)
 
 data NotifyMaintainerUpdateType = MaintainerAdded | MaintainerRemoved
+  deriving (Show)
 
 -- | Notifications in the same group are batched in the same email.
 --

--- a/src/Distribution/Server/Features/UserNotify.hs
+++ b/src/Distribution/Server/Features/UserNotify.hs
@@ -818,8 +818,8 @@ userNotifyFeature ServerEnv{serverBaseURI, serverCron}
     describeRevision users earlier now pkg
       | pkgNumRevisions pkg <= 1 =
           EmailContentParagraph $
-          "Package upload, " <> renderPkgLink (pkgInfoId pkg) <> ", by " <>
-          formatTimeUser users (pkgLatestUploadTime pkg) (pkgLatestUploadUser pkg)
+            "Package upload, " <> renderPkgLink (pkgInfoId pkg) <> ", by " <>
+            formatTimeUser users (pkgLatestUploadTime pkg) (pkgLatestUploadUser pkg)
       | otherwise =
           EmailContentParagraph ("Package metadata revision(s), " <> renderPkgLink (pkgInfoId pkg) <> ":")
           <> EmailContentList (map (uncurry (formatTimeUser users) . snd) recentRevs)
@@ -875,25 +875,25 @@ userNotifyFeature ServerEnv{serverBaseURI, serverCron}
                 depVersion = emailContentDisplay (packageVersion dep)
             in
               foldMap EmailContentParagraph
-              [ "The dependency " <> renderPkgLink dep <> " has been uploaded or revised."
-              , case notifyDependencyTriggerBounds of
-                  Always ->
-                    "You have requested to be notified for each upload or revision \
-                    \of a dependency."
-                  _ ->
-                    "You have requested to be notified when a dependency isn't \
-                    \accepted by any of your maintained packages."
-              , case notifyDependencyTriggerBounds of
-                  Always ->
-                    "These are your packages that depend on " <> depName <> ":"
-                  BoundsOutOfRange ->
-                    "These are your packages that require " <> depName
-                    <> " but don't accept " <> depVersion <> ":"
-                  NewIncompatibility ->
-                    "The following packages require " <> depName
-                    <> " but don't accept " <> depVersion
-                    <> " (they do accept the second-highest version):"
-              ]
+                [ "The dependency " <> renderPkgLink dep <> " has been uploaded or revised."
+                , case notifyDependencyTriggerBounds of
+                    Always ->
+                      "You have requested to be notified for each upload or revision \
+                      \of a dependency."
+                    _ ->
+                      "You have requested to be notified when a dependency isn't \
+                      \accepted by any of your maintained packages."
+                , case notifyDependencyTriggerBounds of
+                    Always ->
+                      "These are your packages that depend on " <> depName <> ":"
+                    BoundsOutOfRange ->
+                      "These are your packages that require " <> depName
+                      <> " but don't accept " <> depVersion <> ":"
+                    NewIncompatibility ->
+                      "The following packages require " <> depName
+                      <> " but don't accept " <> depVersion
+                      <> " (they do accept the second-highest version):"
+                ]
               <> EmailContentList (map renderPkgLink revDeps)
 
     sendNotifyEmailAndDelay :: Users.Users -> (UserId, (T.Text, EmailContent)) -> IO ()
@@ -919,13 +919,13 @@ userNotifyFeature ServerEnv{serverBaseURI, serverCron}
       where
         updatePreferencesText =
           EmailContentParagraph $
-          "You can adjust your notification preferences at" <> EmailContentSoftBreak
-          <> emailContentUrl
-              serverBaseURI
-                { uriPath =
-                    concatMap ("/" <>)
-                      [ "user"
-                      , display $ Users.userIdToName users uid
-                      , "notify"
-                      ]
-                }
+            "You can adjust your notification preferences at" <> EmailContentSoftBreak
+            <> emailContentUrl
+                serverBaseURI
+                  { uriPath =
+                      concatMap ("/" <>)
+                        [ "user"
+                        , display $ Users.userIdToName users uid
+                        , "notify"
+                        ]
+                  }

--- a/src/Distribution/Server/Features/UserNotify.hs
+++ b/src/Distribution/Server/Features/UserNotify.hs
@@ -847,27 +847,28 @@ userNotifyFeature ServerEnv{serverBaseURI, serverCron}
         case mPrefs of
           Nothing -> []
           Just NotifyPref{notifyDependencyTriggerBounds} ->
-            [ "The dependency " <> display dep <> " has been updated."
-            ] ++
-              case notifyDependencyTriggerBounds of
-                Always ->
-                  [ "You have requested to be notified for each upload/revision of a dependency. \
-                    \These are your packages that depend on " <> display dep <> ":"
-                  ]
-                outOfRangeOption ->
-                  [ "You have requested to be notified when a dependency isn't accepted by any of \
-                    \your maintained packages."
-                  ] ++
-                    case outOfRangeOption of
-                      NewIncompatibility ->
-                        [ "The following packages did accept the second highest version of "
-                          <> display (packageName dep) <> "."
-                        ]
-                      _ ->
-                        []
-                    ++
-                  [ "These are your packages that require " <> display (packageName dep) <> " but don't accept " <> display (packageVersion dep) <> ":"
-                  ]
+            let depName = display (packageName dep)
+                depVersion = display (packageVersion dep)
+            in
+              [ "The dependency " <> display dep <> " has been uploaded or revised."
+              , case notifyDependencyTriggerBounds of
+                  Always ->
+                    "You have requested to be notified for each upload or revision \
+                    \of a dependency."
+                  _ ->
+                    "You have requested to be notified when a dependency isn't \
+                    \accepted by any of your maintained packages."
+              , case notifyDependencyTriggerBounds of
+                  Always ->
+                    "These are your packages that depend on " <> depName <> ":"
+                  BoundsOutOfRange ->
+                    "These are your packages that require " <> depName
+                    <> " but don't accept " <> depVersion <> ":"
+                  NewIncompatibility ->
+                    "The following packages require " <> depName
+                    <> " but don't accept " <> depVersion
+                    <> " (they do accept the second-highest version):"
+              ]
               ++ map display revDeps
 
     sendNotifyEmailAndDelay :: Users.Users -> (UserId, (T.Text, [String])) -> IO ()

--- a/src/Distribution/Server/Features/UserNotify.hs
+++ b/src/Distribution/Server/Features/UserNotify.hs
@@ -58,10 +58,10 @@ import Data.Bifunctor (Bifunctor(second))
 import Data.Bimap (lookup, lookupR)
 import Data.Graph (Vertex)
 import Data.Hashable (Hashable(..))
-import Data.List (maximumBy, sortBy)
+import Data.List (maximumBy, sortOn)
 import Data.List (intercalate)
 import Data.Maybe (fromJust, fromMaybe, listToMaybe, mapMaybe, maybeToList)
-import Data.Ord (comparing)
+import Data.Ord (Down(..), comparing)
 import Data.SafeCopy (Migrate(migrate), MigrateFrom, base, deriveSafeCopy, extension)
 import Data.Time (UTCTime(..), addUTCTime, defaultTimeLocale, diffUTCTime, formatTime, getCurrentTime)
 import Data.Time.Format.Internal (buildTime)
@@ -505,7 +505,7 @@ dependencyReleaseEmails userSetIdForPackage index (ReverseIndex revs nodemap dep
           case notifyDependencyTriggerBounds of
             NewIncompatibility -> do
               let allNewUploadPkgInfos = PackageIndex.lookupPackageName index (pkgName pkgId)
-                  sortedByVersionDesc = sortBy (flip $ comparing packageVersion) allNewUploadPkgInfos
+                  sortedByVersionDesc = sortOn (Down . packageVersion) allNewUploadPkgInfos
                   mSecondHighest =
                     case sortedByVersionDesc of
                       _:b:_ -> Just b

--- a/src/Distribution/Server/Features/UserNotify.hs
+++ b/src/Distribution/Server/Features/UserNotify.hs
@@ -846,11 +846,11 @@ userNotifyFeature ServerEnv{serverBaseURI, serverCron}
             (Admin_GroupAddUser tn (MaintainerGroup pkg)) -> Just $
                     "Group modified by " ++ formatTimeUser users time uid ++ ":\n" ++
                     display (Users.userIdToName users tn) ++ " added to maintainers for " ++ BS.unpack pkg ++
-                    "\n" ++ "reason: " ++ BS.unpack descr
+                    "\n" ++ "Reason: " ++ BS.unpack descr
             (Admin_GroupDelUser tn (MaintainerGroup pkg)) -> Just $
                     "Group modified by " ++ formatTimeUser users time uid ++ ":\n" ++
                     display (Users.userIdToName users tn) ++ " removed from maintainers for " ++ BS.unpack pkg ++
-                    "\n" ++ "reason: " ++ BS.unpack descr
+                    "\n" ++ "Reason: " ++ BS.unpack descr
             _ -> Nothing
 
     describeDocReport (pkg, doc) =
@@ -860,9 +860,9 @@ userNotifyFeature ServerEnv{serverBaseURI, serverCron}
           else "Build failed."
 
     describeTagProposal (pkgName, (addTags, delTags)) =
-      "Pending tag propasal for " ++ display pkgName ++ ":\n" ++
-        "Addition: " ++ showTags addTags ++ "\n" ++
-        "Deletion: " ++ showTags delTags
+      "Pending tag proposal for " ++ display pkgName ++ ":\n" ++
+        "Additions: " ++ showTags addTags ++ "\n" ++
+        "Deletions: " ++ showTags delTags
       where
         showTags = intercalate ", " . map display . Set.toList
 

--- a/src/Distribution/Server/Util/Email.hs
+++ b/src/Distribution/Server/Util/Email.hs
@@ -68,20 +68,9 @@ emailContentUrl uri = EmailContentLink (uriToText uri) uri
 
 fromEmailContent :: EmailContent -> Alternatives
 fromEmailContent emailContent =
-  [ Part
-      { partType = contentType <> "; charset=utf-8"
-      , partEncoding = None
-      , partDisposition = DefaultDisposition
-      , partHeaders = []
-      , partContent = PartContent $ TextL.encodeUtf8 $ TextL.fromStrict content
-      }
-  | (contentType, content) <- contents
+  [ plainPart $ TextL.fromStrict $ toPlainContent emailContent
+  , htmlPart $ TextL.fromStrict $ toHtmlContent emailContent
   ]
-  where
-    contents =
-      [ ("text/plain", toPlainContent emailContent)
-      , ("text/html", toHtmlContent emailContent)
-      ]
 
 -- | Convert an 'EmailContent' to plain text.
 --

--- a/src/Distribution/Server/Util/Email.hs
+++ b/src/Distribution/Server/Util/Email.hs
@@ -1,0 +1,148 @@
+{-# LANGUAGE LambdaCase #-}
+{-# LANGUAGE OverloadedStrings #-}
+
+module Distribution.Server.Util.Email
+  ( EmailContent(..)
+  , emailContentStr
+  , emailContentLBS
+  , emailContentDisplay
+  , emailContentIntercalate
+  , emailContentUrl
+
+  -- * Rendering email content
+  , fromEmailContent
+  , toPlainContent
+  , toHtmlContent
+  ) where
+
+import qualified Data.ByteString.Lazy as Lazy (ByteString)
+import Data.List (intersperse)
+import Data.String (IsString(..))
+import Data.Text (Text)
+import qualified Data.Text as Text
+import qualified Data.Text.Lazy as TextL
+import qualified Data.Text.Lazy.Encoding as TextL
+import Distribution.Pretty (Pretty)
+import Distribution.Text (display)
+import Network.Mail.Mime
+import Network.URI (URI, uriToString)
+
+{- $setup
+>>> :set -XOverloadedStrings
+>>> import qualified Data.Text.IO as Text
+>>> import Network.URI (parseURI)
+-}
+
+data EmailContent
+  = EmailContentText Text
+  | EmailContentLink Text URI
+  | EmailContentSoftBreak
+  | EmailContentParagraph EmailContent
+  | EmailContentList [EmailContent]
+  | EmailContentConcat EmailContent EmailContent
+  deriving (Show)
+
+instance IsString EmailContent where
+  fromString = EmailContentText . Text.pack
+
+instance Semigroup EmailContent where
+  (<>) = EmailContentConcat
+
+instance Monoid EmailContent where
+  mempty = EmailContentText ""
+
+emailContentStr :: String -> EmailContent
+emailContentStr = EmailContentText . Text.pack
+
+emailContentLBS :: Lazy.ByteString -> EmailContent
+emailContentLBS = EmailContentText . TextL.toStrict . TextL.decodeUtf8
+
+emailContentDisplay :: Pretty a => a -> EmailContent
+emailContentDisplay = EmailContentText . Text.pack . display
+
+emailContentIntercalate :: EmailContent -> [EmailContent] -> EmailContent
+emailContentIntercalate x = mconcat . intersperse x
+
+emailContentUrl :: URI -> EmailContent
+emailContentUrl uri = EmailContentLink (uriToText uri) uri
+
+fromEmailContent :: EmailContent -> Alternatives
+fromEmailContent emailContent =
+  [ Part
+      { partType = contentType <> "; charset=utf-8"
+      , partEncoding = None
+      , partDisposition = DefaultDisposition
+      , partHeaders = []
+      , partContent = PartContent $ TextL.encodeUtf8 $ TextL.fromStrict content
+      }
+  | (contentType, content) <- contents
+  ]
+  where
+    contents =
+      [ ("text/plain", toPlainContent emailContent)
+      , ("text/html", toHtmlContent emailContent)
+      ]
+
+-- | Convert an 'EmailContent' to plain text.
+--
+-- >>> let Just haskellURI = parseURI "https://haskell.org"
+-- >>> let Just hackageURI = parseURI "https://hackage.haskell.org"
+-- >>> :{
+--   Text.putStr . toPlainContent . mconcat $
+--     [ EmailContentParagraph "Haskell is fun!"
+--     , EmailContentList
+--         [ "Website: " <> EmailContentLink "haskell.org" haskellURI
+--         , EmailContentLink "Hackage" hackageURI
+--         ]
+--     ]
+-- :}
+-- Haskell is fun!
+-- <BLANKLINE>
+-- * Website: haskell.org (https://haskell.org)
+-- * Hackage (https://hackage.haskell.org)
+-- <BLANKLINE>
+toPlainContent :: EmailContent -> Text
+toPlainContent = \case
+  EmailContentText s -> s
+  EmailContentLink s uri -> s <> " (" <> uriToText uri <> ")"
+  EmailContentSoftBreak -> "\n"
+  EmailContentParagraph content -> toPlainContent content <> "\n\n"
+  EmailContentList items ->
+    let renderListItem item = "* " <> toPlainContent item
+    in Text.intercalate "\n" (map renderListItem items) <> "\n\n"
+  EmailContentConcat a b -> toPlainContent a <> toPlainContent b
+
+-- | Convert an 'EmailContent' to HTML.
+--
+-- >>> let Just haskellURI = parseURI "https://haskell.org"
+-- >>> let Just hackageURI = parseURI "https://hackage.haskell.org"
+-- >>> :{
+--   Text.putStr . toHtmlContent . mconcat $
+--     [ EmailContentParagraph "Haskell is fun!"
+--     , EmailContentList
+--         [ "Website: " <> EmailContentLink "haskell.org" haskellURI
+--         , EmailContentLink "Hackage" hackageURI
+--         ]
+--     ]
+-- :}
+-- <BLANKLINE>
+-- <p>
+-- Haskell is fun!
+-- </p>
+-- <ul>
+--   <li>Website: <a href="https://haskell.org">haskell.org</a></li>
+--   <li><a href="https://hackage.haskell.org">Hackage</a></li>
+-- </ul>
+toHtmlContent :: EmailContent -> Text
+toHtmlContent = \case
+  EmailContentText s -> s
+  EmailContentLink s uri -> "<a href=\"" <> uriToText uri <> "\">" <> s <> "</a>"
+  EmailContentSoftBreak -> "\n<br />"
+  EmailContentParagraph content -> "\n<p>\n" <> toHtmlContent content <> "\n</p>"
+  EmailContentList items ->
+    let renderListItem item = "  <li>" <> toHtmlContent item <> "</li>"
+    in "\n<ul>\n" <> Text.unlines (map renderListItem items) <> "</ul>"
+  EmailContentConcat a b -> toHtmlContent a <> toHtmlContent b
+
+uriToText :: URI -> Text
+uriToText uri = Text.pack $ uriToString id uri ""

--- a/tests/ReverseDependenciesTest.hs
+++ b/tests/ReverseDependenciesTest.hs
@@ -1,25 +1,43 @@
 {-# LANGUAGE OverloadedStrings, NamedFieldPuns, TypeApplications, ScopedTypeVariables #-}
+{-# LANGUAGE LambdaCase #-}
+{-# LANGUAGE TupleSections #-}
 module Main where
 
+import           Control.Monad (guard)
 import           Control.Monad.IO.Class (liftIO)
+import qualified Control.Monad.Trans.State as State
 import qualified Data.Array as Arr
 import qualified Data.Bimap as Bimap
+import qualified Data.ByteString.Lazy as Lazy (ByteString)
+import qualified Data.ByteString.Lazy as ByteStringL
 import           Data.Foldable (for_)
 import           Data.Functor.Identity (Identity(..))
 import           Data.List (partition, foldl')
 import qualified Data.Map as Map
+import           Data.Maybe (fromJust)
 import qualified Data.Set as Set
+import qualified Data.Time as Time
+import           Data.Vector (Vector)
+import qualified Data.Vector as Vector
+import qualified Network.Mail.Mime as Mail
+import           Network.URI (parseURI)
+import           System.Random (mkStdGen)
 
 import Distribution.Package (PackageIdentifier(..), mkPackageName, packageId, packageName)
 import Distribution.Server.Features.PreferredVersions.State (PreferredVersions(..), VersionStatus(NormalVersion), PreferredInfo(..))
 import Distribution.Server.Features.ReverseDependencies (ReverseFeature(..), ReverseCount(..), reverseFeature)
 import Distribution.Server.Features.ReverseDependencies.State (ReverseIndex(..), addPackage, constructReverseIndex, emptyReverseIndex, getDependenciesFlat, getDependencies, getDependenciesFlatRaw, getDependenciesRaw)
+import Distribution.Server.Features.Tags (Tag(..))
+import Distribution.Server.Features.UserDetails (AccountDetails(..), UserDetailsFeature(..))
 import Distribution.Server.Features.UserNotify
-  ( NotifyData(..)
+  ( Notification(..)
+  , NotifyMaintainerUpdateType(..)
+  , NotifyData(..)
   , NotifyPref(..)
-  , NotifyRevisionRange
+  , NotifyRevisionRange(..)
   , NotifyTriggerBounds(..)
   , defaultNotifyPrefs
+  , getNotificationEmails
   , getUserNotificationsOnRelease
   , importNotifyPref
   , notifyDataToCSV
@@ -27,18 +45,38 @@ import Distribution.Server.Features.UserNotify
 import Distribution.Server.Framework.BackupRestore (runRestore)
 import Distribution.Server.Framework.Hook (newHook)
 import Distribution.Server.Framework.MemState (newMemStateWHNF)
+import Distribution.Server.Framework.ServerEnv (ServerEnv(..))
 import Distribution.Server.Packages.PackageIndex as PackageIndex
-import Distribution.Server.Packages.Types (PkgInfo(..))
-import Distribution.Server.Users.Types (UserId(..))
+import Distribution.Server.Packages.Types (CabalFileText(..), PkgInfo(..))
+import Distribution.Server.Users.Types
+  ( PasswdHash(..)
+  , UserAuth(..)
+  , UserId(..)
+  , UserName(..)
+  )
 import Distribution.Server.Users.UserIdSet as UserIdSet
+import qualified Distribution.Server.Users.Users as Users
 import Distribution.Version (mkVersion, version0)
 
-import Test.Tasty (TestTree, defaultMain, testGroup)
+import Test.Tasty (TestName, TestTree, defaultMain, testGroup)
+import Test.Tasty.Golden (goldenVsString)
+import Test.Tasty.Hedgehog (testProperty)
 import Test.Tasty.HUnit
 
 import qualified Hedgehog.Range as Range
 import qualified Hedgehog.Gen as Gen
-import           Hedgehog ((===), Group(Group), MonadGen, Property, PropertyT, checkSequential, forAll, property)
+import           Hedgehog
+  ( (===)
+  , Group(Group)
+  , MonadGen
+  , Property
+  , PropertyT
+  , Range
+  , checkSequential
+  , forAll
+  , property
+  , withTests
+  )
 
 import RevDepCommon (Package(..), TestPackage(..), mkPackage, mkPackageWithCabalFileSuffix, packToPkgInfo)
 
@@ -276,10 +314,260 @@ allTests = testGroup "ReverseDependenciesTest"
                 \    build-depends: base >= 4.15 && < 4.16"
             ])
           base4_15)
+  , getNotificationEmailsTests
   , testCase "hedgehogTests" $ do
       res <- hedgehogTests
       assertEqual "hedgehog test pass" True res
   ]
+
+getNotificationEmailsTests :: TestTree
+getNotificationEmailsTests =
+  testGroup "getNotificationEmails"
+    [ testProperty "All general notifications batched in one email" . withTests 30 . property $ do
+        notifs <- forAll $ Gen.list (Range.linear 1 10) $ Gen.filterT isGeneral genNotification
+        emails <- liftIO $ getNotificationEmailsMocked $ map (userWatcher,) notifs
+        length emails === 1
+    , testGolden "Render NotifyNewVersion" "getNotificationEmails-NotifyNewVersion.golden" $
+        fmap renderMail . getNotificationEmailMocked userWatcher $
+          NotifyNewVersion
+            { notifyPackageInfo =
+                PkgInfo
+                  { pkgInfoId = PackageIdentifier "base" (mkVersion [4, 18, 0, 0])
+                  , pkgMetadataRevisions = Vector.singleton (CabalFileText "", (timestamp, userActor))
+                  , pkgTarballRevisions = mempty
+                  }
+            }
+    , testGolden "Render NotifyNewRevision" "getNotificationEmails-NotifyNewRevision.golden" $ do
+        let mkRev rev = (CabalFileText "", (rev, userActor))
+            rev0 = (0 * Time.nominalDay) `Time.addUTCTime` timestamp
+            rev1 = (1 * Time.nominalDay) `Time.addUTCTime` timestamp
+            rev2 = (2 * Time.nominalDay) `Time.addUTCTime` timestamp
+        fmap renderMail . getNotificationEmailMocked userWatcher $
+          NotifyNewRevision
+            { notifyPackageId = PackageIdentifier "base" (mkVersion [4, 18, 0, 0])
+            , notifyRevisions = map (, userActor) [rev1, rev2]
+            }
+    , testGolden "Render NotifyMaintainerUpdate-MaintainerAdded" "getNotificationEmails-NotifyMaintainerUpdate-MaintainerAdded.golden" $
+        fmap renderMail . getNotificationEmailMocked userWatcher $
+          NotifyMaintainerUpdate
+            { notifyMaintainerUpdateType = MaintainerAdded
+            , notifyUserActor = userActor
+            , notifyUserSubject = userSubject
+            , notifyPackageName = "base"
+            , notifyReason = "User is cool"
+            , notifyUpdatedAt = timestamp
+            }
+    , testGolden "Render NotifyMaintainerUpdate-MaintainerRemoved" "getNotificationEmails-NotifyMaintainerUpdate-MaintainerRemoved.golden" $
+        fmap renderMail . getNotificationEmailMocked userWatcher $
+          NotifyMaintainerUpdate
+            { notifyMaintainerUpdateType = MaintainerRemoved
+            , notifyUserActor = userActor
+            , notifyUserSubject = userSubject
+            , notifyPackageName = "base"
+            , notifyReason = "User is no longer cool"
+            , notifyUpdatedAt = timestamp
+            }
+    , testGolden "Render NotifyDocsBuild-success" "getNotificationEmails-NotifyDocsBuild-success.golden" $
+        fmap renderMail . getNotificationEmailMocked userWatcher $
+          NotifyDocsBuild
+            { notifyPackageId = PackageIdentifier "base" (mkVersion [4, 18, 0, 0])
+            , notifyBuildSuccess = True
+            }
+    , testGolden "Render NotifyDocsBuild-failure" "getNotificationEmails-NotifyDocsBuild-failure.golden" $
+        fmap renderMail . getNotificationEmailMocked userWatcher $
+          NotifyDocsBuild
+            { notifyPackageId = PackageIdentifier "base" (mkVersion [4, 18, 0, 0])
+            , notifyBuildSuccess = False
+            }
+    , testGolden "Render NotifyUpdateTags" "getNotificationEmails-NotifyUpdateTags.golden" $
+        fmap renderMail . getNotificationEmailMocked userWatcher $
+          NotifyUpdateTags
+            { notifyPackageName = "base"
+            , notifyAddedTags = Set.fromList . map Tag $ ["bsd3", "library", "prelude"]
+            , notifyDeletedTags = Set.fromList . map Tag $ ["example", "bad", "foo"]
+            }
+    , testGolden "Render NotifyDependencyUpdate-Always" "getNotificationEmails-NotifyDependencyUpdate-Always.golden" $
+        fmap renderMail
+          . getNotificationEmail
+              testServerEnv
+              testUserDetailsFeature
+              (\_ -> pure $ Just notifyEverything{notifyDependencyTriggerBounds = Always})
+              allUsers
+              userWatcher
+          $ NotifyDependencyUpdate
+              { notifyPackageId = PackageIdentifier "base" (mkVersion [4, 18, 0, 0])
+              , notifyWatchedPackages = [PackageIdentifier "mtl" (mkVersion [2, 3])]
+              }
+    , testGolden "Render NotifyDependencyUpdate-NewIncompatibility" "getNotificationEmails-NotifyDependencyUpdate-NewIncompatibility.golden" $
+        fmap renderMail
+          . getNotificationEmail
+              testServerEnv
+              testUserDetailsFeature
+              (\_ -> pure $ Just notifyEverything{notifyDependencyTriggerBounds = NewIncompatibility})
+              allUsers
+              userWatcher
+          $ NotifyDependencyUpdate
+              { notifyPackageId = PackageIdentifier "base" (mkVersion [4, 18, 0, 0])
+              , notifyWatchedPackages = [PackageIdentifier "mtl" (mkVersion [2, 3])]
+              }
+    , testGolden "Render NotifyDependencyUpdate-BoundsOutOfRange" "getNotificationEmails-NotifyDependencyUpdate-BoundsOutOfRange.golden" $
+        fmap renderMail
+          . getNotificationEmail
+              testServerEnv
+              testUserDetailsFeature
+              (\_ -> pure $ Just notifyEverything{notifyDependencyTriggerBounds = BoundsOutOfRange})
+              allUsers
+              userWatcher
+          $ NotifyDependencyUpdate
+              { notifyPackageId = PackageIdentifier "base" (mkVersion [4, 18, 0, 0])
+              , notifyWatchedPackages = [PackageIdentifier "mtl" (mkVersion [2, 3])]
+              }
+    , testGolden "Render general notifications in single batched email" "getNotificationEmails-batched.golden" $ do
+        emails <-
+          getNotificationEmailsMocked . map (userWatcher,) $
+            [ NotifyNewRevision
+                { notifyPackageId = PackageIdentifier "base" (mkVersion [4, 18, 0, 0])
+                , notifyRevisions = [(timestamp, userActor)]
+                }
+            , NotifyDocsBuild
+                { notifyPackageId = PackageIdentifier "base" (mkVersion [4, 18, 0, 0])
+                , notifyBuildSuccess = True
+                }
+            , NotifyUpdateTags
+                { notifyPackageName = "base"
+                , notifyAddedTags = Set.fromList [Tag "newtag"]
+                , notifyDeletedTags = Set.fromList [Tag "oldtag"]
+                }
+            ]
+        case emails of
+          [email] -> pure $ renderMail email
+          _ -> error $ "Emails were not batched: " ++ show emails
+    ]
+  where
+    -- If adding a new constructor here, make sure to do the following:
+    --   * update genNotification
+    --   * add a golden test above
+    --   * add the golden file to hackage-server.cabal
+    _allNotificationTypes = \case
+      NotifyNewVersion{} -> ()
+      NotifyNewRevision{} -> ()
+      NotifyMaintainerUpdate{} -> ()
+      NotifyDocsBuild{} -> ()
+      NotifyUpdateTags{} -> ()
+      NotifyDependencyUpdate{} -> ()
+
+    isGeneral = \case
+      NotifyNewVersion{} -> True
+      NotifyNewRevision{} -> True
+      NotifyMaintainerUpdate{} -> True
+      NotifyDocsBuild{} -> True
+      NotifyUpdateTags{} -> True
+      NotifyDependencyUpdate{} -> False
+
+    -- userWatcher = user getting the notification
+    -- userActor   = user that did the action
+    -- userSubject = user the action is about
+    ((userWatcher, userActor, userSubject), allUsers) =
+      (`State.runState` Users.emptyUsers) $ do
+        let addUser name = State.StateT $ \users0 ->
+              case Users.addUserEnabled (UserName name) (UserAuth $ PasswdHash "") users0 of
+                Right (users1, uid) -> pure (uid, users1)
+                Left _ -> error $ "Got duplicate username: " <> name
+        (,,)
+          <$> addUser "user-watcher"
+          <*> addUser "user-actor"
+          <*> addUser "user-subject"
+
+    getNotificationEmail env details pref users uid notif =
+      getNotificationEmails env details pref users [(uid, notif)] >>= \case
+        [email] -> pure email
+        _ -> error "Did not get exactly one email"
+
+    testServerEnv =
+      ServerEnv
+        { serverBaseURI = fromJust $ parseURI "https://hackage.haskell.org"
+        }
+    testUserDetailsFeature =
+      UserDetailsFeature
+        { queryUserDetails = \uid ->
+            pure $ do
+              guard $ uid == userWatcher
+              Just
+                AccountDetails
+                  { accountName = "user-watcher"
+                  , accountContactEmail = "user-watcher@example.com"
+                  , accountKind = Nothing
+                  , accountAdminNotes = ""
+                  }
+        }
+    notifyEverything =
+      NotifyPref
+        { notifyOptOut = False
+        , notifyRevisionRange = NotifyAllVersions
+        , notifyUpload = True
+        , notifyMaintainerGroup = True
+        , notifyDocBuilderReport = True
+        , notifyPendingTags = True
+        , notifyDependencyForMaintained = True
+        , notifyDependencyTriggerBounds = Always
+        }
+    testGetUserNotifyPref uid = pure $ do
+      guard $ uid == userWatcher
+      Just notifyEverything
+    getNotificationEmailsMocked =
+      getNotificationEmails
+        testServerEnv
+        testUserDetailsFeature
+        testGetUserNotifyPref
+        allUsers
+    getNotificationEmailMocked =
+      getNotificationEmail
+        testServerEnv
+        testUserDetailsFeature
+        testGetUserNotifyPref
+        allUsers
+
+    renderMail = fst . Mail.renderMail (mkStdGen 0)
+    timestamp = Time.UTCTime (Time.fromGregorian 2020 1 1) 0
+
+    genNotification =
+      Gen.choice
+        [ NotifyNewVersion
+            <$> genPkgInfo
+        , NotifyNewRevision
+            <$> genPackageId
+            <*> Gen.list (Range.linear 1 5) genUploadInfo
+        , NotifyMaintainerUpdate
+            <$> Gen.element [MaintainerAdded, MaintainerRemoved]
+            <*> genNonExistentUserId
+            <*> genNonExistentUserId
+            <*> genPackageName
+            <*> Gen.text (Range.linear 1 20) Gen.unicode
+            <*> genUTCTime
+        , NotifyDocsBuild
+            <$> genPackageId
+            <*> Gen.bool
+        , NotifyUpdateTags
+            <$> genPackageName
+            <*> Gen.set (Range.linear 1 5) genTag
+            <*> Gen.set (Range.linear 1 5) genTag
+        , NotifyDependencyUpdate
+            <$> genPackageId
+            <*> Gen.list (Range.linear 1 10) genPackageId
+        ]
+
+    genPackageName = mkPackageName <$> Gen.string (Range.linear 1 30) Gen.unicode
+    genVersion = mkVersion <$> Gen.list (Range.linear 1 4) (Gen.int $ Range.linear 0 50)
+    genPackageId = PackageIdentifier <$> genPackageName <*> genVersion
+    genCabalFileText = CabalFileText . ByteStringL.fromStrict <$> Gen.utf8 (Range.linear 0 50000) Gen.unicode
+    genNonExistentUserId = UserId <$> Gen.int (Range.linear (-1000) (-1))
+    genUploadInfo = (,) <$> genUTCTime <*> genNonExistentUserId
+    genTag = Tag <$> Gen.string (Range.linear 1 10) Gen.unicode
+    genPkgInfo =
+      PkgInfo
+        <$> genPackageId
+        <*> genVec (Range.linear 1 5) ((,) <$> genCabalFileText <*> genUploadInfo)
+        <*> pure Vector.empty -- ignoring pkgTarballRevisions for now
 
 genPacks :: PropertyT IO [Package TestPackage]
 genPacks = do
@@ -385,5 +673,26 @@ hedgehogTests =
     , ("prop_csvBackupRoundtrips", prop_csvBackupRoundtrips)
     ]
 
+testGolden :: TestName -> FilePath -> IO Lazy.ByteString -> TestTree
+testGolden name fp = goldenVsString name ("tests/golden/ReverseDependenciesTest/" <> fp)
+
 main :: IO ()
 main = defaultMain allTests
+
+{----- Utilities -----}
+
+genUTCTime :: MonadGen m => m Time.UTCTime
+genUTCTime =
+  Time.UTCTime
+    <$> genDay
+    <*> genDiffTime
+  where
+    genDay =
+      Time.fromGregorian
+        <$> Gen.integral (Range.linear 0 3000)
+        <*> Gen.int (Range.linear 1 12)
+        <*> Gen.int (Range.linear 1 31)
+    genDiffTime = realToFrac <$> Gen.double (Range.linearFrac 0 86400)
+
+genVec :: MonadGen m => Range Int -> m a -> m (Vector a)
+genVec r = fmap Vector.fromList . Gen.list r

--- a/tests/golden/ReverseDependenciesTest/getNotificationEmails-NotifyDependencyUpdate-Always.golden
+++ b/tests/golden/ReverseDependenciesTest/getNotificationEmails-NotifyDependencyUpdate-Always.golden
@@ -6,37 +6,46 @@ Content-Type: multipart/alternative; boundary="YIYrWcf3to"
 
 --YIYrWcf3to
 Content-Type: text/plain; charset=utf-8
+Content-Transfer-Encoding: quoted-printable
 
-The dependency base-4.18.0.0 (https://hackage.haskell.org/package/base-4.18.0.0) has been uploaded or revised.
+The dependency base-4=2E18=2E0=2E0 (https://hackage=2Ehaskell=2Eorg/package=
+/base-4=2E18=2E0=2E0) has been uploaded or revised=2E
 
-You have requested to be notified for each upload or revision of a dependency.
+You have requested to be notified for each upload or revision of a dependen=
+cy=2E
 
 These are your packages that depend on base:
 
-* mtl-2.3 (https://hackage.haskell.org/package/mtl-2.3)
+* mtl-2=2E3 (https://hackage=2Ehaskell=2Eorg/package/mtl-2=2E3)
 
 You can adjust your notification preferences at
-https://hackage.haskell.org/user/user-watcher/notify (https://hackage.haskell.org/user/user-watcher/notify)
+https://hackage=2Ehaskell=2Eorg/user/user-watcher/notify (https://hackage=
+=2Ehaskell=2Eorg/user/user-watcher/notify)
 
 
 --YIYrWcf3to
 Content-Type: text/html; charset=utf-8
+Content-Transfer-Encoding: quoted-printable
 
 
 <p>
-The dependency <a href="https://hackage.haskell.org/package/base-4.18.0.0">base-4.18.0.0</a> has been uploaded or revised.
+The dependency <a href=3D"https://hackage=2Ehaskell=2Eorg/package/base-4=2E=
+18=2E0=2E0">base-4=2E18=2E0=2E0</a> has been uploaded or revised=2E
 </p>
 <p>
-You have requested to be notified for each upload or revision of a dependency.
+You have requested to be notified for each upload or revision of a dependen=
+cy=2E
 </p>
 <p>
 These are your packages that depend on base:
 </p>
 <ul>
-  <li><a href="https://hackage.haskell.org/package/mtl-2.3">mtl-2.3</a></li>
+  <li><a href=3D"https://hackage=2Ehaskell=2Eorg/package/mtl-2=2E3">mtl-2=
+=2E3</a></li>
 </ul>
 <p>
 You can adjust your notification preferences at
-<br /><a href="https://hackage.haskell.org/user/user-watcher/notify">https://hackage.haskell.org/user/user-watcher/notify</a>
+<br /><a href=3D"https://hackage=2Ehaskell=2Eorg/user/user-watcher/notify">=
+https://hackage=2Ehaskell=2Eorg/user/user-watcher/notify</a>
 </p>
 --YIYrWcf3to--

--- a/tests/golden/ReverseDependenciesTest/getNotificationEmails-NotifyDependencyUpdate-Always.golden
+++ b/tests/golden/ReverseDependenciesTest/getNotificationEmails-NotifyDependencyUpdate-Always.golden
@@ -1,0 +1,42 @@
+From: =?utf-8?Q?Hackage_website?= <noreply@hackage.haskell.org>
+To: =?utf-8?Q?user-watcher?= <user-watcher@example.com>
+Subject: [Hackage] Dependency Update: base-4.18.0.0
+MIME-Version: 1.0
+Content-Type: multipart/alternative; boundary="YIYrWcf3to"
+
+--YIYrWcf3to
+Content-Type: text/plain; charset=utf-8
+
+The dependency base-4.18.0.0 (https://hackage.haskell.org/package/base-4.18.0.0) has been uploaded or revised.
+
+You have requested to be notified for each upload or revision of a dependency.
+
+These are your packages that depend on base:
+
+* mtl-2.3 (https://hackage.haskell.org/package/mtl-2.3)
+
+You can adjust your notification preferences at
+https://hackage.haskell.org/user/user-watcher/notify (https://hackage.haskell.org/user/user-watcher/notify)
+
+
+--YIYrWcf3to
+Content-Type: text/html; charset=utf-8
+
+
+<p>
+The dependency <a href="https://hackage.haskell.org/package/base-4.18.0.0">base-4.18.0.0</a> has been uploaded or revised.
+</p>
+<p>
+You have requested to be notified for each upload or revision of a dependency.
+</p>
+<p>
+These are your packages that depend on base:
+</p>
+<ul>
+  <li><a href="https://hackage.haskell.org/package/mtl-2.3">mtl-2.3</a></li>
+</ul>
+<p>
+You can adjust your notification preferences at
+<br /><a href="https://hackage.haskell.org/user/user-watcher/notify">https://hackage.haskell.org/user/user-watcher/notify</a>
+</p>
+--YIYrWcf3to--

--- a/tests/golden/ReverseDependenciesTest/getNotificationEmails-NotifyDependencyUpdate-BoundsOutOfRange.golden
+++ b/tests/golden/ReverseDependenciesTest/getNotificationEmails-NotifyDependencyUpdate-BoundsOutOfRange.golden
@@ -6,37 +6,46 @@ Content-Type: multipart/alternative; boundary="YIYrWcf3to"
 
 --YIYrWcf3to
 Content-Type: text/plain; charset=utf-8
+Content-Transfer-Encoding: quoted-printable
 
-The dependency base-4.18.0.0 (https://hackage.haskell.org/package/base-4.18.0.0) has been uploaded or revised.
+The dependency base-4=2E18=2E0=2E0 (https://hackage=2Ehaskell=2Eorg/package=
+/base-4=2E18=2E0=2E0) has been uploaded or revised=2E
 
-You have requested to be notified when a dependency isn't accepted by any of your maintained packages.
+You have requested to be notified when a dependency isn't accepted by any o=
+f your maintained packages=2E
 
-These are your packages that require base but don't accept 4.18.0.0:
+These are your packages that require base but don't accept 4=2E18=2E0=2E0:
 
-* mtl-2.3 (https://hackage.haskell.org/package/mtl-2.3)
+* mtl-2=2E3 (https://hackage=2Ehaskell=2Eorg/package/mtl-2=2E3)
 
 You can adjust your notification preferences at
-https://hackage.haskell.org/user/user-watcher/notify (https://hackage.haskell.org/user/user-watcher/notify)
+https://hackage=2Ehaskell=2Eorg/user/user-watcher/notify (https://hackage=
+=2Ehaskell=2Eorg/user/user-watcher/notify)
 
 
 --YIYrWcf3to
 Content-Type: text/html; charset=utf-8
+Content-Transfer-Encoding: quoted-printable
 
 
 <p>
-The dependency <a href="https://hackage.haskell.org/package/base-4.18.0.0">base-4.18.0.0</a> has been uploaded or revised.
+The dependency <a href=3D"https://hackage=2Ehaskell=2Eorg/package/base-4=2E=
+18=2E0=2E0">base-4=2E18=2E0=2E0</a> has been uploaded or revised=2E
 </p>
 <p>
-You have requested to be notified when a dependency isn't accepted by any of your maintained packages.
+You have requested to be notified when a dependency isn't accepted by any o=
+f your maintained packages=2E
 </p>
 <p>
-These are your packages that require base but don't accept 4.18.0.0:
+These are your packages that require base but don't accept 4=2E18=2E0=2E0:
 </p>
 <ul>
-  <li><a href="https://hackage.haskell.org/package/mtl-2.3">mtl-2.3</a></li>
+  <li><a href=3D"https://hackage=2Ehaskell=2Eorg/package/mtl-2=2E3">mtl-2=
+=2E3</a></li>
 </ul>
 <p>
 You can adjust your notification preferences at
-<br /><a href="https://hackage.haskell.org/user/user-watcher/notify">https://hackage.haskell.org/user/user-watcher/notify</a>
+<br /><a href=3D"https://hackage=2Ehaskell=2Eorg/user/user-watcher/notify">=
+https://hackage=2Ehaskell=2Eorg/user/user-watcher/notify</a>
 </p>
 --YIYrWcf3to--

--- a/tests/golden/ReverseDependenciesTest/getNotificationEmails-NotifyDependencyUpdate-BoundsOutOfRange.golden
+++ b/tests/golden/ReverseDependenciesTest/getNotificationEmails-NotifyDependencyUpdate-BoundsOutOfRange.golden
@@ -1,0 +1,42 @@
+From: =?utf-8?Q?Hackage_website?= <noreply@hackage.haskell.org>
+To: =?utf-8?Q?user-watcher?= <user-watcher@example.com>
+Subject: [Hackage] Dependency Update: base-4.18.0.0
+MIME-Version: 1.0
+Content-Type: multipart/alternative; boundary="YIYrWcf3to"
+
+--YIYrWcf3to
+Content-Type: text/plain; charset=utf-8
+
+The dependency base-4.18.0.0 (https://hackage.haskell.org/package/base-4.18.0.0) has been uploaded or revised.
+
+You have requested to be notified when a dependency isn't accepted by any of your maintained packages.
+
+These are your packages that require base but don't accept 4.18.0.0:
+
+* mtl-2.3 (https://hackage.haskell.org/package/mtl-2.3)
+
+You can adjust your notification preferences at
+https://hackage.haskell.org/user/user-watcher/notify (https://hackage.haskell.org/user/user-watcher/notify)
+
+
+--YIYrWcf3to
+Content-Type: text/html; charset=utf-8
+
+
+<p>
+The dependency <a href="https://hackage.haskell.org/package/base-4.18.0.0">base-4.18.0.0</a> has been uploaded or revised.
+</p>
+<p>
+You have requested to be notified when a dependency isn't accepted by any of your maintained packages.
+</p>
+<p>
+These are your packages that require base but don't accept 4.18.0.0:
+</p>
+<ul>
+  <li><a href="https://hackage.haskell.org/package/mtl-2.3">mtl-2.3</a></li>
+</ul>
+<p>
+You can adjust your notification preferences at
+<br /><a href="https://hackage.haskell.org/user/user-watcher/notify">https://hackage.haskell.org/user/user-watcher/notify</a>
+</p>
+--YIYrWcf3to--

--- a/tests/golden/ReverseDependenciesTest/getNotificationEmails-NotifyDependencyUpdate-NewIncompatibility.golden
+++ b/tests/golden/ReverseDependenciesTest/getNotificationEmails-NotifyDependencyUpdate-NewIncompatibility.golden
@@ -6,37 +6,48 @@ Content-Type: multipart/alternative; boundary="YIYrWcf3to"
 
 --YIYrWcf3to
 Content-Type: text/plain; charset=utf-8
+Content-Transfer-Encoding: quoted-printable
 
-The dependency base-4.18.0.0 (https://hackage.haskell.org/package/base-4.18.0.0) has been uploaded or revised.
+The dependency base-4=2E18=2E0=2E0 (https://hackage=2Ehaskell=2Eorg/package=
+/base-4=2E18=2E0=2E0) has been uploaded or revised=2E
 
-You have requested to be notified when a dependency isn't accepted by any of your maintained packages.
+You have requested to be notified when a dependency isn't accepted by any o=
+f your maintained packages=2E
 
-The following packages require base but don't accept 4.18.0.0 (they do accept the second-highest version):
+The following packages require base but don't accept 4=2E18=2E0=2E0 (they d=
+o accept the second-highest version):
 
-* mtl-2.3 (https://hackage.haskell.org/package/mtl-2.3)
+* mtl-2=2E3 (https://hackage=2Ehaskell=2Eorg/package/mtl-2=2E3)
 
 You can adjust your notification preferences at
-https://hackage.haskell.org/user/user-watcher/notify (https://hackage.haskell.org/user/user-watcher/notify)
+https://hackage=2Ehaskell=2Eorg/user/user-watcher/notify (https://hackage=
+=2Ehaskell=2Eorg/user/user-watcher/notify)
 
 
 --YIYrWcf3to
 Content-Type: text/html; charset=utf-8
+Content-Transfer-Encoding: quoted-printable
 
 
 <p>
-The dependency <a href="https://hackage.haskell.org/package/base-4.18.0.0">base-4.18.0.0</a> has been uploaded or revised.
+The dependency <a href=3D"https://hackage=2Ehaskell=2Eorg/package/base-4=2E=
+18=2E0=2E0">base-4=2E18=2E0=2E0</a> has been uploaded or revised=2E
 </p>
 <p>
-You have requested to be notified when a dependency isn't accepted by any of your maintained packages.
+You have requested to be notified when a dependency isn't accepted by any o=
+f your maintained packages=2E
 </p>
 <p>
-The following packages require base but don't accept 4.18.0.0 (they do accept the second-highest version):
+The following packages require base but don't accept 4=2E18=2E0=2E0 (they d=
+o accept the second-highest version):
 </p>
 <ul>
-  <li><a href="https://hackage.haskell.org/package/mtl-2.3">mtl-2.3</a></li>
+  <li><a href=3D"https://hackage=2Ehaskell=2Eorg/package/mtl-2=2E3">mtl-2=
+=2E3</a></li>
 </ul>
 <p>
 You can adjust your notification preferences at
-<br /><a href="https://hackage.haskell.org/user/user-watcher/notify">https://hackage.haskell.org/user/user-watcher/notify</a>
+<br /><a href=3D"https://hackage=2Ehaskell=2Eorg/user/user-watcher/notify">=
+https://hackage=2Ehaskell=2Eorg/user/user-watcher/notify</a>
 </p>
 --YIYrWcf3to--

--- a/tests/golden/ReverseDependenciesTest/getNotificationEmails-NotifyDependencyUpdate-NewIncompatibility.golden
+++ b/tests/golden/ReverseDependenciesTest/getNotificationEmails-NotifyDependencyUpdate-NewIncompatibility.golden
@@ -1,0 +1,42 @@
+From: =?utf-8?Q?Hackage_website?= <noreply@hackage.haskell.org>
+To: =?utf-8?Q?user-watcher?= <user-watcher@example.com>
+Subject: [Hackage] Dependency Update: base-4.18.0.0
+MIME-Version: 1.0
+Content-Type: multipart/alternative; boundary="YIYrWcf3to"
+
+--YIYrWcf3to
+Content-Type: text/plain; charset=utf-8
+
+The dependency base-4.18.0.0 (https://hackage.haskell.org/package/base-4.18.0.0) has been uploaded or revised.
+
+You have requested to be notified when a dependency isn't accepted by any of your maintained packages.
+
+The following packages require base but don't accept 4.18.0.0 (they do accept the second-highest version):
+
+* mtl-2.3 (https://hackage.haskell.org/package/mtl-2.3)
+
+You can adjust your notification preferences at
+https://hackage.haskell.org/user/user-watcher/notify (https://hackage.haskell.org/user/user-watcher/notify)
+
+
+--YIYrWcf3to
+Content-Type: text/html; charset=utf-8
+
+
+<p>
+The dependency <a href="https://hackage.haskell.org/package/base-4.18.0.0">base-4.18.0.0</a> has been uploaded or revised.
+</p>
+<p>
+You have requested to be notified when a dependency isn't accepted by any of your maintained packages.
+</p>
+<p>
+The following packages require base but don't accept 4.18.0.0 (they do accept the second-highest version):
+</p>
+<ul>
+  <li><a href="https://hackage.haskell.org/package/mtl-2.3">mtl-2.3</a></li>
+</ul>
+<p>
+You can adjust your notification preferences at
+<br /><a href="https://hackage.haskell.org/user/user-watcher/notify">https://hackage.haskell.org/user/user-watcher/notify</a>
+</p>
+--YIYrWcf3to--

--- a/tests/golden/ReverseDependenciesTest/getNotificationEmails-NotifyDocsBuild-failure.golden
+++ b/tests/golden/ReverseDependenciesTest/getNotificationEmails-NotifyDocsBuild-failure.golden
@@ -1,0 +1,29 @@
+From: =?utf-8?Q?Hackage_website?= <noreply@hackage.haskell.org>
+To: =?utf-8?Q?user-watcher?= <user-watcher@example.com>
+Subject: [Hackage] Maintainer Notifications
+MIME-Version: 1.0
+Content-Type: multipart/alternative; boundary="YIYrWcf3to"
+
+--YIYrWcf3to
+Content-Type: text/plain; charset=utf-8
+
+Package doc build for base-4.18.0.0 (https://hackage.haskell.org/package/base-4.18.0.0):
+Build failed.
+
+You can adjust your notification preferences at
+https://hackage.haskell.org/user/user-watcher/notify (https://hackage.haskell.org/user/user-watcher/notify)
+
+
+--YIYrWcf3to
+Content-Type: text/html; charset=utf-8
+
+
+<p>
+Package doc build for <a href="https://hackage.haskell.org/package/base-4.18.0.0">base-4.18.0.0</a>:
+<br />Build failed.
+</p>
+<p>
+You can adjust your notification preferences at
+<br /><a href="https://hackage.haskell.org/user/user-watcher/notify">https://hackage.haskell.org/user/user-watcher/notify</a>
+</p>
+--YIYrWcf3to--

--- a/tests/golden/ReverseDependenciesTest/getNotificationEmails-NotifyDocsBuild-failure.golden
+++ b/tests/golden/ReverseDependenciesTest/getNotificationEmails-NotifyDocsBuild-failure.golden
@@ -6,24 +6,30 @@ Content-Type: multipart/alternative; boundary="YIYrWcf3to"
 
 --YIYrWcf3to
 Content-Type: text/plain; charset=utf-8
+Content-Transfer-Encoding: quoted-printable
 
-Package doc build for base-4.18.0.0 (https://hackage.haskell.org/package/base-4.18.0.0):
-Build failed.
+Package doc build for base-4=2E18=2E0=2E0 (https://hackage=2Ehaskell=2Eorg/=
+package/base-4=2E18=2E0=2E0):
+Build failed=2E
 
 You can adjust your notification preferences at
-https://hackage.haskell.org/user/user-watcher/notify (https://hackage.haskell.org/user/user-watcher/notify)
+https://hackage=2Ehaskell=2Eorg/user/user-watcher/notify (https://hackage=
+=2Ehaskell=2Eorg/user/user-watcher/notify)
 
 
 --YIYrWcf3to
 Content-Type: text/html; charset=utf-8
+Content-Transfer-Encoding: quoted-printable
 
 
 <p>
-Package doc build for <a href="https://hackage.haskell.org/package/base-4.18.0.0">base-4.18.0.0</a>:
-<br />Build failed.
+Package doc build for <a href=3D"https://hackage=2Ehaskell=2Eorg/package/ba=
+se-4=2E18=2E0=2E0">base-4=2E18=2E0=2E0</a>:
+<br />Build failed=2E
 </p>
 <p>
 You can adjust your notification preferences at
-<br /><a href="https://hackage.haskell.org/user/user-watcher/notify">https://hackage.haskell.org/user/user-watcher/notify</a>
+<br /><a href=3D"https://hackage=2Ehaskell=2Eorg/user/user-watcher/notify">=
+https://hackage=2Ehaskell=2Eorg/user/user-watcher/notify</a>
 </p>
 --YIYrWcf3to--

--- a/tests/golden/ReverseDependenciesTest/getNotificationEmails-NotifyDocsBuild-success.golden
+++ b/tests/golden/ReverseDependenciesTest/getNotificationEmails-NotifyDocsBuild-success.golden
@@ -1,0 +1,29 @@
+From: =?utf-8?Q?Hackage_website?= <noreply@hackage.haskell.org>
+To: =?utf-8?Q?user-watcher?= <user-watcher@example.com>
+Subject: [Hackage] Maintainer Notifications
+MIME-Version: 1.0
+Content-Type: multipart/alternative; boundary="YIYrWcf3to"
+
+--YIYrWcf3to
+Content-Type: text/plain; charset=utf-8
+
+Package doc build for base-4.18.0.0 (https://hackage.haskell.org/package/base-4.18.0.0):
+Build successful.
+
+You can adjust your notification preferences at
+https://hackage.haskell.org/user/user-watcher/notify (https://hackage.haskell.org/user/user-watcher/notify)
+
+
+--YIYrWcf3to
+Content-Type: text/html; charset=utf-8
+
+
+<p>
+Package doc build for <a href="https://hackage.haskell.org/package/base-4.18.0.0">base-4.18.0.0</a>:
+<br />Build successful.
+</p>
+<p>
+You can adjust your notification preferences at
+<br /><a href="https://hackage.haskell.org/user/user-watcher/notify">https://hackage.haskell.org/user/user-watcher/notify</a>
+</p>
+--YIYrWcf3to--

--- a/tests/golden/ReverseDependenciesTest/getNotificationEmails-NotifyDocsBuild-success.golden
+++ b/tests/golden/ReverseDependenciesTest/getNotificationEmails-NotifyDocsBuild-success.golden
@@ -6,24 +6,30 @@ Content-Type: multipart/alternative; boundary="YIYrWcf3to"
 
 --YIYrWcf3to
 Content-Type: text/plain; charset=utf-8
+Content-Transfer-Encoding: quoted-printable
 
-Package doc build for base-4.18.0.0 (https://hackage.haskell.org/package/base-4.18.0.0):
-Build successful.
+Package doc build for base-4=2E18=2E0=2E0 (https://hackage=2Ehaskell=2Eorg/=
+package/base-4=2E18=2E0=2E0):
+Build successful=2E
 
 You can adjust your notification preferences at
-https://hackage.haskell.org/user/user-watcher/notify (https://hackage.haskell.org/user/user-watcher/notify)
+https://hackage=2Ehaskell=2Eorg/user/user-watcher/notify (https://hackage=
+=2Ehaskell=2Eorg/user/user-watcher/notify)
 
 
 --YIYrWcf3to
 Content-Type: text/html; charset=utf-8
+Content-Transfer-Encoding: quoted-printable
 
 
 <p>
-Package doc build for <a href="https://hackage.haskell.org/package/base-4.18.0.0">base-4.18.0.0</a>:
-<br />Build successful.
+Package doc build for <a href=3D"https://hackage=2Ehaskell=2Eorg/package/ba=
+se-4=2E18=2E0=2E0">base-4=2E18=2E0=2E0</a>:
+<br />Build successful=2E
 </p>
 <p>
 You can adjust your notification preferences at
-<br /><a href="https://hackage.haskell.org/user/user-watcher/notify">https://hackage.haskell.org/user/user-watcher/notify</a>
+<br /><a href=3D"https://hackage=2Ehaskell=2Eorg/user/user-watcher/notify">=
+https://hackage=2Ehaskell=2Eorg/user/user-watcher/notify</a>
 </p>
 --YIYrWcf3to--

--- a/tests/golden/ReverseDependenciesTest/getNotificationEmails-NotifyMaintainerUpdate-MaintainerAdded.golden
+++ b/tests/golden/ReverseDependenciesTest/getNotificationEmails-NotifyMaintainerUpdate-MaintainerAdded.golden
@@ -1,0 +1,34 @@
+From: =?utf-8?Q?Hackage_website?= <noreply@hackage.haskell.org>
+To: =?utf-8?Q?user-watcher?= <user-watcher@example.com>
+Subject: [Hackage] Maintainer Notifications
+MIME-Version: 1.0
+Content-Type: multipart/alternative; boundary="YIYrWcf3to"
+
+--YIYrWcf3to
+Content-Type: text/plain; charset=utf-8
+
+Group modified by user-actor [Wed Jan  1 00:00:00 UTC 2020]:
+
+* user-subject added to maintainers for base
+* Reason: User is cool
+
+You can adjust your notification preferences at
+https://hackage.haskell.org/user/user-watcher/notify (https://hackage.haskell.org/user/user-watcher/notify)
+
+
+--YIYrWcf3to
+Content-Type: text/html; charset=utf-8
+
+
+<p>
+Group modified by user-actor [Wed Jan  1 00:00:00 UTC 2020]:
+</p>
+<ul>
+  <li>user-subject added to maintainers for base</li>
+  <li>Reason: User is cool</li>
+</ul>
+<p>
+You can adjust your notification preferences at
+<br /><a href="https://hackage.haskell.org/user/user-watcher/notify">https://hackage.haskell.org/user/user-watcher/notify</a>
+</p>
+--YIYrWcf3to--

--- a/tests/golden/ReverseDependenciesTest/getNotificationEmails-NotifyMaintainerUpdate-MaintainerAdded.golden
+++ b/tests/golden/ReverseDependenciesTest/getNotificationEmails-NotifyMaintainerUpdate-MaintainerAdded.golden
@@ -6,6 +6,7 @@ Content-Type: multipart/alternative; boundary="YIYrWcf3to"
 
 --YIYrWcf3to
 Content-Type: text/plain; charset=utf-8
+Content-Transfer-Encoding: quoted-printable
 
 Group modified by user-actor [Wed Jan  1 00:00:00 UTC 2020]:
 
@@ -13,11 +14,13 @@ Group modified by user-actor [Wed Jan  1 00:00:00 UTC 2020]:
 * Reason: User is cool
 
 You can adjust your notification preferences at
-https://hackage.haskell.org/user/user-watcher/notify (https://hackage.haskell.org/user/user-watcher/notify)
+https://hackage=2Ehaskell=2Eorg/user/user-watcher/notify (https://hackage=
+=2Ehaskell=2Eorg/user/user-watcher/notify)
 
 
 --YIYrWcf3to
 Content-Type: text/html; charset=utf-8
+Content-Transfer-Encoding: quoted-printable
 
 
 <p>
@@ -29,6 +32,7 @@ Group modified by user-actor [Wed Jan  1 00:00:00 UTC 2020]:
 </ul>
 <p>
 You can adjust your notification preferences at
-<br /><a href="https://hackage.haskell.org/user/user-watcher/notify">https://hackage.haskell.org/user/user-watcher/notify</a>
+<br /><a href=3D"https://hackage=2Ehaskell=2Eorg/user/user-watcher/notify">=
+https://hackage=2Ehaskell=2Eorg/user/user-watcher/notify</a>
 </p>
 --YIYrWcf3to--

--- a/tests/golden/ReverseDependenciesTest/getNotificationEmails-NotifyMaintainerUpdate-MaintainerRemoved.golden
+++ b/tests/golden/ReverseDependenciesTest/getNotificationEmails-NotifyMaintainerUpdate-MaintainerRemoved.golden
@@ -1,0 +1,34 @@
+From: =?utf-8?Q?Hackage_website?= <noreply@hackage.haskell.org>
+To: =?utf-8?Q?user-watcher?= <user-watcher@example.com>
+Subject: [Hackage] Maintainer Notifications
+MIME-Version: 1.0
+Content-Type: multipart/alternative; boundary="YIYrWcf3to"
+
+--YIYrWcf3to
+Content-Type: text/plain; charset=utf-8
+
+Group modified by user-actor [Wed Jan  1 00:00:00 UTC 2020]:
+
+* user-subject removed from maintainers for base
+* Reason: User is no longer cool
+
+You can adjust your notification preferences at
+https://hackage.haskell.org/user/user-watcher/notify (https://hackage.haskell.org/user/user-watcher/notify)
+
+
+--YIYrWcf3to
+Content-Type: text/html; charset=utf-8
+
+
+<p>
+Group modified by user-actor [Wed Jan  1 00:00:00 UTC 2020]:
+</p>
+<ul>
+  <li>user-subject removed from maintainers for base</li>
+  <li>Reason: User is no longer cool</li>
+</ul>
+<p>
+You can adjust your notification preferences at
+<br /><a href="https://hackage.haskell.org/user/user-watcher/notify">https://hackage.haskell.org/user/user-watcher/notify</a>
+</p>
+--YIYrWcf3to--

--- a/tests/golden/ReverseDependenciesTest/getNotificationEmails-NotifyMaintainerUpdate-MaintainerRemoved.golden
+++ b/tests/golden/ReverseDependenciesTest/getNotificationEmails-NotifyMaintainerUpdate-MaintainerRemoved.golden
@@ -6,6 +6,7 @@ Content-Type: multipart/alternative; boundary="YIYrWcf3to"
 
 --YIYrWcf3to
 Content-Type: text/plain; charset=utf-8
+Content-Transfer-Encoding: quoted-printable
 
 Group modified by user-actor [Wed Jan  1 00:00:00 UTC 2020]:
 
@@ -13,11 +14,13 @@ Group modified by user-actor [Wed Jan  1 00:00:00 UTC 2020]:
 * Reason: User is no longer cool
 
 You can adjust your notification preferences at
-https://hackage.haskell.org/user/user-watcher/notify (https://hackage.haskell.org/user/user-watcher/notify)
+https://hackage=2Ehaskell=2Eorg/user/user-watcher/notify (https://hackage=
+=2Ehaskell=2Eorg/user/user-watcher/notify)
 
 
 --YIYrWcf3to
 Content-Type: text/html; charset=utf-8
+Content-Transfer-Encoding: quoted-printable
 
 
 <p>
@@ -29,6 +32,7 @@ Group modified by user-actor [Wed Jan  1 00:00:00 UTC 2020]:
 </ul>
 <p>
 You can adjust your notification preferences at
-<br /><a href="https://hackage.haskell.org/user/user-watcher/notify">https://hackage.haskell.org/user/user-watcher/notify</a>
+<br /><a href=3D"https://hackage=2Ehaskell=2Eorg/user/user-watcher/notify">=
+https://hackage=2Ehaskell=2Eorg/user/user-watcher/notify</a>
 </p>
 --YIYrWcf3to--

--- a/tests/golden/ReverseDependenciesTest/getNotificationEmails-NotifyNewRevision.golden
+++ b/tests/golden/ReverseDependenciesTest/getNotificationEmails-NotifyNewRevision.golden
@@ -6,22 +6,27 @@ Content-Type: multipart/alternative; boundary="YIYrWcf3to"
 
 --YIYrWcf3to
 Content-Type: text/plain; charset=utf-8
+Content-Transfer-Encoding: quoted-printable
 
-Package metadata revision(s), base-4.18.0.0 (https://hackage.haskell.org/package/base-4.18.0.0):
+Package metadata revision(s), base-4=2E18=2E0=2E0 (https://hackage=2Ehaskel=
+l=2Eorg/package/base-4=2E18=2E0=2E0):
 
 * user-actor [Fri Jan  3 00:00:00 UTC 2020]
 * user-actor [Thu Jan  2 00:00:00 UTC 2020]
 
 You can adjust your notification preferences at
-https://hackage.haskell.org/user/user-watcher/notify (https://hackage.haskell.org/user/user-watcher/notify)
+https://hackage=2Ehaskell=2Eorg/user/user-watcher/notify (https://hackage=
+=2Ehaskell=2Eorg/user/user-watcher/notify)
 
 
 --YIYrWcf3to
 Content-Type: text/html; charset=utf-8
+Content-Transfer-Encoding: quoted-printable
 
 
 <p>
-Package metadata revision(s), <a href="https://hackage.haskell.org/package/base-4.18.0.0">base-4.18.0.0</a>:
+Package metadata revision(s), <a href=3D"https://hackage=2Ehaskell=2Eorg/pa=
+ckage/base-4=2E18=2E0=2E0">base-4=2E18=2E0=2E0</a>:
 </p>
 <ul>
   <li>user-actor [Fri Jan  3 00:00:00 UTC 2020]</li>
@@ -29,6 +34,7 @@ Package metadata revision(s), <a href="https://hackage.haskell.org/package/base-
 </ul>
 <p>
 You can adjust your notification preferences at
-<br /><a href="https://hackage.haskell.org/user/user-watcher/notify">https://hackage.haskell.org/user/user-watcher/notify</a>
+<br /><a href=3D"https://hackage=2Ehaskell=2Eorg/user/user-watcher/notify">=
+https://hackage=2Ehaskell=2Eorg/user/user-watcher/notify</a>
 </p>
 --YIYrWcf3to--

--- a/tests/golden/ReverseDependenciesTest/getNotificationEmails-NotifyNewRevision.golden
+++ b/tests/golden/ReverseDependenciesTest/getNotificationEmails-NotifyNewRevision.golden
@@ -1,0 +1,34 @@
+From: =?utf-8?Q?Hackage_website?= <noreply@hackage.haskell.org>
+To: =?utf-8?Q?user-watcher?= <user-watcher@example.com>
+Subject: [Hackage] Maintainer Notifications
+MIME-Version: 1.0
+Content-Type: multipart/alternative; boundary="YIYrWcf3to"
+
+--YIYrWcf3to
+Content-Type: text/plain; charset=utf-8
+
+Package metadata revision(s), base-4.18.0.0 (https://hackage.haskell.org/package/base-4.18.0.0):
+
+* user-actor [Fri Jan  3 00:00:00 UTC 2020]
+* user-actor [Thu Jan  2 00:00:00 UTC 2020]
+
+You can adjust your notification preferences at
+https://hackage.haskell.org/user/user-watcher/notify (https://hackage.haskell.org/user/user-watcher/notify)
+
+
+--YIYrWcf3to
+Content-Type: text/html; charset=utf-8
+
+
+<p>
+Package metadata revision(s), <a href="https://hackage.haskell.org/package/base-4.18.0.0">base-4.18.0.0</a>:
+</p>
+<ul>
+  <li>user-actor [Fri Jan  3 00:00:00 UTC 2020]</li>
+  <li>user-actor [Thu Jan  2 00:00:00 UTC 2020]</li>
+</ul>
+<p>
+You can adjust your notification preferences at
+<br /><a href="https://hackage.haskell.org/user/user-watcher/notify">https://hackage.haskell.org/user/user-watcher/notify</a>
+</p>
+--YIYrWcf3to--

--- a/tests/golden/ReverseDependenciesTest/getNotificationEmails-NotifyNewVersion.golden
+++ b/tests/golden/ReverseDependenciesTest/getNotificationEmails-NotifyNewVersion.golden
@@ -6,22 +6,29 @@ Content-Type: multipart/alternative; boundary="YIYrWcf3to"
 
 --YIYrWcf3to
 Content-Type: text/plain; charset=utf-8
+Content-Transfer-Encoding: quoted-printable
 
-Package upload, base-4.18.0.0 (https://hackage.haskell.org/package/base-4.18.0.0), by user-actor [Wed Jan  1 00:00:00 UTC 2020]
+Package upload, base-4=2E18=2E0=2E0 (https://hackage=2Ehaskell=2Eorg/packag=
+e/base-4=2E18=2E0=2E0), by user-actor [Wed Jan  1 00:00:00 UTC 2020]
 
 You can adjust your notification preferences at
-https://hackage.haskell.org/user/user-watcher/notify (https://hackage.haskell.org/user/user-watcher/notify)
+https://hackage=2Ehaskell=2Eorg/user/user-watcher/notify (https://hackage=
+=2Ehaskell=2Eorg/user/user-watcher/notify)
 
 
 --YIYrWcf3to
 Content-Type: text/html; charset=utf-8
+Content-Transfer-Encoding: quoted-printable
 
 
 <p>
-Package upload, <a href="https://hackage.haskell.org/package/base-4.18.0.0">base-4.18.0.0</a>, by user-actor [Wed Jan  1 00:00:00 UTC 2020]
+Package upload, <a href=3D"https://hackage=2Ehaskell=2Eorg/package/base-4=
+=2E18=2E0=2E0">base-4=2E18=2E0=2E0</a>, by user-actor [Wed Jan  1 00:00:00 =
+UTC 2020]
 </p>
 <p>
 You can adjust your notification preferences at
-<br /><a href="https://hackage.haskell.org/user/user-watcher/notify">https://hackage.haskell.org/user/user-watcher/notify</a>
+<br /><a href=3D"https://hackage=2Ehaskell=2Eorg/user/user-watcher/notify">=
+https://hackage=2Ehaskell=2Eorg/user/user-watcher/notify</a>
 </p>
 --YIYrWcf3to--

--- a/tests/golden/ReverseDependenciesTest/getNotificationEmails-NotifyNewVersion.golden
+++ b/tests/golden/ReverseDependenciesTest/getNotificationEmails-NotifyNewVersion.golden
@@ -1,0 +1,27 @@
+From: =?utf-8?Q?Hackage_website?= <noreply@hackage.haskell.org>
+To: =?utf-8?Q?user-watcher?= <user-watcher@example.com>
+Subject: [Hackage] Maintainer Notifications
+MIME-Version: 1.0
+Content-Type: multipart/alternative; boundary="YIYrWcf3to"
+
+--YIYrWcf3to
+Content-Type: text/plain; charset=utf-8
+
+Package upload, base-4.18.0.0 (https://hackage.haskell.org/package/base-4.18.0.0), by user-actor [Wed Jan  1 00:00:00 UTC 2020]
+
+You can adjust your notification preferences at
+https://hackage.haskell.org/user/user-watcher/notify (https://hackage.haskell.org/user/user-watcher/notify)
+
+
+--YIYrWcf3to
+Content-Type: text/html; charset=utf-8
+
+
+<p>
+Package upload, <a href="https://hackage.haskell.org/package/base-4.18.0.0">base-4.18.0.0</a>, by user-actor [Wed Jan  1 00:00:00 UTC 2020]
+</p>
+<p>
+You can adjust your notification preferences at
+<br /><a href="https://hackage.haskell.org/user/user-watcher/notify">https://hackage.haskell.org/user/user-watcher/notify</a>
+</p>
+--YIYrWcf3to--

--- a/tests/golden/ReverseDependenciesTest/getNotificationEmails-NotifyUpdateTags.golden
+++ b/tests/golden/ReverseDependenciesTest/getNotificationEmails-NotifyUpdateTags.golden
@@ -1,0 +1,34 @@
+From: =?utf-8?Q?Hackage_website?= <noreply@hackage.haskell.org>
+To: =?utf-8?Q?user-watcher?= <user-watcher@example.com>
+Subject: [Hackage] Maintainer Notifications
+MIME-Version: 1.0
+Content-Type: multipart/alternative; boundary="YIYrWcf3to"
+
+--YIYrWcf3to
+Content-Type: text/plain; charset=utf-8
+
+Pending tag proposal for base:
+
+* Additions: bsd3, library, prelude
+* Deletions: bad, example, foo
+
+You can adjust your notification preferences at
+https://hackage.haskell.org/user/user-watcher/notify (https://hackage.haskell.org/user/user-watcher/notify)
+
+
+--YIYrWcf3to
+Content-Type: text/html; charset=utf-8
+
+
+<p>
+Pending tag proposal for base:
+</p>
+<ul>
+  <li>Additions: bsd3, library, prelude</li>
+  <li>Deletions: bad, example, foo</li>
+</ul>
+<p>
+You can adjust your notification preferences at
+<br /><a href="https://hackage.haskell.org/user/user-watcher/notify">https://hackage.haskell.org/user/user-watcher/notify</a>
+</p>
+--YIYrWcf3to--

--- a/tests/golden/ReverseDependenciesTest/getNotificationEmails-NotifyUpdateTags.golden
+++ b/tests/golden/ReverseDependenciesTest/getNotificationEmails-NotifyUpdateTags.golden
@@ -6,6 +6,7 @@ Content-Type: multipart/alternative; boundary="YIYrWcf3to"
 
 --YIYrWcf3to
 Content-Type: text/plain; charset=utf-8
+Content-Transfer-Encoding: quoted-printable
 
 Pending tag proposal for base:
 
@@ -13,11 +14,13 @@ Pending tag proposal for base:
 * Deletions: bad, example, foo
 
 You can adjust your notification preferences at
-https://hackage.haskell.org/user/user-watcher/notify (https://hackage.haskell.org/user/user-watcher/notify)
+https://hackage=2Ehaskell=2Eorg/user/user-watcher/notify (https://hackage=
+=2Ehaskell=2Eorg/user/user-watcher/notify)
 
 
 --YIYrWcf3to
 Content-Type: text/html; charset=utf-8
+Content-Transfer-Encoding: quoted-printable
 
 
 <p>
@@ -29,6 +32,7 @@ Pending tag proposal for base:
 </ul>
 <p>
 You can adjust your notification preferences at
-<br /><a href="https://hackage.haskell.org/user/user-watcher/notify">https://hackage.haskell.org/user/user-watcher/notify</a>
+<br /><a href=3D"https://hackage=2Ehaskell=2Eorg/user/user-watcher/notify">=
+https://hackage=2Ehaskell=2Eorg/user/user-watcher/notify</a>
 </p>
 --YIYrWcf3to--

--- a/tests/golden/ReverseDependenciesTest/getNotificationEmails-batched.golden
+++ b/tests/golden/ReverseDependenciesTest/getNotificationEmails-batched.golden
@@ -6,25 +6,30 @@ Content-Type: multipart/alternative; boundary="YIYrWcf3to"
 
 --YIYrWcf3to
 Content-Type: text/plain; charset=utf-8
+Content-Transfer-Encoding: quoted-printable
 
 Pending tag proposal for base:
 
 * Additions: newtag
 * Deletions: oldtag
 
-Package doc build for base-4.18.0.0 (https://hackage.haskell.org/package/base-4.18.0.0):
-Build successful.
+Package doc build for base-4=2E18=2E0=2E0 (https://hackage=2Ehaskell=2Eorg/=
+package/base-4=2E18=2E0=2E0):
+Build successful=2E
 
-Package metadata revision(s), base-4.18.0.0 (https://hackage.haskell.org/package/base-4.18.0.0):
+Package metadata revision(s), base-4=2E18=2E0=2E0 (https://hackage=2Ehaskel=
+l=2Eorg/package/base-4=2E18=2E0=2E0):
 
 * user-actor [Wed Jan  1 00:00:00 UTC 2020]
 
 You can adjust your notification preferences at
-https://hackage.haskell.org/user/user-watcher/notify (https://hackage.haskell.org/user/user-watcher/notify)
+https://hackage=2Ehaskell=2Eorg/user/user-watcher/notify (https://hackage=
+=2Ehaskell=2Eorg/user/user-watcher/notify)
 
 
 --YIYrWcf3to
 Content-Type: text/html; charset=utf-8
+Content-Transfer-Encoding: quoted-printable
 
 
 <p>
@@ -35,17 +40,20 @@ Pending tag proposal for base:
   <li>Deletions: oldtag</li>
 </ul>
 <p>
-Package doc build for <a href="https://hackage.haskell.org/package/base-4.18.0.0">base-4.18.0.0</a>:
-<br />Build successful.
+Package doc build for <a href=3D"https://hackage=2Ehaskell=2Eorg/package/ba=
+se-4=2E18=2E0=2E0">base-4=2E18=2E0=2E0</a>:
+<br />Build successful=2E
 </p>
 <p>
-Package metadata revision(s), <a href="https://hackage.haskell.org/package/base-4.18.0.0">base-4.18.0.0</a>:
+Package metadata revision(s), <a href=3D"https://hackage=2Ehaskell=2Eorg/pa=
+ckage/base-4=2E18=2E0=2E0">base-4=2E18=2E0=2E0</a>:
 </p>
 <ul>
   <li>user-actor [Wed Jan  1 00:00:00 UTC 2020]</li>
 </ul>
 <p>
 You can adjust your notification preferences at
-<br /><a href="https://hackage.haskell.org/user/user-watcher/notify">https://hackage.haskell.org/user/user-watcher/notify</a>
+<br /><a href=3D"https://hackage=2Ehaskell=2Eorg/user/user-watcher/notify">=
+https://hackage=2Ehaskell=2Eorg/user/user-watcher/notify</a>
 </p>
 --YIYrWcf3to--

--- a/tests/golden/ReverseDependenciesTest/getNotificationEmails-batched.golden
+++ b/tests/golden/ReverseDependenciesTest/getNotificationEmails-batched.golden
@@ -1,0 +1,51 @@
+From: =?utf-8?Q?Hackage_website?= <noreply@hackage.haskell.org>
+To: =?utf-8?Q?user-watcher?= <user-watcher@example.com>
+Subject: [Hackage] Maintainer Notifications
+MIME-Version: 1.0
+Content-Type: multipart/alternative; boundary="YIYrWcf3to"
+
+--YIYrWcf3to
+Content-Type: text/plain; charset=utf-8
+
+Pending tag proposal for base:
+
+* Additions: newtag
+* Deletions: oldtag
+
+Package doc build for base-4.18.0.0 (https://hackage.haskell.org/package/base-4.18.0.0):
+Build successful.
+
+Package metadata revision(s), base-4.18.0.0 (https://hackage.haskell.org/package/base-4.18.0.0):
+
+* user-actor [Wed Jan  1 00:00:00 UTC 2020]
+
+You can adjust your notification preferences at
+https://hackage.haskell.org/user/user-watcher/notify (https://hackage.haskell.org/user/user-watcher/notify)
+
+
+--YIYrWcf3to
+Content-Type: text/html; charset=utf-8
+
+
+<p>
+Pending tag proposal for base:
+</p>
+<ul>
+  <li>Additions: newtag</li>
+  <li>Deletions: oldtag</li>
+</ul>
+<p>
+Package doc build for <a href="https://hackage.haskell.org/package/base-4.18.0.0">base-4.18.0.0</a>:
+<br />Build successful.
+</p>
+<p>
+Package metadata revision(s), <a href="https://hackage.haskell.org/package/base-4.18.0.0">base-4.18.0.0</a>:
+</p>
+<ul>
+  <li>user-actor [Wed Jan  1 00:00:00 UTC 2020]</li>
+</ul>
+<p>
+You can adjust your notification preferences at
+<br /><a href="https://hackage.haskell.org/user/user-watcher/notify">https://hackage.haskell.org/user/user-watcher/notify</a>
+</p>
+--YIYrWcf3to--


### PR DESCRIPTION
Fixes #1242 

Apologies in advance for the huge changeset. Probably easiest to review commit-by-commit.

Everything up to the "Add markup to emails" commit is what's minimally necessary to send both plain text + HTML. The commits after "Add markup to emails" include a ton of refactoring in order to test this. Happy to break this out into a separate PR if desired.

Key areas of note:
* "Add markup to emails" (e0c89e7c): This adds markup like linking things, making bulleted lists, etc. Would be good to audit this. The HTML can be inspected in the [golden files](https://github.com/brandonchinn178/hackage-server/tree/notify-email/tests/golden/ReverseDependenciesTest).
* "Simplify describeDependencyUpdate" (https://github.com/haskell/hackage-server/pull/1243/commits/d0d539ef0dc9bc866f30c2740c42c49089e389ee): This commit slightly changes the template sent out for dependency updates. It makes the rendering logic more linear, at the cost of a bit more verbosity.
* "Improve email subject for dep update emails" (https://github.com/haskell/hackage-server/pull/1243/commits/6a46f306f609eed4d66dfa3c5e5dfe5889fad1c3): Instead of a generic "Maintainer Notifications" subject line, dependency update emails will have the dependency name in the subject line.
    * Related, why not batch all the emails, or batch none of them? Now that we're rendering HTML, we can use `<hr>` to render a horizontal line between notifications (plain text could just render a line of hyphens). But it also doesn't seem likely for multiple notifications to come at once; maybe batching is premature optimization + sending one email per notification is fine?

Happy to set up a call if you want to pair review. I'm on PST, my email can be found in my profile