### PR TITLE
note in cabal file about DocTests

### DIFF
--- a/hackage-server.cabal
+++ b/hackage-server.cabal
@@ -680,6 +680,10 @@ test-suite HashTests
     , tasty       ^>= 1.5
     , tasty-hunit ^>= 0.10
 
+-- DocTests require `write-ghc-environment=always`
+-- https://github.com/haskell/hackage-server/issues/1197
+--   cabal build --write-ghc-environment-files=always
+--   cabal test DocTests --write-ghc-environment=always
 test-suite DocTests
   import:         test-defaults
 


### PR DESCRIPTION
https://github.com/haskell/hackage-server/issues/1197

I know this is `cabal.project`, but I don't think that takes effect for some reason.