### PR TITLE
Add vouching

### DIFF
--- a/datafiles/templates/Html/vouch.html.st
+++ b/datafiles/templates/Html/vouch.html.st
@@ -18,9 +18,7 @@ $hackagePageHeader()$
 </form>
 
 <p>Endorsing cannot be undone! When the user has $requiredNumber$ endorsements, the user
-can upload packages. Note that users are, to a certain degree, held accountable
-for the actions of the users they endorse. Only endorse people you know.</p>
-
+will be added to the uploaders group, and allowed to upload packages. Only endorse people who you trust to upload packages responsibly.</p>
 <ul>
   $vouches$
 </ul>

--- a/datafiles/templates/Html/vouch.html.st
+++ b/datafiles/templates/Html/vouch.html.st
@@ -1,0 +1,29 @@
+<!DOCTYPE html>
+<html>
+<head>
+$hackageCssTheme()$
+<title>Vouch for user | Hackage</title>
+</head>
+
+<body>
+$hackagePageHeader()$
+
+<div id="content">
+<h2>Vouch for user</h2>
+
+<p>$msg$</p>
+
+<form action="" method=POST>
+<input type=submit value="Vouch for this user">
+</form>
+
+<p>Vouching cannot be undone! When the user has three vouches, the user
+can upload packages. Note that users are, to a certain degree, held accountable
+for the actions of the users they vouch for. Only vouch for people you know.</p>
+
+<ul>
+  $vouches$
+</ul>
+
+</div>
+</body></html>

--- a/datafiles/templates/Html/vouch.html.st
+++ b/datafiles/templates/Html/vouch.html.st
@@ -2,24 +2,24 @@
 <html>
 <head>
 $hackageCssTheme()$
-<title>Vouch for user | Hackage</title>
+<title>Endorse user | Hackage</title>
 </head>
 
 <body>
 $hackagePageHeader()$
 
 <div id="content">
-<h2>Vouch for user</h2>
+<h2>Endorse user</h2>
 
 <p>$msg$</p>
 
 <form action="" method=POST>
-<input type=submit value="Vouch for this user">
+<input type=submit value="Endorse this user">
 </form>
 
-<p>Vouching cannot be undone! When the user has three vouches, the user
+<p>Endorsing cannot be undone! When the user has $requiredNumber$ endorsements, the user
 can upload packages. Note that users are, to a certain degree, held accountable
-for the actions of the users they vouch for. Only vouch for people you know.</p>
+for the actions of the users they endorse. Only endorse people you know.</p>
 
 <ul>
   $vouches$

--- a/hackage-server.cabal
+++ b/hackage-server.cabal
@@ -373,8 +373,9 @@ library lib-server
       Distribution.Server.Features.Search.TermBag
       Distribution.Server.Features.Sitemap.Functions
       Distribution.Server.Features.Votes
-      Distribution.Server.Features.Votes.State
       Distribution.Server.Features.Votes.Render
+      Distribution.Server.Features.Votes.State
+      Distribution.Server.Features.Vouch
       Distribution.Server.Features.RecentPackages
       Distribution.Server.Features.PreferredVersions
       Distribution.Server.Features.PreferredVersions.State

--- a/hackage-server.cabal
+++ b/hackage-server.cabal
@@ -574,6 +574,14 @@ test-suite HighLevelTest
     , io-streams      ^>= 1.5.0.1
     , http-io-streams ^>= 0.1.6.1
 
+test-suite VouchTest
+  import: test-defaults
+  type: exitcode-stdio-1.0
+  main-is: VouchTest.hs
+  build-depends:
+    , tasty        ^>= 1.4
+    , tasty-hunit  ^>= 0.10
+
 test-suite ReverseDependenciesTest
   import: test-defaults
   type: exitcode-stdio-1.0

--- a/src/Distribution/Server/Features.hs
+++ b/src/Distribution/Server/Features.hs
@@ -51,6 +51,7 @@ import Distribution.Server.Features.Votes               (initVotesFeature)
 import Distribution.Server.Features.Sitemap             (initSitemapFeature)
 import Distribution.Server.Features.UserNotify          (initUserNotifyFeature)
 import Distribution.Server.Features.PackageFeed         (initPackageFeedFeature)
+import Distribution.Server.Features.Vouch               (initVouchFeature)
 #endif
 import Distribution.Server.Features.ServerIntrospect (serverIntrospectFeature)
 
@@ -159,6 +160,8 @@ initHackageFeatures env@ServerEnv{serverVerbosity = verbosity} = do
                                initUserNotifyFeature env
     mkPackageFeedFeature    <- logStartup "package feed" $
                                initPackageFeedFeature env
+    mkVouchFeature          <- logStartup "vouch" $
+                               initVouchFeature env
     mkBrowseFeature         <- logStartup "browse" $
                                initBrowseFeature env
     mkPackageJSONFeature    <- logStartup "package info JSON" $
@@ -359,6 +362,10 @@ initHackageFeatures env@ServerEnv{serverVerbosity = verbosity} = do
                             usersFeature
                             tarIndexCacheFeature
 
+    vouchFeature <- mkVouchFeature
+                      usersFeature
+                      uploadFeature
+
     browseFeature <- mkBrowseFeature
                        coreFeature
                        usersFeature
@@ -415,6 +422,7 @@ initHackageFeatures env@ServerEnv{serverVerbosity = verbosity} = do
          , getFeatureInterface userNotifyFeature
          , getFeatureInterface packageFeedFeature
          , getFeatureInterface packageInfoJSONFeature
+         , getFeatureInterface vouchFeature
 #endif
          , staticFilesFeature
          , serverIntrospectFeature allFeatures

--- a/src/Distribution/Server/Features.hs
+++ b/src/Distribution/Server/Features.hs
@@ -347,6 +347,10 @@ initHackageFeatures env@ServerEnv{serverVerbosity = verbosity} = do
                         tagsFeature
                         tarIndexCacheFeature
 
+    vouchFeature <- mkVouchFeature
+                      usersFeature
+                      uploadFeature
+
     userNotifyFeature <- mkUserNotifyFeature
                            usersFeature
                            coreFeature
@@ -356,15 +360,12 @@ initHackageFeatures env@ServerEnv{serverVerbosity = verbosity} = do
                            reportsCoreFeature
                            tagsFeature
                            reverseFeature
+                           vouchFeature
 
     packageFeedFeature <- mkPackageFeedFeature
                             coreFeature
                             usersFeature
                             tarIndexCacheFeature
-
-    vouchFeature <- mkVouchFeature
-                      usersFeature
-                      uploadFeature
 
     browseFeature <- mkBrowseFeature
                        coreFeature

--- a/src/Distribution/Server/Features/UserNotify.hs
+++ b/src/Distribution/Server/Features/UserNotify.hs
@@ -1100,7 +1100,7 @@ getNotificationEmails
 
     renderNotifyVouchingCompleted =
       EmailContentParagraph
-        "You have received all necessary vouches. \
+        "You have received all necessary endorsements. \
         \You have been added the the 'uploaders' group. \
         \You can now upload packages to Hackage. \
         \Note that packages cannot be deleted, so be careful."

--- a/src/Distribution/Server/Features/Vouch.hs
+++ b/src/Distribution/Server/Features/Vouch.hs
@@ -218,6 +218,7 @@ initVouchFeature ServerEnv{serverStateDir, serverTemplatesDir, serverTemplatesMo
                 liftIO $ Group.addUserToGroup uploadersGroup vouchee
                 pure . toResponse $ vouchTemplate
                   [ "msg" $= "Added endorsement. User is now an uploader!"
+                  , "requiredNumber" $= show requiredCountOfVouches                  
                   , param
                   ]
               AddVouchIncomplete stillRequired ->

--- a/src/Distribution/Server/Features/Vouch.hs
+++ b/src/Distribution/Server/Features/Vouch.hs
@@ -1,0 +1,218 @@
+{-# LANGUAGE GeneralizedNewtypeDeriving #-}
+{-# LANGUAGE NamedFieldPuns #-}
+{-# LANGUAGE TemplateHaskell #-}
+{-# LANGUAGE TypeFamilies #-}
+{-# LANGUAGE DerivingStrategies #-}
+module Distribution.Server.Features.Vouch where
+
+import Control.Monad (when, join)
+import Control.Monad.Except (runExceptT, throwError)
+import Control.Monad.Reader (ask)
+import Control.Monad.State (get, put)
+import qualified Data.ByteString.Lazy.Char8 as LBS
+import qualified Data.Map.Strict as Map
+import Data.Maybe (fromMaybe)
+import Data.Time (UTCTime(..), addUTCTime, getCurrentTime, nominalDay, secondsToDiffTime)
+import Data.Time.Format.ISO8601 (formatShow, iso8601Format)
+import Text.XHtml.Strict (prettyHtmlFragment, stringToHtml, li)
+
+import Data.SafeCopy (base, deriveSafeCopy)
+import Distribution.Server.Framework ((</>), AcidState, DynamicPath, HackageFeature, IsHackageFeature, IsHackageFeature(..), MemSize)
+import Distribution.Server.Framework (MessageSpan(MText), Method(..), Query, Response, ServerEnv(..), ServerPartE, StateComponent(..), Update)
+import Distribution.Server.Framework (abstractAcidStateComponent, emptyHackageFeature, errBadRequest)
+import Distribution.Server.Framework (featureDesc, featureReloadFiles, featureResources, featureState)
+import Distribution.Server.Framework (liftIO, makeAcidic, openLocalStateFrom, query, queryState, resourceAt, resourceDesc, resourceGet)
+import Distribution.Server.Framework (resourcePost, toResponse, update, updateState)
+import Distribution.Server.Framework.BackupRestore (RestoreBackup(..))
+import Distribution.Server.Framework.Templating (($=), TemplateAttr, getTemplate, loadTemplates, reloadTemplates, templateUnescaped)
+import qualified Distribution.Server.Users.Group as Group
+import Distribution.Server.Users.Types (UserId(..), UserInfo, UserName(..), userName)
+import Distribution.Server.Features.Upload(UploadFeature(..))
+import Distribution.Server.Features.Users (UserFeature(..))
+import Distribution.Simple.Utils (toUTF8LBS)
+
+newtype VouchData = VouchData (Map.Map UserId [(UserId, UTCTime)])
+  deriving (Show, Eq)
+  deriving newtype MemSize
+
+putVouch :: UserId -> (UserId, UTCTime) -> Update VouchData ()
+putVouch vouchee (voucher, now) = do
+  VouchData tbl <- get
+  let oldMap = fromMaybe [] (Map.lookup vouchee tbl)
+      newMap = (voucher, now) : oldMap
+  put $ VouchData (Map.insert vouchee newMap tbl)
+
+getVouchesFor :: UserId -> Query VouchData [(UserId, UTCTime)]
+getVouchesFor needle = do
+  VouchData tbl <- ask
+  pure . fromMaybe [] $ Map.lookup needle tbl
+
+getVouchesData :: Query VouchData VouchData
+getVouchesData = ask
+
+replaceVouchesData :: VouchData -> Update VouchData ()
+replaceVouchesData = put
+
+$(deriveSafeCopy 0 'base ''VouchData)
+
+makeAcidic ''VouchData
+  [ 'putVouch
+  , 'getVouchesFor
+  -- Stock
+  , 'getVouchesData
+  , 'replaceVouchesData
+  ]
+
+vouchStateComponent :: FilePath -> IO (StateComponent AcidState VouchData)
+vouchStateComponent stateDir = do
+  st <- openLocalStateFrom (stateDir </> "db" </> "Vouch") (VouchData mempty)
+  let initialVouchData = VouchData mempty
+      restore =
+        RestoreBackup
+          { restoreEntry = error "Unexpected backup entry"
+          , restoreFinalize = return initialVouchData
+          }
+  pure StateComponent
+    { stateDesc = "Keeps track of vouches"
+    , stateHandle = st
+    , getState = query st GetVouchesData
+    , putState = update st . ReplaceVouchesData
+    , backupState = \_ _ -> []
+    , restoreState = restore
+    , resetState = vouchStateComponent
+    }
+
+data VouchFeature =
+  VouchFeature
+    { vouchFeatureInterface :: HackageFeature
+    }
+
+instance IsHackageFeature VouchFeature where
+  getFeatureInterface = vouchFeatureInterface
+
+requiredCountOfVouches :: Int
+requiredCountOfVouches = 3
+
+isWithinLastMonth :: UTCTime -> (UserId, UTCTime) -> Bool
+isWithinLastMonth now (_, vouchTime) =
+  addUTCTime (30 * nominalDay) vouchTime < now
+
+data Err
+  = NotAnUploader
+  | You'reTooNew
+  | VoucheeAlreadyUploader
+  | AlreadySufficientlyVouched
+  | YouAlreadyVouched
+
+data Success = AddVouchComplete | AddVouchIncomplete
+
+judge :: Group.UserIdSet -> UTCTime -> UserId -> [(UserId, UTCTime)] -> [(UserId, UTCTime)] -> UserId -> Either Err (Either Err Success)
+judge ugroup now vouchee vouchersForVoucher existingVouchers voucher = runExceptT $ do
+  when (not (voucher `Group.member` ugroup)) $
+    throwError NotAnUploader
+  -- You can only vouch for non-uploaders, so if this list has items, the user is uploader because of these vouches.
+  -- Make sure none of them are too recent.
+  when (length vouchersForVoucher >= requiredCountOfVouches && any (isWithinLastMonth now) vouchersForVoucher) $
+    throwError You'reTooNew
+  when (vouchee `Group.member` ugroup) $
+    throwError VoucheeAlreadyUploader
+  when (length existingVouchers >= 3) $
+    throwError AlreadySufficientlyVouched
+  when (voucher `elem` map fst existingVouchers) $
+    throwError YouAlreadyVouched
+  pure $
+    if length existingVouchers == requiredCountOfVouches - 1
+       then AddVouchComplete
+       else AddVouchIncomplete
+
+renderToLBS :: (UserId -> ServerPartE UserInfo) -> [(UserId, UTCTime)] -> ServerPartE TemplateAttr
+renderToLBS lookupUserInfo vouches = do
+  rendered <- traverse renderVouchers vouches
+  pure $
+    templateUnescaped "vouches" $
+      if null rendered
+         then LBS.pack "Nobody has vouched yet."
+         else LBS.intercalate mempty rendered
+  where
+  renderVouchers :: (UserId, UTCTime) -> ServerPartE LBS.ByteString
+  renderVouchers (uid, timestamp) = do
+    info <- lookupUserInfo uid
+    let UserName name = userName info
+        -- We don't need to show millisecond precision
+        -- So we truncate it off here
+        truncated = truncate $ utctDayTime timestamp
+        newUTCTime = timestamp {utctDayTime = secondsToDiffTime truncated}
+    pure . toUTF8LBS . prettyHtmlFragment . li . stringToHtml $ name <> " vouched on " <> formatShow iso8601Format newUTCTime
+
+initVouchFeature :: ServerEnv -> IO (UserFeature -> UploadFeature -> IO VouchFeature)
+initVouchFeature ServerEnv{serverStateDir, serverTemplatesDir, serverTemplatesMode} = do
+  vouchState <- vouchStateComponent serverStateDir
+  templates <- loadTemplates serverTemplatesMode [ serverTemplatesDir, serverTemplatesDir </> "Html"]
+                                                 ["vouch.html"]
+  vouchTemplate <- getTemplate templates "vouch.html"
+  return $ \UserFeature{userNameInPath, lookupUserName, lookupUserInfo, guardAuthenticated}
+            UploadFeature{uploadersGroup} -> do
+    let
+      handleGetVouches :: DynamicPath -> ServerPartE Response
+      handleGetVouches dpath = do
+        uid <- lookupUserName =<< userNameInPath dpath
+        userIds <- queryState vouchState $ GetVouchesFor uid
+        param <- renderToLBS lookupUserInfo userIds
+        pure . toResponse $ vouchTemplate
+          [ "msg" $= ""
+          , param
+          ]
+      handlePostVouch :: DynamicPath -> ServerPartE Response
+      handlePostVouch dpath = do
+        voucher <- guardAuthenticated
+        ugroup <- liftIO $ Group.queryUserGroup uploadersGroup
+        now <- liftIO getCurrentTime
+        vouchee <- lookupUserName =<< userNameInPath dpath
+        vouchersForVoucher <- queryState vouchState $ GetVouchesFor voucher
+        existingVouchers <- queryState vouchState $ GetVouchesFor vouchee
+        case join $ judge ugroup now vouchee vouchersForVoucher existingVouchers voucher of
+          Left NotAnUploader ->
+            errBadRequest "Not an uploader" [MText "You must be an uploader yourself to vouch for other users."]
+          Left You'reTooNew ->
+            errBadRequest "You're too new" [MText "The latest of the vouches for your user must be at least 30 days old."]
+          Left VoucheeAlreadyUploader ->
+            errBadRequest "Vouchee already uploader" [MText "You can't vouch for this user, since they are already an uploader."]
+          Left AlreadySufficientlyVouched ->
+            errBadRequest "Already sufficiently vouched" [MText "There are already a sufficient number of vouches for this user."]
+          Left YouAlreadyVouched ->
+            errBadRequest "Already vouched" [MText "You have already vouched for this user."]
+          Right result -> do
+            updateState vouchState $ PutVouch vouchee (voucher, now)
+            param <- renderToLBS lookupUserInfo $ existingVouchers ++ [(voucher, now)]
+            case result of
+              AddVouchComplete -> do
+                liftIO $ Group.addUserToGroup uploadersGroup vouchee
+                pure . toResponse $ vouchTemplate
+                  [ "msg" $= "Added vouch. User is now an uploader!"
+                  , param
+                  ]
+              AddVouchIncomplete -> do
+                let stillRequired = requiredCountOfVouches - length existingVouchers - 1
+                pure . toResponse $ vouchTemplate
+                  [ "msg" $=
+                         "Added vouch. User still needs "
+                      <> show stillRequired
+                      <> if stillRequired == 1 then " vouch" else " vouches"
+                      <> " to become uploader."
+                  , param
+                  ]
+    return $ VouchFeature $
+      (emptyHackageFeature "vouch")
+        { featureDesc = "Vouching for users getting upload permission."
+        , featureResources =
+          [(resourceAt "/user/:username/vouch")
+            { resourceDesc = [(GET, "list people vouching")
+                             ,(POST, "vouch for user")
+                             ]
+            , resourceGet = [("html", handleGetVouches)]
+            , resourcePost = [("html", handlePostVouch)]
+            }
+          ]
+        , featureState = [ abstractAcidStateComponent vouchState ]
+        , featureReloadFiles = reloadTemplates templates
+        }

--- a/tests/ReverseDependenciesTest.hs
+++ b/tests/ReverseDependenciesTest.hs
@@ -422,6 +422,8 @@ getNotificationEmailsTests =
               , notifyWatchedPackages = [PackageIdentifier "mtl" (mkVersion [2, 3])]
               , notifyTriggerBounds = BoundsOutOfRange
               }
+    , testGolden "Render NotifyVouchingCompleted" "getNotificationEmails-NotifyVouchingCompleted.golden" $
+        fmap renderMail $ getNotificationEmailMocked userWatcher NotifyVouchingCompleted
     , testGolden "Render general notifications in single batched email" "getNotificationEmails-batched.golden" $ do
         emails <-
           getNotificationEmailsMocked . map (userWatcher,) $
@@ -455,6 +457,7 @@ getNotificationEmailsTests =
       NotifyDocsBuild{} -> ()
       NotifyUpdateTags{} -> ()
       NotifyDependencyUpdate{} -> ()
+      NotifyVouchingCompleted{} -> ()
 
     isGeneral = \case
       NotifyNewVersion{} -> True
@@ -463,6 +466,7 @@ getNotificationEmailsTests =
       NotifyDocsBuild{} -> True
       NotifyUpdateTags{} -> True
       NotifyDependencyUpdate{} -> False
+      NotifyVouchingCompleted{} -> True
 
     -- userWatcher = user getting the notification
     -- userActor   = user that did the action
@@ -539,6 +543,7 @@ getNotificationEmailsTests =
             <$> genPackageId
             <*> Gen.list (Range.linear 1 10) genPackageId
             <*> Gen.element [Always, NewIncompatibility, BoundsOutOfRange]
+        , pure NotifyVouchingCompleted
         ]
 
     genPackageName = mkPackageName <$> Gen.string (Range.linear 1 30) Gen.unicode

--- a/tests/VouchTest.hs
+++ b/tests/VouchTest.hs
@@ -1,0 +1,96 @@
+module Main where
+
+import Data.Time (UTCTime(UTCTime), fromGregorian)
+
+import Distribution.Server.Features.Vouch (VouchError(..), VouchSuccess(..), judgeVouch)
+import Distribution.Server.Users.UserIdSet (fromList)
+import Distribution.Server.Users.Types (UserId(UserId))
+
+import Test.Tasty (TestTree, defaultMain, testGroup)
+import Test.Tasty.HUnit (assertEqual, testCase)
+
+allTests :: TestTree
+allTests = testGroup "VouchTest"
+  [ testCase "happy path, vouch added, but more vouches needed" $ do
+      let ref = Right (AddVouchIncomplete 1)
+          voucher = UserId 1
+          vouchee = UserId 2
+      assertEqual "must match" ref $
+        judgeVouch
+          (fromList [voucher]) -- uploaders. Can't vouch if user is not a voucher
+          (UTCTime (fromGregorian 2020 1 1) 0)
+          vouchee
+          [] -- vouchers for voucher. If this short enough, voucher is assumed to be old enough to vouch themselves.
+          [] -- no existing vouchers
+          voucher
+  , testCase "happy path, vouch added, no more vouches needed" $ do
+      let ref = Right AddVouchComplete
+          voucher = UserId 1
+          vouchee = UserId 2
+          otherVoucherForVouchee = UserId 4
+      assertEqual "must match" ref $
+        judgeVouch
+          (fromList [voucher])
+          (UTCTime (fromGregorian 2020 1 1) 0)
+          vouchee
+          []
+          [(otherVoucherForVouchee, UTCTime (fromGregorian 2020 1 1) 0)]
+          voucher
+  , testCase "non-uploader tried to vouch" $ do
+      let ref = Left NotAnUploader
+          voucher = UserId 1
+          vouchee = UserId 2
+      assertEqual "must match" ref $
+        judgeVouch
+          (fromList []) -- empty. Should contain voucher for operation to proceed.
+          (UTCTime (fromGregorian 2020 1 1) 0)
+          vouchee
+          []
+          []
+          voucher
+  , testCase "voucher too new" $ do
+      let ref = Left You'reTooNew
+          voucher = UserId 1
+          vouchee = UserId 2
+          fstVoucherForVoucher = UserId 3
+          sndVoucherForVoucher = UserId 4
+          now = UTCTime (fromGregorian 2020 1 1) 0
+      assertEqual "must match" ref $
+        judgeVouch
+          (fromList [voucher])
+          now
+          vouchee
+          [ (fstVoucherForVoucher, now) -- These two timestamps are too new
+          , (sndVoucherForVoucher, now)
+          ]
+          []
+          voucher
+  , testCase "vouchee already uploader" $ do
+      let ref = Left VoucheeAlreadyUploader
+          voucher = UserId 1
+          vouchee = UserId 2
+          now = UTCTime (fromGregorian 2020 1 1) 0
+      assertEqual "must match" ref $
+        judgeVouch
+          (fromList [voucher, vouchee]) -- vouchee is here. So they're already an uploader.
+          now
+          vouchee
+          []
+          []
+          voucher
+  , testCase "already vouched" $ do
+      let ref = Left YouAlreadyVouched
+          voucher = UserId 1
+          vouchee = UserId 2
+      assertEqual "must match" ref $
+        judgeVouch
+          (fromList [voucher])
+          (UTCTime (fromGregorian 2020 1 1) 0)
+          vouchee
+          []
+          [(voucher, UTCTime (fromGregorian 2020 1 1) 0)] -- voucher is here. So they already vouched
+          voucher
+  ]
+
+main :: IO ()
+main = defaultMain allTests

--- a/tests/golden/ReverseDependenciesTest/getNotificationEmails-NotifyVouchingCompleted.golden
+++ b/tests/golden/ReverseDependenciesTest/getNotificationEmails-NotifyVouchingCompleted.golden
@@ -8,9 +8,9 @@ Content-Type: multipart/alternative; boundary="YIYrWcf3to"
 Content-Type: text/plain; charset=utf-8
 Content-Transfer-Encoding: quoted-printable
 
-You have received all necessary vouches=2E You have been added the the 'upl=
-oaders' group=2E You can now upload packages to Hackage=2E Note that packag=
-es cannot be deleted, so be careful=2E
+You have received all necessary endorsements=2E You have been added the the=
+ 'uploaders' group=2E You can now upload packages to Hackage=2E Note that p=
+ackages cannot be deleted, so be careful=2E
 
 You can adjust your notification preferences at
 https://hackage=2Ehaskell=2Eorg/user/user-watcher/notify (https://hackage=
@@ -23,9 +23,9 @@ Content-Transfer-Encoding: quoted-printable
 
 
 <p>
-You have received all necessary vouches=2E You have been added the the 'upl=
-oaders' group=2E You can now upload packages to Hackage=2E Note that packag=
-es cannot be deleted, so be careful=2E
+You have received all necessary endorsements=2E You have been added the the=
+ 'uploaders' group=2E You can now upload packages to Hackage=2E Note that p=
+ackages cannot be deleted, so be careful=2E
 </p>
 <p>
 You can adjust your notification preferences at

--- a/tests/golden/ReverseDependenciesTest/getNotificationEmails-NotifyVouchingCompleted.golden
+++ b/tests/golden/ReverseDependenciesTest/getNotificationEmails-NotifyVouchingCompleted.golden
@@ -1,0 +1,35 @@
+From: =?utf-8?Q?Hackage_website?= <noreply@hackage.haskell.org>
+To: =?utf-8?Q?user-watcher?= <user-watcher@example.com>
+Subject: [Hackage] Maintainer Notifications
+MIME-Version: 1.0
+Content-Type: multipart/alternative; boundary="YIYrWcf3to"
+
+--YIYrWcf3to
+Content-Type: text/plain; charset=utf-8
+Content-Transfer-Encoding: quoted-printable
+
+You have received all necessary vouches=2E You have been added the the 'upl=
+oaders' group=2E You can now upload packages to Hackage=2E Note that packag=
+es cannot be deleted, so be careful=2E
+
+You can adjust your notification preferences at
+https://hackage=2Ehaskell=2Eorg/user/user-watcher/notify (https://hackage=
+=2Ehaskell=2Eorg/user/user-watcher/notify)
+
+
+--YIYrWcf3to
+Content-Type: text/html; charset=utf-8
+Content-Transfer-Encoding: quoted-printable
+
+
+<p>
+You have received all necessary vouches=2E You have been added the the 'upl=
+oaders' group=2E You can now upload packages to Hackage=2E Note that packag=
+es cannot be deleted, so be careful=2E
+</p>
+<p>
+You can adjust your notification preferences at
+<br /><a href=3D"https://hackage=2Ehaskell=2Eorg/user/user-watcher/notify">=
+https://hackage=2Ehaskell=2Eorg/user/user-watcher/notify</a>
+</p>
+--YIYrWcf3to--


### PR DESCRIPTION
Fixes #1093.

Vouching allows new users to get added to the uploaders group by way of other people "vouching" for then. This should alleviate privileged Hackage users, since they were previously the only people that could add people to the uploaders group.

Tagging @david-christiansen since we discussed this.