### PR TITLE
enable `hlsCheck`

### DIFF
--- a/flake.nix
+++ b/flake.nix
@@ -70,7 +70,7 @@
                 expat
               ;
             };
-            hlsCheck.enable = false;
+            hlsCheck.enable = true;
           };
         };
       };


### PR DESCRIPTION
https://srid.ca/haskell-template/checks


-----------------

I wonder if related to https://github.com/haskell/hackage-server/issues/1250

```
l/Email.hs
Hidden:   no
Range:    1:1-2:1
Source:   cradle
Severity: DiagnosticSeverity_Error
Message: 
  Error when calling cabal exec -v0 -- ghc --print-libdir

  dieVerbatim: user error (Error: cabal: Couldn't establish HTTP connection. Possible cause: HTTP
  proxy
  server is down.
  )
```
