### PR TITLE
Update suggested licences

### DIFF
--- a/datafiles/templates/UserSignupReset/SignupRequest.html.st
+++ b/datafiles/templates/UserSignupReset/SignupRequest.html.st
@@ -89,7 +89,7 @@ operate the service in compliance with copyright laws.</p>
 on what is and is not a valid open source license, but we retain the right to
 remove packages that are not under licenses that are open source in spirit, or
 that conflict with our ability to operate this service. (If you want advice,
-see the ones <a href="/package/Cabal/docs/Distribution-License.html">Cabal
+see the ones <a href="/package/Cabal-syntax/docs/Distribution-License.html">Cabal
 recommends</a>.)</p>
 
 <p>The Hackage operators do <em>not</em> need and are <em>not</em> asking for

--- a/datafiles/templates/upload.html.st
+++ b/datafiles/templates/upload.html.st
@@ -96,7 +96,7 @@ operate the service in compliance with copyright laws.</p>
 on what is and is not a valid open source license, but we retain the right to
 remove packages that are not under licenses that are open source in spirit, or
 that conflict with our ability to operate this service. (If you want advice,
-see the ones <a href="/package/Cabal/docs/Distribution-License.html">Cabal
+see the ones <a href="/package/Cabal-syntax/docs/Distribution-License.html">Cabal
 recommends</a>.)</p>
 
 <p>The Hackage operators do <em>not</em> need and are <em>not</em> asking for


### PR DESCRIPTION
Point to `Cabal-syntax`.

See Deepak [reporting the issue](https://discourse.haskell.org/t/outdated-link-to-licenses-in-the-hackage-upload-guide/12066/2).