### PR TITLE
fix expected content-types for documentation tarballs

### DIFF
--- a/src/Distribution/Server/Framework/RequestContentTypes.hs
+++ b/src/Distribution/Server/Framework/RequestContentTypes.hs
@@ -19,7 +19,6 @@ module Distribution.Server.Framework.RequestContentTypes (
 
     -- * various specific content types
     expectTextPlain,
-    expectUncompressedTarball,
     expectCompressedTarball,
     expectAesonContent,
     expectCSV,
@@ -102,15 +101,6 @@ gzipDecompress content = go content decompressor
 expectTextPlain :: ServerPartE LBS.ByteString
 expectTextPlain = expectContentType "text/plain"
 
--- | Expect an uncompressed @.tar@ file.
---
--- The tar file is not validated.
---
--- A content-encoding of \"gzip\" is handled transparently.
---
-expectUncompressedTarball :: ServerPartE LBS.ByteString
-expectUncompressedTarball = expectContentType "application/x-tar"
-
 -- | Expect a compressed @.tar.gz@ file.
 --
 -- Neither the gzip encoding nor the tar format are validated.
@@ -128,7 +118,7 @@ expectCompressedTarball = do
       Just actual
         | actual == "application/x-tar"
         , contentEncoding == Just "gzip" -> consumeRequestBody
-        | actual == "application/x-gzip"
+        | actual == "application/gzip" || actual == "application/x-gzip" 
         , contentEncoding == Nothing     -> consumeRequestBody
       _                                  -> errExpectedTarball
   where


### PR DESCRIPTION
Fixes #1269

- documentation tarballs produced by cabal haddock are compressed
- their mimetype is application/gzip
- keeps the applicatoin/x-tar and applicatoin/x-gzip even though there is no tar mimetype and there's now (since 2014) a gzip mimetype, according to RFC6713
- remove the expectUncompressedTarball function as it is now dead code
- remove a pair of redundant paren and replace infix `liftM` with <$>