### PR TITLE
Add Syntax highglighting for package pages

### DIFF
--- a/datafiles/static/hackage.css
+++ b/datafiles/static/hackage.css
@@ -147,6 +147,10 @@ table {
   font:100%;
 }
 
+pre {
+  border-radius: 3px;
+}
+
 pre, code, kbd, samp, .src {
   font-family: monospace;
 }

--- a/datafiles/templates/Html/package-page.html.st
+++ b/datafiles/templates/Html/package-page.html.st
@@ -5,6 +5,8 @@
   <link href="$doc.baseUrl$/quick-jump.css" rel="stylesheet" type="text/css" title="QuickJump" />
   $endif$
   $hackageCssTheme()$
+  <link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/prismjs@1.29.0/themes/prism-solarizedlight.min.css" media="(prefers-color-scheme: light)" />
+  <link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/prismjs@1.29.0/themes/prism-tomorrow.min.css" media="(prefers-color-scheme: dark)" />
   <title>
     $package.name$$if(package.optional.hasSynopsis)$: $package.optional.synopsis$$endif$
   </title>
@@ -293,6 +295,8 @@
       [<a href="#description">back to package description</a>]
       $package.optional.readme$
     </div>
+    <script src="https://cdn.jsdelivr.net/npm/prismjs@v1.29.0/components/prism-core.min.js"></script>
+    <script src="https://cdn.jsdelivr.net/npm/prismjs@v1.29.0/plugins/autoloader/prism-autoloader.min.js"></script>
     $endif$
   </div> <!-- /content -->
 

--- a/flake.nix
+++ b/flake.nix
@@ -37,7 +37,7 @@
             echo 'Copying packages from real Hackage Server into local Hackage Server.'
             echo 'This assumes the local Hackage Server uses default credentials;'
             echo 'otherwise, override in nix-default-servers.cfg'
-            hackage-mirror nix-default-servers.cfg
+            hackage-mirror nix-default-servers.cfg "$@"
           '';
         };
         packages.default = config.packages.hackage-server;


### PR DESCRIPTION
Use [prism.js](https://prismjs.com/) to add syntax highlighting to package pages.

Justification: 
- makes landing pages much more readable
- jdelivr CDN is already in use
- prism.js isn't big
- languages are automatically loaded as needed