### PR TITLE
Detailed doc string on /package/{name}.json

### DIFF
--- a/src/Distribution/Server/Features/PackageInfoJSON.hs
+++ b/src/Distribution/Server/Features/PackageInfoJSON.hs
@@ -85,7 +85,9 @@ initPackageInfoJSONFeature env = do
   return $ \core preferred -> do
 
     let coreR = coreResource core
-        info = "Get basic package information"
+        info = "Get basic package information: \
+               \The response contains a JSON object where the keys are version numbers as strings, \
+               \and the values are whether the version is preferred or not"
         vInfo = "Get basic package information at a specific metadata revision"
 
         jsonResources = [


### PR DESCRIPTION
I want to make the Renovate pull version information from Hackage. It would be
nice to use this endpoint, and have Hackage commit to the API having a certain
structure; which it could do by documenting the response body.
