### PR TITLE
feature: add 'reporting vulnerabilities' link on package pages

### DIFF
--- a/datafiles/templates/Html/package-page.html.st
+++ b/datafiles/templates/Html/package-page.html.st
@@ -32,6 +32,7 @@
     <div style="font-size: small">
       [ $tags$ ]
       [ <a href="/package/$package.name$/tags/edit">Propose Tags</a> ]
+      [ <a href="https://github.com/haskell/security-advisories/blob/main/CONTRIBUTING.md">Report a vulnerability</a> ]
     </div>
 
     $if(isDeprecated)$


### PR DESCRIPTION
It's the implementation of [haskell/security-advisories#7](https://github.com/haskell/security-advisories/issues/7)

It looks like this:

![image](https://github.com/haskell/hackage-server/assets/1362807/817baced-598c-4e97-ab0d-7751b3151e16)
