### PR TITLE
divide Nix Flake GitHub Action into smaller jobs

### DIFF
--- a/.github/workflows/nix-flake.yml
+++ b/.github/workflows/nix-flake.yml
@@ -7,7 +7,7 @@ on:
     branches:
       - master
 jobs:
-  nix:
+  nix-develop-shell:
     strategy:
       fail-fast: false
       matrix:
@@ -35,6 +35,29 @@ jobs:
 
     - name: "Check `nix develop` shell can run command"
       run: nix develop --command "echo"
+
+  nix-build:
+    strategy:
+      fail-fast: false
+      matrix:
+        os:
+        - ubuntu-latest
+        - ubuntu-24.04-arm
+        - macos-latest
+    name: Nix on ${{ matrix.os }}
+    runs-on: ${{ matrix.os }}
+    steps:
+    - uses: actions/checkout@v4
+    - uses: cachix/install-nix-action@v31
+      with:
+        extra_nix_config: |
+          trusted-public-keys = cache.nixos.org-1:6NCHdD59X431o0gWypbMrAURkbJ16ZPMQFGspcDShjY= hackage-server.cachix.org-1:iw0iRh6+gsFIrxROFaAt5gKNgIHejKjIfyRdbpPYevY=
+          substituters = https://cache.nixos.org/ https://hackage-server.cachix.org/
+    - uses: cachix/cachix-action@v16
+      with:
+        # https://nix.dev/tutorials/continuous-integration-github-actions#setting-up-github-actions
+        name: hackage-server
+        authToken: '${{ secrets.CACHIX_AUTH_TOKEN }}'
 
     - run: nix build
 


### PR DESCRIPTION
* one job for `nix develop` and related
* one job for building Hackage binary with `nix build`

to avoid GitHub Action resource limit