### PR TITLE
email template for endorsements complete

### DIFF
--- a/datafiles/templates/UserNotify/endorsements-complete.txt.st
+++ b/datafiles/templates/UserNotify/endorsements-complete.txt.st
@@ -1,0 +1,3 @@
+You have received all necessary endorsements, and have been added the the 'uploaders' group.
+Note that packages cannot be deleted, so be careful.
+

--- a/src/Distribution/Server/Framework/Templating.hs
+++ b/src/Distribution/Server/Framework/Templating.hs
@@ -27,6 +27,7 @@ module Distribution.Server.Framework.Templating (
     utcTimeTemplateVal,
     templateEnumDesriptor,
     templateUnescaped,
+    mockTemplates,
     ToSElem(..),
   ) where
 
@@ -143,6 +144,9 @@ data Templates = TemplatesNormalMode !(IORef RawTemplateGroup)
                | TemplatesDesignMode [FilePath] [String]
 
 data TemplatesMode = NormalMode | DesignMode
+
+mockTemplates :: [FilePath] -> [String] -> Templates
+mockTemplates = TemplatesDesignMode
 
 loadTemplates :: TemplatesMode -> [FilePath] -> [String] -> IO Templates
 loadTemplates templateMode templateDirs expectedTemplates = do

--- a/tests/ReverseDependenciesTest.hs
+++ b/tests/ReverseDependenciesTest.hs
@@ -48,6 +48,7 @@ import Distribution.Server.Framework.MemState (newMemStateWHNF)
 import Distribution.Server.Framework.ServerEnv (ServerEnv(..))
 import Distribution.Server.Packages.PackageIndex as PackageIndex
 import Distribution.Server.Packages.Types (CabalFileText(..), PkgInfo(..))
+import Distribution.Server.Framework.Templating
 import Distribution.Server.Users.Types
   ( PasswdHash(..)
   , UserAuth(..)
@@ -483,7 +484,7 @@ getNotificationEmailsTests =
           <*> addUser "user-subject"
 
     getNotificationEmail env details users uid notif =
-      getNotificationEmails env details users [(uid, notif)] >>= \case
+      getNotificationEmails env details users (mockTemplates ["datafiles/templates/UserNotify"] ["endorsements-complete.txt"]) [(uid, notif)] >>= \case
         [email] -> pure email
         _ -> error "Did not get exactly one email"
 
@@ -509,6 +510,7 @@ getNotificationEmailsTests =
         testServerEnv
         testUserDetailsFeature
         allUsers
+        (mockTemplates ["datafiles/templates/UserNotify"] ["endorsements-complete.txt"])
     getNotificationEmailMocked =
       getNotificationEmail
         testServerEnv

--- a/tests/golden/ReverseDependenciesTest/getNotificationEmails-NotifyVouchingCompleted.golden
+++ b/tests/golden/ReverseDependenciesTest/getNotificationEmails-NotifyVouchingCompleted.golden
@@ -8,9 +8,10 @@ Content-Type: multipart/alternative; boundary="YIYrWcf3to"
 Content-Type: text/plain; charset=utf-8
 Content-Transfer-Encoding: quoted-printable
 
-You have received all necessary endorsements=2E You have been added the the=
- 'uploaders' group=2E You can now upload packages to Hackage=2E Note that p=
-ackages cannot be deleted, so be careful=2E
+You have received all necessary endorsements, and have been added the the '=
+uploaders' group=2E
+Note that packages cannot be deleted, so be careful=2E
+
 
 You can adjust your notification preferences at
 https://hackage=2Ehaskell=2Eorg/user/user-watcher/notify (https://hackage=
@@ -23,9 +24,10 @@ Content-Transfer-Encoding: quoted-printable
 
 
 <p>
-You have received all necessary endorsements=2E You have been added the the=
- 'uploaders' group=2E You can now upload packages to Hackage=2E Note that p=
-ackages cannot be deleted, so be careful=2E
+You have received all necessary endorsements, and have been added the the '=
+uploaders' group=2E
+Note that packages cannot be deleted, so be careful=2E
+
 </p>
 <p>
 You can adjust your notification preferences at


### PR DESCRIPTION
Moves the endorsements complete email content to a template file, so it can be customized more easily.