### PR TITLE
Add uploader's username to package json API

### DIFF
--- a/src/Distribution/Server/Features.hs
+++ b/src/Distribution/Server/Features.hs
@@ -379,6 +379,7 @@ initHackageFeatures env@ServerEnv{serverVerbosity = verbosity} = do
     packageInfoJSONFeature <- mkPackageJSONFeature
                                 coreFeature
                                 versionsFeature
+                                usersFeature
 
 #endif
 

--- a/src/Distribution/Server/Users/Types.hs
+++ b/src/Distribution/Server/Users/Types.hs
@@ -1,5 +1,6 @@
 {-# LANGUAGE DeriveDataTypeable, GeneralizedNewtypeDeriving, TemplateHaskell #-}
 {-# LANGUAGE TypeFamilies #-}
+{-# LANGUAGE DerivingStrategies #-}
 module Distribution.Server.Users.Types (
     module Distribution.Server.Users.Types,
     module Distribution.Server.Users.AuthToken,
@@ -26,13 +27,14 @@ import Data.Aeson (ToJSON, FromJSON)
 import Data.SafeCopy (base, extension, deriveSafeCopy, Migrate(..))
 import Data.Typeable (Typeable)
 import Data.Hashable
+import Data.Serialize (Serialize)
 
 
 newtype UserId = UserId Int
-  deriving (Eq, Ord, Read, Show, Typeable, MemSize, ToJSON, FromJSON, Pretty)
+  deriving newtype (Eq, Ord, Read, Show, Typeable, MemSize, ToJSON, FromJSON, Pretty)
 
 newtype UserName  = UserName String
-  deriving (Eq, Ord, Read, Show, Typeable, MemSize, ToJSON, FromJSON, Hashable)
+  deriving newtype (Eq, Ord, Read, Show, Typeable, MemSize, ToJSON, FromJSON, Hashable, Serialize)
 
 data UserInfo = UserInfo {
                   userName   :: !UserName,


### PR DESCRIPTION
This gives the following payload:

```diff
{
    "author": "qwbarch",
    "copyright": "2021 qwbarch",
    "description": "Haskell package for easy integration with the 2captcha API.\n\nFeature list:\n\n* Lens-based API\n* Uses Wreq for http calls",
    "homepage": "https://github.com/qwbarch/2captcha-haskell#readme",
    "license": "MIT",
    "metadata_revision": 0,
    "synopsis": "Haskell package for easy integration with the 2captcha API.",
    "uploaded_at": "2022-09-24T05:49:45Z",
+    "uploader": "admin"
}
```