### PR TITLE
Add Tested-With to package page

### DIFF
--- a/datafiles/templates/Html/package-page.html.st
+++ b/datafiles/templates/Html/package-page.html.st
@@ -140,6 +140,15 @@
               <td>$package.buildDepends$</td>
             </tr>
 
+            $if(package.optional.hasTestedWith)$
+            <tr>
+              <th>Tested with</th>
+              <td class="word-wrap">
+                $package.optional.testedWith$
+              </td>
+            </tr>
+            $endif$
+
             <tr>
               <th>License</th>
               <td class="word-wrap">$package.license$</td>

--- a/src/Distribution/Server/Pages/PackageFromTemplate.hs
+++ b/src/Distribution/Server/Pages/PackageFromTemplate.hs
@@ -33,7 +33,7 @@ import Text.XHtml.Strict hiding (p, name, title, content)
 import qualified Text.XHtml.Strict as XHtml
 
 import Data.Maybe               (maybeToList, fromMaybe, isJust)
-import Data.List                (intersperse)
+import Data.List                (intercalate, intersperse)
 import System.FilePath.Posix    ((</>), takeFileName, dropTrailingPathSeparator)
 import Data.Time.Format         (defaultTimeLocale, formatTime)
 
@@ -228,6 +228,12 @@ packagePageTemplate render
           (vList $ map sourceRepositoryToHtml (sourceRepos desc))
       ] ++
 
+      [ templateVal "hasTestedWith"
+          (not $ null pkgTestedWith)
+      , templateVal "testedWith"
+          (intercalate ", " pkgTestedWith)
+      ] ++
+
       [ templateVal "hasSynopsis"
           (not . Short.null $ synopsis (rendOther render))
       , templateVal "synopsis"
@@ -238,6 +244,10 @@ packagePageTemplate render
     pkgid   = rendPkgId render
     pkgVer  = display $ pkgVersion pkgid
     pkgName = display $ packageName pkgid
+    pkgTestedWith =
+      [ display compilerFlavor ++ " " ++ display versionRange
+      | (compilerFlavor, versionRange) <- testedWith desc
+      ]
 
     desc = rendOther render
 


### PR DESCRIPTION
Is this what you wanted @telser ?

Preview with smtp-mail:

![smtp-mail side pane](https://github.com/haskell/hackage-server/assets/284023/e6f91ea0-a406-4855-854b-2f7d23df9fdc)
