### PR TITLE
feat: Add support for sublibrary module listings

### DIFF
--- a/datafiles/static/hackage.css
+++ b/datafiles/static/hackage.css
@@ -1146,6 +1146,14 @@ a.deprecated[href]:visited {
     color: #61B01E;
 }
 
+.lib-contents {
+  margin-left: 20px;
+}
+
+.lib-contents > h3 {
+  margin: 0.7em 0;
+}
+
 /* Paginator */
 #paginatorContainer {
   display: flex;

--- a/src/Distribution/Server/Packages/Render.hs
+++ b/src/Distribution/Server/Packages/Render.hs
@@ -1,6 +1,7 @@
 -- TODO: Review and possibly move elsewhere. This code was part of the
 -- RecentPackages (formerly "Check") feature, but that caused some cyclic
 -- dependencies.
+{-# LANGUAGE TupleSections #-}
 module Distribution.Server.Packages.Render (
     -- * Package render
     PackageRender(..)
@@ -53,6 +54,7 @@ import Distribution.Utils.ShortText (fromShortText)
 
 import qualified Data.TarIndex as TarIndex
 import Data.TarIndex (TarIndex, TarEntryOffset)
+import Data.Bifunctor (first, Bifunctor (..))
 
 data ModSigIndex = ModSigIndex {
         modIndex :: ModuleForest,
@@ -64,10 +66,10 @@ data ModSigIndex = ModSigIndex {
 -- This is why some fields of PackageDescription are preprocessed, and others aren't.
 data PackageRender = PackageRender {
     rendPkgId        :: PackageIdentifier,
+    rendLibName      :: LibraryName -> String,
     rendDepends      :: [Dependency],
     rendExecNames    :: [String],
-    rendLibraryDeps  :: Maybe DependencyTree,
-    rendSublibraryDeps :: [(String, DependencyTree)],
+    rendLibraryDeps  :: [(LibraryName, DependencyTree)],
     rendExecutableDeps :: [(String, DependencyTree)],
     rendLicenseName  :: String,
     rendLicenseFiles :: [FilePath],
@@ -78,7 +80,7 @@ data PackageRender = PackageRender {
     -- to test if a module actually has a corresponding documentation HTML
     -- file we can link to.  If no 'TarIndex' is provided, it is assumed
     -- all links are dead.
-    rendModules      :: Maybe TarIndex -> Maybe ModSigIndex,
+    rendModules      :: Maybe TarIndex -> [(LibraryName, ModSigIndex)],
     rendHasTarball   :: Bool,
     rendChangeLog    :: Maybe (FilePath, ETag, TarEntryOffset, FilePath),
     rendReadme       :: Maybe (FilePath, ETag, TarEntryOffset, FilePath),
@@ -95,14 +97,13 @@ data PackageRender = PackageRender {
 
 doPackageRender :: Users.Users -> PkgInfo -> PackageRender
 doPackageRender users info = PackageRender
-    { rendPkgId        = pkgInfoId info
+    { rendPkgId        = packageId'
     , rendDepends      = flatDependencies genDesc
+    , rendLibName      = renderLibName
     , rendExecNames    = map (unUnqualComponentName . exeName) (executables flatDesc)
-    , rendLibraryDeps  = depTree libBuildInfo `fmap` condLibrary genDesc
     , rendExecutableDeps = (unUnqualComponentName *** depTree buildInfo)
                                 `map` condExecutables genDesc
-    , rendSublibraryDeps = (unUnqualComponentName *** depTree libBuildInfo)
-                                `map` condSubLibraries genDesc
+    , rendLibraryDeps = second (depTree libBuildInfo) <$> allCondLibs genDesc
     , rendLicenseName  = prettyShow (license desc) -- maybe make this a bit more human-readable
     , rendLicenseFiles = map getSymbolicPath $ licenseFiles desc
     , rendMaintainer   = case fromShortText $ maintainer desc of
@@ -144,17 +145,15 @@ doPackageRender users info = PackageRender
                                then Buildable
                                else NotBuildable
 
-    renderModules docindex
-      | Just lib <- library flatDesc
-      = let mod_ix = mkForest $ exposedModules lib
+    renderModules :: Maybe TarIndex -> [(LibraryName, ModSigIndex)]
+    renderModules docindex = flip fmap (allLibraries flatDesc) $ \lib ->
+      let mod_ix = mkForest $ exposedModules lib
                            -- Assumes that there is an HTML per reexport
                            ++ map moduleReexportName (reexportedModules lib)
                            ++ virtualModules (libBuildInfo lib)
-            sig_ix = mkForest $ signatures lib
-            mkForest = moduleForest . map (\m -> (m, moduleHasDocs docindex m))
-        in Just (ModSigIndex { modIndex = mod_ix, sigIndex = sig_ix })
-      | otherwise
-      = Nothing
+          sig_ix = mkForest $ signatures lib
+          mkForest = moduleForest . map (\m -> (m, moduleHasDocs docindex m))
+      in (libName lib, ModSigIndex { modIndex = mod_ix, sigIndex = sig_ix })
 
     moduleHasDocs :: Maybe TarIndex -> ModuleName -> Bool
     moduleHasDocs Nothing       = const False
@@ -171,6 +170,21 @@ doPackageRender users info = PackageRender
         ty <- repoType r
         loc <- repoLocation r
         return (ty, loc, r)
+
+    packageId' :: PackageIdentifier
+    packageId' = pkgInfoId info
+
+    packageName' :: String
+    packageName' = unPackageName $ pkgName packageId'
+
+    renderLibName :: LibraryName -> String
+    renderLibName LMainLibName = packageName'
+    renderLibName (LSubLibName name) =
+      packageName' ++ ":" ++ unUnqualComponentName name
+
+allCondLibs :: GenericPackageDescription -> [(LibraryName, CondTree ConfVar [Dependency] Library)]
+allCondLibs desc = maybeToList ((LMainLibName,) <$> condLibrary desc)
+  ++ (first LSubLibName <$> condSubLibraries desc)
 
 type DependencyTree = CondTree ConfVar [Dependency] IsBuildable
 


### PR DESCRIPTION
works on https://github.com/haskell/hackage-server/issues/1218

## Changes:

* Adds a "renderer" for library names
* Uses the library name renderer in the dependency details page
* Add module and signature trees per-library on the package page

I figured it's appropriate to make sure libraries are shown by the same name in the dependency-details page, and on the package page, hence the library name renderer. I also think it's more intuitive to refer to the libraries by the same name that is used to add them as dependencies, rather than just saying `library`, or using just the sublibrary component name.

## Screenshots

Using the unpacked-containers package, as it has sublibraries, and signatures as well as modules

### Before

![Screenshot from 2023-12-30 20-18-28](https://github.com/haskell/hackage-server/assets/1714287/2b50cc4d-bc3e-4aee-aa61-886a177c000f)
![Screenshot from 2023-12-30 19-47-05](https://github.com/haskell/hackage-server/assets/1714287/e2fe34ea-02a3-4a9a-ac42-c76f639e5114)


### After

![Screenshot from 2023-12-30 20-18-20](https://github.com/haskell/hackage-server/assets/1714287/25f16a3f-5892-4bc2-ad3f-3f31539462d3)

![Screenshot from 2023-12-30 19-46-56](https://github.com/haskell/hackage-server/assets/1714287/c5abc4dc-4d28-4fd4-a12d-d191fcbb6fc4)
