### PR TITLE
feat: Specify component types in detailed deps page

### DIFF
--- a/src/Distribution/Server/Features/Html.hs
+++ b/src/Distribution/Server/Features/Html.hs
@@ -1461,7 +1461,7 @@ mkHtmlCandidates ServerEnv{..} utilities@HtmlUtilities{..}
 dependenciesPage :: Bool -> PackageRender -> URL -> Resource.XHtml
 dependenciesPage isCandidate render docURL =
     Resource.XHtml $ hackagePage (pkg ++ ": dependencies") $
-      [h2 << heading, Pages.renderDetailedDependencies render]
+      [h1 << heading, Pages.renderDetailedDependencies render]
        ++ Pages.renderPackageFlags render docURL
   where
     pkg = display $ rendPkgId render


### PR DESCRIPTION
With the advent of multiple sublibraries per
package, it has become less clear what each
component is, on the 'detailed dependencies'
page.

This changeset replaces the tabulated view of

| component name | list of dependencies |
| -------------- | -------------------- |
| - lib 1        | - dep 1              |
|                | - dep 2              |
| - exe 1        | - dep 3              |

With the more heirarchical:

Libraries
  - lib 1
    - dep 1
    - dep 2 ...

Executables
  - exe 1
    - dep 3

This change is related to https://github.com/haskell/hackage-server/issues/1218

---

## Screenshots

### Before

![Screenshot from 2024-01-01 23-04-03](https://github.com/haskell/hackage-server/assets/1714287/ccadea17-9a7a-46d7-b119-45040c57e4b7)


### After

![Screenshot from 2024-01-01 23-01-48](https://github.com/haskell/hackage-server/assets/1714287/88d401ff-1075-4e65-9aa5-00ba6212b255)

Obviously, when there are no components of a given type ({Executables, Libraries}), the header itself is not rendered.