### PR TITLE
Cabal 3.12

### DIFF
--- a/.github/workflows/haskell-ci.yml
+++ b/.github/workflows/haskell-ci.yml
@@ -8,9 +8,9 @@
 #
 # For more information, see https://github.com/andreasabel/haskell-ci
 #
-# version: 0.17.20231012
+# version: 0.19.20240630
 #
-# REGENDATA ("0.17.20231012",["github","hackage-server.cabal"])
+# REGENDATA ("0.19.20240630",["github","hackage-server.cabal"])
 #
 name: Haskell-CI
 on:
@@ -32,19 +32,24 @@ jobs:
     strategy:
       matrix:
         include:
-          - compiler: ghc-9.8.1
+          - compiler: ghc-9.10.1
             compilerKind: ghc
-            compilerVersion: 9.8.1
+            compilerVersion: 9.10.1
             setup-method: ghcup
             allow-failure: false
-          - compiler: ghc-9.6.3
+          - compiler: ghc-9.8.2
             compilerKind: ghc
-            compilerVersion: 9.6.3
+            compilerVersion: 9.8.2
             setup-method: ghcup
             allow-failure: false
-          - compiler: ghc-9.4.7
+          - compiler: ghc-9.6.5
             compilerKind: ghc
-            compilerVersion: 9.4.7
+            compilerVersion: 9.6.5
+            setup-method: ghcup
+            allow-failure: false
+          - compiler: ghc-9.4.8
+            compilerKind: ghc
+            compilerVersion: 9.4.8
             setup-method: ghcup
             allow-failure: false
           - compiler: ghc-9.2.8
@@ -74,11 +79,10 @@ jobs:
           apt-get update
           apt-get install -y --no-install-recommends gnupg ca-certificates dirmngr curl git software-properties-common libtinfo5
           mkdir -p "$HOME/.ghcup/bin"
-          curl -sL https://downloads.haskell.org/ghcup/0.1.19.5/x86_64-linux-ghcup-0.1.19.5 > "$HOME/.ghcup/bin/ghcup"
+          curl -sL https://downloads.haskell.org/ghcup/0.1.20.0/x86_64-linux-ghcup-0.1.20.0 > "$HOME/.ghcup/bin/ghcup"
           chmod a+x "$HOME/.ghcup/bin/ghcup"
-          "$HOME/.ghcup/bin/ghcup" config add-release-channel https://raw.githubusercontent.com/haskell/ghcup-metadata/master/ghcup-prereleases-0.0.7.yaml;
           "$HOME/.ghcup/bin/ghcup" install ghc "$HCVER" || (cat "$HOME"/.ghcup/logs/*.* && false)
-          "$HOME/.ghcup/bin/ghcup" install cabal 3.10.1.0 || (cat "$HOME"/.ghcup/logs/*.* && false)
+          "$HOME/.ghcup/bin/ghcup" install cabal 3.12.1.0 || (cat "$HOME"/.ghcup/logs/*.* && false)
           apt-get update
           apt-get install -y libbrotli-dev libgd-dev
         env:
@@ -98,7 +102,7 @@ jobs:
           echo "HC=$HC" >> "$GITHUB_ENV"
           echo "HCPKG=$HCPKG" >> "$GITHUB_ENV"
           echo "HADDOCK=$HADDOCK" >> "$GITHUB_ENV"
-          echo "CABAL=$HOME/.ghcup/bin/cabal-3.10.1.0 -vnormal+nowrap" >> "$GITHUB_ENV"
+          echo "CABAL=$HOME/.ghcup/bin/cabal-3.12.1.0 -vnormal+nowrap" >> "$GITHUB_ENV"
           HCNUMVER=$(${HC} --numeric-version|perl -ne '/^(\d+)\.(\d+)\.(\d+)(\.(\d+))?$/; print(10000 * $1 + 100 * $2 + ($3 == 0 ? $5 != 1 : $3))')
           echo "HCNUMVER=$HCNUMVER" >> "$GITHUB_ENV"
           echo "ARG_TESTS=--enable-tests" >> "$GITHUB_ENV"
@@ -183,7 +187,7 @@ jobs:
           echo "    ghc-options: -Werror=missing-methods" >> cabal.project
           cat >> cabal.project <<EOF
           EOF
-          $HCPKG list --simple-output --names-only | perl -ne 'for (split /\s+/) { print "constraints: $_ installed\n" unless /^(Cabal|Cabal-syntax|hackage-server|parsec|process|text)$/; }' >> cabal.project.local
+          $HCPKG list --simple-output --names-only | perl -ne 'for (split /\s+/) { print "constraints: any.$_ installed\n" unless /^(Cabal|Cabal-syntax|hackage-server|parsec|process|text)$/; }' >> cabal.project.local
           cat cabal.project
           cat cabal.project.local
       - name: dump install plan

--- a/cabal.project
+++ b/cabal.project
@@ -6,15 +6,6 @@ packages:
 
 -- This project config requires cabal 2.4 or later
 
--- If in doubt, use GHC 8.8 to build hackage-server; see
--- 'tested-with' in 'hackage-server.cabal' for a list of currently
--- CI-validated GHC versions
---
--- with-compiler: ghc-8.8
-
-         
-allow-newer: rss:time, rss:base
-
 -----------------------------------------------------------------------------
 -- Anti-constraints
 

--- a/hackage-server.cabal
+++ b/hackage-server.cabal
@@ -149,8 +149,8 @@ common defaults
   -- other dependencies shared by most components
   build-depends:
     , aeson                  >= 2.1.0.0 && < 2.3
-    , Cabal                  >= 3.10.1.0 && < 3.14
-    , Cabal-syntax           >= 3.10.1.0 && < 3.14
+    , Cabal                  >= 3.12.1.0 && < 3.14
+    , Cabal-syntax           >= 3.12.1.0 && < 3.14
         -- Cabal-syntax needs to be bound to constrain hackage-security
         -- see https://github.com/haskell/hackage-server/issues/1130
     , fail                  ^>= 4.9.0

--- a/hackage-server.cabal
+++ b/hackage-server.cabal
@@ -28,9 +28,10 @@ license:      BSD-3-Clause
 license-file: LICENSE
 
 tested-with:
-  GHC == 9.8.1
-  GHC == 9.6.3
-  GHC == 9.4.7
+  GHC == 9.10.1
+  GHC == 9.8.2
+  GHC == 9.6.5
+  GHC == 9.4.8
   GHC == 9.2.8
   GHC == 9.0.2
   GHC == 8.10.7
@@ -129,13 +130,13 @@ common defaults
   -- see `cabal.project.local-ghc-${VERSION}` files
   build-depends:
     , array                  >= 0.5   && < 0.6
-    , base                   >= 4.13  && < 4.20
+    , base                   >= 4.13  && < 4.21
     , binary                 >= 0.8   && < 0.9
     , bytestring             >= 0.10  && < 0.13
     , containers             >= 0.6.0 && < 0.8
     , deepseq                >= 1.4   && < 1.6
     , directory              >= 1.3   && < 1.4
-    , filepath               >= 1.4   && < 1.5
+    , filepath               >= 1.4   && < 1.6
     , mtl                    >= 2.2.1 && < 2.4
         -- we use Control.Monad.Except, introduced in mtl-2.2.1
     , pretty                 >= 1.1   && < 1.2
@@ -148,19 +149,19 @@ common defaults
   -- other dependencies shared by most components
   build-depends:
     , aeson                  >= 2.1.0.0 && < 2.3
-    , Cabal                  >= 3.10.1.0 && < 3.12
-    , Cabal-syntax           >= 3.10.1.0 && < 3.12
+    , Cabal                  >= 3.10.1.0 && < 3.14
+    , Cabal-syntax           >= 3.10.1.0 && < 3.14
         -- Cabal-syntax needs to be bound to constrain hackage-security
         -- see https://github.com/haskell/hackage-server/issues/1130
     , fail                  ^>= 4.9.0
-    , network                >= 3 && < 3.2
+    , network                >= 3 && < 3.3
     , network-bsd           ^>= 2.8
     , network-uri           ^>= 2.6
     , parsec                ^>= 3.1.13
     , tar                   ^>= 0.6
     , unordered-containers  ^>= 0.2.10
     , vector                ^>= 0.12 || ^>= 0.13.0.0
-    , zlib                  ^>= 0.6.2
+    , zlib                  ^>= 0.6.2  || ^>= 0.7.0.0
 
   ghc-options:
     -funbox-strict-fields
@@ -170,6 +171,7 @@ common defaults
   if impl(ghc >= 8.10)
     ghc-options: -Wno-unused-record-wildcards
 
+  default-extensions: LambdaCase, TupleSections
   other-extensions: CPP, TemplateHaskell
 
 
@@ -407,7 +409,7 @@ library
   build-depends:
     , HStringTemplate       ^>= 0.8
     , HTTP                  ^>= 4000.3.16 || ^>= 4000.4.1
-    , QuickCheck            ^>= 2.14
+    , QuickCheck             >= 2.14      && < 2.16
     , acid-state            ^>= 0.16
     , async                 ^>= 2.2.1
     -- requires bumping http-io-streams
@@ -438,7 +440,7 @@ library
     , haddock-library       ^>= 1.11.0
         -- haddock-library-1.11.0 changed type of markupOrderedList
         -- see https://github.com/haskell/hackage-server/issues/1128
-    , happstack-server      ^>= 7.7.1     || ^>= 7.8.0
+    , happstack-server      ^>= 7.7.1     || ^>= 7.8.0  || ^>= 7.9.0
     , hashable              ^>= 1.3       || ^>= 1.4
     , hs-captcha            ^>= 1.0
     , hslogger              ^>= 1.3.1
@@ -452,7 +454,7 @@ library
     , stm                   ^>= 2.5.0
     , stringsearch          ^>= 0.3.6.6
     , tagged                ^>= 0.8.5
-    , xhtml                 ^>= 3000.2.0.0
+    , xhtml                  >= 3000.2.0.0 && < 3000.4
     , xmlgen                ^>= 0.6
     , xss-sanitize          ^>= 0.3.6
 
@@ -611,6 +613,9 @@ benchmark RevDeps
   build-depends:
     , random       ^>= 1.2
     , gauge
+  -- gauge does not support base-4.20
+  if impl(ghc >= 9.10)
+    buildable: False
   ghc-options: -with-rtsopts=-s
   other-modules: RevDepCommon
 

--- a/hackage-server.cabal
+++ b/hackage-server.cabal
@@ -173,7 +173,7 @@ common defaults
   other-extensions: CPP, TemplateHaskell
 
 
-library lib-server
+library
   import: defaults
   hs-source-dirs:   src
 
@@ -472,7 +472,7 @@ library lib-server
 common exe-defaults
   import: defaults
 
-  build-depends: lib-server
+  build-depends: hackage-server
   hs-source-dirs: exes
   ghc-options: -threaded -rtsopts
 
@@ -493,7 +493,7 @@ executable hackage-mirror
   main-is: MirrorClient.hs
 
   build-depends:
-    -- version constraints inherited from lib-server
+    -- version constraints inherited from hackage-server
     , HTTP
     , hackage-security
 
@@ -503,7 +503,7 @@ executable hackage-build
   main-is: BuildClient.hs
 
   build-depends:
-    -- version constraints inherited from lib-server
+    -- version constraints inherited from hackage-server
     , HTTP
 
   -- Runtime dependency only;
@@ -523,7 +523,7 @@ executable hackage-import
   main-is: ImportClient.hs
 
   build-depends:
-      -- version constraints inherited from lib-server
+      -- version constraints inherited from hackage-server
     , HTTP
     , async
     , csv
@@ -533,7 +533,7 @@ executable hackage-import
 common test-defaults
   import: defaults
 
-  build-depends: lib-server
+  build-depends: hackage-server
   hs-source-dirs: tests
   ghc-options: -threaded -rtsopts -fno-warn-orphans
 
@@ -563,9 +563,9 @@ test-suite HighLevelTest
   -- so if this works, it's accidental!
   build-tool-depends: hackage-server:hackage-server
 
-  -- NOTE: lib-server is not a real dependency; it's only used to inherit version constraints
+  -- NOTE: hackage-server is not a real dependency; it's only used to inherit version constraints
   build-depends:
-    -- version constraints inherited from lib-server
+    -- version constraints inherited from hackage-server
     , HTTP
     , attoparsec-aeson >= 2.1.0.0 && < 2.3
     , base64-bytestring
@@ -640,9 +640,9 @@ test-suite CreateUserTest
   -- see note in 'Test-Suite HighLevelTest'
   build-tool-depends: hackage-server:hackage-server
 
-  -- NOTE: lib-server is not a real dependency; it's only used to inherit version constraints
+  -- NOTE: hackage-server is not a real dependency; it's only used to inherit version constraints
   build-depends:
-    -- version constraints inherited from lib-server
+    -- version constraints inherited from hackage-server
     , HTTP
     , base64-bytestring
     , random
@@ -657,7 +657,7 @@ test-suite PackageTests
   other-modules:  Distribution.Server.Packages.UnpackTest
 
   build-depends:
-    -- version constraints inherited from lib-server
+    -- version constraints inherited from hackage-server
     -- component-specific dependencies
     , tasty        ^>= 1.5
     , tasty-hunit  ^>= 0.10
@@ -670,7 +670,7 @@ test-suite HashTests
   main-is:        HashTestMain.hs
 
   build-depends:
-    -- version constraints inherited from lib-server
+    -- version constraints inherited from hackage-server
     , base16-bytestring
     , cereal
     , cryptohash-md5
@@ -686,7 +686,7 @@ test-suite DocTests
   type:           exitcode-stdio-1.0
   main-is:        DocTestMain.hs
   build-depends:
-    , lib-server
+    , hackage-server
     , doctest-parallel ^>= 0.3.0
         -- doctest-parallel-0.2.2 is the first to filter out autogen-modules
 

--- a/hackage-server.cabal
+++ b/hackage-server.cabal
@@ -162,10 +162,10 @@ common defaults
     , vector                ^>= 0.12 || ^>= 0.13.0.0
     , zlib                  ^>= 0.6.2
 
-  ghc-options: -Wall -fwarn-tabs -fno-warn-unused-do-bind -fno-warn-deprecated-flags -funbox-strict-fields
-
-  if impl(ghc >= 8.2)
-    ghc-options: -Werror=incomplete-patterns -Werror=missing-methods
+  ghc-options:
+    -funbox-strict-fields
+    -Wall -fwarn-tabs -fno-warn-unused-do-bind -fno-warn-deprecated-flags
+    -Werror=incomplete-patterns -Werror=missing-methods
 
   if impl(ghc >= 8.10)
     ghc-options: -Wno-unused-record-wildcards

--- a/src/Distribution/Server/Packages/Unpack.hs
+++ b/src/Distribution/Server/Packages/Unpack.hs
@@ -292,9 +292,17 @@ extraChecks :: GenericPackageDescription
             -> UploadMonad ()
 extraChecks genPkgDesc pkgId tarIndex = do
   let pkgDesc = flattenPackageDescription genPkgDesc
-  fileChecks <- checkPackageContent (tarOps pkgId tarIndex) pkgDesc
-
-  let pureChecks = checkPackage genPkgDesc (Just pkgDesc)
+  fileChecks <- checkPackageContent (tarOps pkgId tarIndex)
+-- The API change of checkPackage happened somewhere between 3.10 and 3.12.
+#if !MIN_VERSION_Cabal(3,12,0)
+                  pkgDesc
+#else
+                  genPkgDesc
+#endif
+  let pureChecks = checkPackage genPkgDesc
+#if !MIN_VERSION_Cabal(3,12,0)
+                     (Just pkgDesc)
+#endif
       checks = pureChecks ++ fileChecks
       isDistError (PackageDistSuspicious     {}) = False -- just a warning
       isDistError (PackageDistSuspiciousWarn {}) = False -- just a warning

--- a/src/Distribution/Server/Util/CabalRevisions.hs
+++ b/src/Distribution/Server/Util/CabalRevisions.hs
@@ -178,12 +178,19 @@ checkCabalFileRevision checkXRevision old new = do
 
     checkPackageChecks :: Check GenericPackageDescription
     checkPackageChecks pkg pkg' =
-      let checks  = checkPackage pkg  Nothing
-          checks' = filter notUpperBounds $ checkPackage pkg' Nothing
+      let checks  = checkPackage pkg
+-- The API change of checkPackage happened somewhere between 3.10 and 3.12.
+#if !MIN_VERSION_Cabal(3,12,0)
+                      Nothing
+#endif
+          checks' = filter notUpperBounds $ checkPackage pkg'
+#if !MIN_VERSION_Cabal(3,12,0)
+                      Nothing
+#endif
           -- if multiple upper bounds are missing, then the simple set subtraction might detect a change to
           -- just one, and fail. Ideally we'd perform a set subtraction directly on just the missing bounds
           -- warning contents. A simple second best is to discard this check for now.
-          notUpperBounds (PackageDistSuspiciousWarn (MissingUpperBounds _)) = False
+          notUpperBounds (PackageDistSuspiciousWarn MissingUpperBounds{}) = False
           notUpperBounds _ = True
        in case checks' \\ checks of
             []        -> return ()

--- a/tests/DocTestMain.hs
+++ b/tests/DocTestMain.hs
@@ -14,5 +14,5 @@ main = do
   args <- getArgs
   pkg  <- findCabalPackage "hackage-server"
   -- Need to give the library name, otherwise the parser does not find it.
-  lib  <- extractSpecificCabalLibrary (Just "lib-server") pkg
+  lib  <- extractSpecificCabalLibrary Nothing pkg
   mainFromLibrary lib args


### PR DESCRIPTION
This PR does the minimum changes needed for `Cabal-3.12` (and some cleanup work).

Subsumes:
- #1137

Commits:
- **Clean cabal.project**: remove some cruft
- **Default library (hackage-server) instead of internal library lib-server**: the introduction of a internal library 7 years ago never got anywhere, and internal libs still cause problems with some tooling
- **.cabal: remove outdated conditional**: remove some cruft
- **Tags feature: replace some clumsy code**: a drive-by shooting; couldn't look past this contrived and inefficient piece of code when I ran into it
- **Support Cabal-3.12 and GHC 9.10**: main commit, introducing `#if`s and the necessary code to work with latest `Cabal(-syntax)`.  Passes CI.
- **Commit to Cabal-3.12.1.0**: bump the lower bound of `Cabal(-syntax)` to latest; breaks the nix CI

I had to disable the reverse dependencies benchmark because `gauge` does not support `base-4.20` and there is no maintainer for this package dropped by @vincenth in sight.  @ysangkok, consider switiching to `criterion` or related.

Eventually we can remove all the `#if MIN_VERSION_Cabal` conditionals, but there is no rush now (they have been CI tested).
