### PR TITLE
update `flake.nix` for recent `haskell-flake`

### DIFF
--- a/cabal.project
+++ b/cabal.project
@@ -1,3 +1,9 @@
+packages:
+         .
+
+-- This comment moved below "packages" to fix parsing of this file
+-- by flake.nix
+
 -- This project config requires cabal 2.4 or later
 
 -- If in doubt, use GHC 8.8 to build hackage-server; see
@@ -6,8 +12,7 @@
 --
 -- with-compiler: ghc-8.8
 
-packages: .
-
+         
 allow-newer: rss:time, rss:base
 
 -----------------------------------------------------------------------------

--- a/cabal.project
+++ b/cabal.project
@@ -1,5 +1,5 @@
 packages:
-         .
+  .
 
 -- This comment moved below "packages" to fix parsing of this file
 -- by flake.nix

--- a/flake.lock
+++ b/flake.lock
@@ -2,14 +2,16 @@
   "nodes": {
     "flake-parts": {
       "inputs": {
-        "nixpkgs-lib": "nixpkgs-lib"
+        "nixpkgs-lib": [
+          "nixpkgs"
+        ]
       },
       "locked": {
-        "lastModified": 1680392223,
-        "narHash": "sha256-n3g7QFr85lDODKt250rkZj2IFS3i4/8HBU2yKHO3tqw=",
+        "lastModified": 1690933134,
+        "narHash": "sha256-ab989mN63fQZBFrkk4Q8bYxQCktuHmBIBqUG1jl6/FQ=",
         "owner": "hercules-ci",
         "repo": "flake-parts",
-        "rev": "dcc36e45d054d7bb554c9cdab69093debd91a0b5",
+        "rev": "59cf3f1447cfc75087e7273b04b31e689a8599fb",
         "type": "github"
       },
       "original": {
@@ -35,41 +37,26 @@
     },
     "haskell-flake": {
       "locked": {
-        "lastModified": 1682000949,
-        "narHash": "sha256-yWu5/pR7WWuXgVFDEGe6rrsHwnSAHeMGo8wGZ1jVwzs=",
+        "lastModified": 1691763544,
+        "narHash": "sha256-QQsSI5VXm0bBijeGSXXNf4fyw76/XmN67NGbmTCx71s=",
         "owner": "srid",
         "repo": "haskell-flake",
-        "rev": "1f801ee0bf776ae3f34e8942004fa5639c79b3a7",
+        "rev": "f16e7ac05b1f22b66ef05b7fcc8a96281bb2b749",
         "type": "github"
       },
       "original": {
         "owner": "srid",
         "repo": "haskell-flake",
-        "type": "github"
-      }
-    },
-    "mission-control": {
-      "locked": {
-        "lastModified": 1682001320,
-        "narHash": "sha256-cXxEhjdJjWw1n8d14+PR8h/i0gLVLG2xq4kw5sJeuxg=",
-        "owner": "Platonic-Systems",
-        "repo": "mission-control",
-        "rev": "c2f3f0a8dce770c46bfa217270ee5592f3a5ebf5",
-        "type": "github"
-      },
-      "original": {
-        "owner": "Platonic-Systems",
-        "repo": "mission-control",
         "type": "github"
       }
     },
     "nixpkgs": {
       "locked": {
-        "lastModified": 1691885509,
-        "narHash": "sha256-MCKEstJdWdlUnh3V34SpOZTQj4bOeada+xhDh9U/0y8=",
+        "lastModified": 1692490321,
+        "narHash": "sha256-5GAMLkvPQroGsLv6gmCct+GLFCOOL0hKQFv7UWpUMsc=",
         "owner": "nixos",
         "repo": "nixpkgs",
-        "rev": "163a5a5675d7e95d3856cf6ae2a26227f25a96f8",
+        "rev": "b8a3b5d228949ae9cc782ef0e9cf2b4518403dad",
         "type": "github"
       },
       "original": {
@@ -79,82 +66,12 @@
         "type": "github"
       }
     },
-    "nixpkgs-140774-workaround": {
-      "locked": {
-        "lastModified": 1681394207,
-        "narHash": "sha256-hk9RUPnChwKjCtm/YzixAak5wIzIw+b1avp7I3vg3dQ=",
-        "owner": "srid",
-        "repo": "nixpkgs-140774-workaround",
-        "rev": "a3c6d0622758e5d3da3d63100547f400ce6cb376",
-        "type": "github"
-      },
-      "original": {
-        "owner": "srid",
-        "repo": "nixpkgs-140774-workaround",
-        "type": "github"
-      }
-    },
-    "nixpkgs-lib": {
-      "locked": {
-        "dir": "lib",
-        "lastModified": 1680213900,
-        "narHash": "sha256-cIDr5WZIj3EkKyCgj/6j3HBH4Jj1W296z7HTcWj1aMA=",
-        "owner": "NixOS",
-        "repo": "nixpkgs",
-        "rev": "e3652e0735fbec227f342712f180f4f21f0594f2",
-        "type": "github"
-      },
-      "original": {
-        "dir": "lib",
-        "owner": "NixOS",
-        "ref": "nixos-unstable",
-        "repo": "nixpkgs",
-        "type": "github"
-      }
-    },
-    "nixpkgs_2": {
-      "locked": {
-        "lastModified": 1680945546,
-        "narHash": "sha256-8FuaH5t/aVi/pR1XxnF0qi4WwMYC+YxlfdsA0V+TEuQ=",
-        "owner": "nixos",
-        "repo": "nixpkgs",
-        "rev": "d9f759f2ea8d265d974a6e1259bd510ac5844c5d",
-        "type": "github"
-      },
-      "original": {
-        "owner": "nixos",
-        "ref": "nixos-unstable",
-        "repo": "nixpkgs",
-        "type": "github"
-      }
-    },
     "root": {
       "inputs": {
         "flake-parts": "flake-parts",
         "flake-root": "flake-root",
         "haskell-flake": "haskell-flake",
-        "mission-control": "mission-control",
-        "nixpkgs": "nixpkgs",
-        "nixpkgs-140774-workaround": "nixpkgs-140774-workaround",
-        "treefmt-nix": "treefmt-nix"
-      }
-    },
-    "treefmt-nix": {
-      "inputs": {
-        "nixpkgs": "nixpkgs_2"
-      },
-      "locked": {
-        "lastModified": 1681486253,
-        "narHash": "sha256-EjiQZvXQH9tUPCyLC6lQpfGnoq4+kI9v59bDJWPicYo=",
-        "owner": "numtide",
-        "repo": "treefmt-nix",
-        "rev": "b25d1a3c2c7554d0462ab1dfddf2f13128638b90",
-        "type": "github"
-      },
-      "original": {
-        "owner": "numtide",
-        "repo": "treefmt-nix",
-        "type": "github"
+        "nixpkgs": "nixpkgs"
       }
     }
   },

--- a/flake.nix
+++ b/flake.nix
@@ -34,14 +34,14 @@
               # Setting to null should remove this tool from defaults.
               ghcid = null;
               haskell-language-server = null;
-
               inherit (pkgs)
                 cabal-install
                 ghc
 
-                glibc
-                icu67
-                zlib
+                # https://github.com/haskell/hackage-server/pull/1219#issuecomment-1597140858
+                # glibc
+                # icu67
+                # zlib
                 openssl
                 cryptodev
                 pkg-config

--- a/flake.nix
+++ b/flake.nix
@@ -3,74 +3,60 @@
     nixpkgs.url = "github:nixos/nixpkgs/haskell-updates";
     flake-parts.url = "github:hercules-ci/flake-parts";
     haskell-flake.url = "github:srid/haskell-flake";
-    treefmt-nix.url = "github:numtide/treefmt-nix";
     flake-root.url = "github:srid/flake-root";
-    mission-control.url = "github:Platonic-Systems/mission-control";
-
-    nixpkgs-140774-workaround.url = "github:srid/nixpkgs-140774-workaround";
+    flake-parts.inputs.nixpkgs-lib.follows = "nixpkgs";
   };
 
   outputs = inputs@{ self, nixpkgs, flake-parts, ... }:
     flake-parts.lib.mkFlake { inherit inputs; } {
-      systems = [ "x86_64-linux" "x86_64-darwin" "aarch64-darwin" ];
+      systems = [ "x86_64-linux" "x86_64-darwin" "aarch64-linux" "aarch64-darwin" ];
       imports = [
         inputs.haskell-flake.flakeModule
         inputs.flake-root.flakeModule
-        inputs.mission-control.flakeModule
       ];
       perSystem = { self', system, lib, config, pkgs, ... }: {
         # The "main" project. You can have multiple projects, but this template
         # has only one.
-        haskellProjects.main = {
-          # basePackages = pkgs.haskell.packages.ghc927;
-          # basePackages = pkgs.haskell.packages.ghc944;
-          imports = [
-            inputs.nixpkgs-140774-workaround.haskellFlakeProjectModules.default
-          ];
-          packages.hackage-server.root = ./.;  # Auto-discovered by haskell-flake
-
-          overrides = self: super: {
-            Cabal = super.Cabal_3_10_1_0;
-            Cabal-syntax = super.Cabal-syntax_3_10_1_0;
-
-            ghcide = pkgs.haskell.lib.dontCheck (self.callHackage "ghcide" "1.9.0.0" {});
-
-            streamly = self.callHackage "streamly" "0.9.0" {};
-            streamly_0_9_0 = self.callHackage "streamly" "0.9.0" {};
+        packages.default = config.packages.hackage-server;
+        haskellProjects.default = {
+          settings = {
+            hackage-server.check = false;
+            heist.check = false;
+          };
+          packages = {
+            Cabal.source = "3.10.1.0";
+            Cabal-syntax.source = "3.10.1.0";
+            attoparsec-aeson.source = "2.1.0.0";
+            hedgehog.source = "1.3";
           };
           devShell = {
+            tools = hp: {
+              # Setting to null should remove this tool from defaults.
+              ghcid = null;
+              haskell-language-server = null;
+
+              inherit (pkgs)
+                cabal-install
+                ghc
+
+                glibc
+                icu67
+                zlib
+                openssl
+                cryptodev
+                pkg-config
+                brotli
+
+                gd
+                libpng
+                libjpeg
+                fontconfig
+                freetype
+                expat
+              ;
+            };
             hlsCheck.enable = false;
           };
-        };
-
-        packages.default = pkgs.haskell.lib.dontCheck (self'.packages.main-hackage-server);
-
-        # TODO: fix HLS https://github.com/haskell/haskell-language-server/issues/3518
-        # Default shell.
-        # devShells.default =
-        #   config.mission-control.installToDevShell self'.devShells.main;
-        devShells.default = pkgs.mkShell {
-          buildInputs =
-            with pkgs;
-            [ cabal-install
-              ghc
-
-              glibc
-              icu67
-              zlib
-              openssl
-              cryptodev
-              pkg-config
-              brotli
-
-              gd
-              libpng
-              libjpeg
-              fontconfig
-              freetype
-              expat
-
-            ];
         };
       };
     };


### PR DESCRIPTION
- The `flake.nix` is updated to be compatible with the latest https://github.com/srid/haskell-flake

- Small tweak to `cabal.project` to fix a parsing error in the Nix Flake. No effect on `cabal`.

- `nix flake update`

- Updates to the Nix section of the readme