### PR TITLE
Allow serving cabal files with package name in the file name.

### DIFF
--- a/datafiles/templates/Html/revisions.html.st
+++ b/datafiles/templates/Html/revisions.html.st
@@ -25,7 +25,7 @@ stored separately.
   </tr>
   $revisions:{revision|
     <tr>
-      <td valign="top"><a href="/package/$pkgid$/revision/$revision.number$.cabal">-r$revision.number$</a></td>
+      <td valign="top"><a href="/package/$pkgid$/revision/$revision.number$.cabal">-r$revision.number$</a> (<a href="/package/$pkgid$/revision/$pkgid$-$revision.number$.cabal">$pkgid$-r$revision.number$</a>)</td>
       <td valign="top">$revision.htmltime$</td>
       <td valign="top"><a href="/user/$revision.user$">$revision.user$</td>
       <td valign="top">$revision.sha256$</th>


### PR DESCRIPTION
Allow serving url like this:
https://hackage.haskell.org/package/pkg-2.6/revision/pkg-2.6-1.cabal

Resolves: https://github.com/haskell/hackage-server/issues/1261 #1261 