### PR TITLE
BuildReports: Add test report log

### DIFF
--- a/datafiles/templates/Html/report.html.st
+++ b/datafiles/templates/Html/report.html.st
@@ -110,6 +110,14 @@ $else$
 <p>No test log was submitted for this report.</p>
 $endif$
 
+<h3>Test report log</h3>
+
+$if(test)$
+<pre>
+$testReport$</pre>
+$else$
+<p>No test report log was submitted for this report.</p>
+$endif$
 
 </div>
 </body></html>

--- a/datafiles/templates/Html/report.html.st
+++ b/datafiles/templates/Html/report.html.st
@@ -112,7 +112,7 @@ $endif$
 
 <h3>Test report log</h3>
 
-$if(test)$
+$if(testReport)$
 <pre>
 $testReport$</pre>
 $else$

--- a/exes/BuildClient.hs
+++ b/exes/BuildClient.hs
@@ -590,9 +590,10 @@ processPkg verbosity opts config docInfo = do
     let installOk = fmap ("install-outcome: InstallOk" `isInfixOf`) buildReport == Just True
 
     -- Run Tests if installOk, Run coverage is Tests runs
-    (testOutcome, hpcLoc, testfile)   <- case installOk && docInfoRunTests docInfo of
+    (testOutcome, hpcLoc, testfile, testReportFile) <-
+      case installOk && docInfoRunTests docInfo of
       True  -> testPackage verbosity opts docInfo
-      False -> return (Nothing, Nothing, Nothing)
+      False -> return (Nothing, Nothing, Nothing, Nothing)
     coverageFile <- mapM (coveragePackage verbosity opts docInfo) hpcLoc
 
     -- Modify test-outcome and rewrite report file.
@@ -601,7 +602,8 @@ processPkg verbosity opts config docInfo = do
     case bo_dryRun opts of
       True -> return ()
       False -> uploadResults verbosity config docInfo
-                                    mTgz mRpt logfile testfile coverageFile installOk
+                                    mTgz mRpt logfile testfile coverageFile
+                                    testReportFile installOk
   where
     prepareTempBuildDir :: IO ()
     prepareTempBuildDir = do
@@ -651,7 +653,7 @@ coveragePackage verbosity opts docInfo loc = do
   return coverageFile
 
 
-testPackage :: Verbosity -> BuildOpts -> DocInfo -> IO (Maybe String, Maybe FilePath, Maybe FilePath)
+testPackage :: Verbosity -> BuildOpts -> DocInfo -> IO (Maybe String, Maybe FilePath, Maybe FilePath, Maybe FilePath)
 testPackage verbosity opts docInfo = do
   let pkgid = docInfoPackage docInfo
       testLogFile = (installDirectory opts) </> display pkgid <.> "test"
@@ -684,7 +686,7 @@ testPackage verbosity opts docInfo = do
       [ "Test results for " ++ display pkgid ++ ":"
       , testResultFile
       ]
-  return (testOutcome, hpcLoc, Just testResultFile)
+  return (testOutcome, hpcLoc, Just testResultFile, Just testReportFile)
 
 
 -- | Build documentation and return @(Just tgz)@ for the built tgz file
@@ -876,16 +878,19 @@ tarGzDirectory dir = do
   where (containing_dir, nested_dir) = splitFileName dir
 
 uploadResults :: Verbosity -> BuildConfig -> DocInfo -> Maybe FilePath
-                    -> Maybe FilePath -> FilePath -> Maybe FilePath -> Maybe FilePath -> Bool -> IO ()
+                    -> Maybe FilePath -> FilePath -> Maybe FilePath
+                    -> Maybe FilePath -> Maybe FilePath -> Bool -> IO ()
 uploadResults verbosity config docInfo
-              mdocsTarballFile buildReportFile buildLogFile testLogFile coverageFile installOk =
+              mdocsTarballFile buildReportFile buildLogFile testLogFile
+              coverageFile testReportFile installOk =
     httpSession verbosity "hackage-build" version $ do
       case mdocsTarballFile of
         Nothing              -> return ()
         Just docsTarballFile ->
           putDocsTarball config docInfo docsTarballFile
 
-      putBuildFiles config docInfo buildReportFile buildLogFile testLogFile coverageFile installOk
+      putBuildFiles config docInfo buildReportFile buildLogFile testLogFile
+        coverageFile testReportFile installOk
 
 withAuth :: BuildConfig -> Request -> Request
 withAuth config req =
@@ -904,14 +909,24 @@ putDocsTarball config docInfo docsTarballFile = do
     mEncoding = Just "gzip"
 
 putBuildFiles :: BuildConfig -> DocInfo -> Maybe FilePath
-                    -> FilePath -> Maybe FilePath -> Maybe FilePath -> Bool -> HttpSession ()
-putBuildFiles config docInfo reportFile buildLogFile testLogFile coverageFile installOk = do
+                    -> FilePath -> Maybe FilePath -> Maybe FilePath
+                    -> Maybe FilePath -> Bool -> HttpSession ()
+putBuildFiles config docInfo reportFile buildLogFile testLogFile coverageFile
+              testReportFile installOk = do
     reportContent   <- liftIO $ traverse readFile reportFile
     logContent      <- liftIO $ readFile buildLogFile
     testContent     <- liftIO $ traverse readFile testLogFile
     coverageContent <- liftIO $ traverse readFile coverageFile
+    testReportCntnt <-
+      case testReportFile of
+        Nothing -> pure Nothing
+        Just fname -> do
+          exists <- liftIO $ doesFileExist fname
+          if exists
+             then Just <$> liftIO (readFile fname)
+             else pure Nothing
     let uri   = docInfoReports config docInfo
-        body  = encode $ BR.BuildFiles reportContent (Just logContent) testContent coverageContent (not installOk)
+        body  = encode $ BR.BuildFiles reportContent (Just logContent) testContent coverageContent testReportCntnt (not installOk)
     let headers = [ (hAccept, BSS.pack "application/json") ]
     req <- withAuth config <$> mkUploadRequest (BSS.pack "PUT") uri "application/json" Nothing headers body
     runRequest req $ \rsp -> do

--- a/src/Distribution/Server/Features/BuildReports/Backup.hs
+++ b/src/Distribution/Server/Features/BuildReports/Backup.hs
@@ -8,7 +8,7 @@ module Distribution.Server.Features.BuildReports.Backup (
 
 import Distribution.Server.Features.BuildReports.BuildReport (BuildReport)
 import qualified Distribution.Server.Features.BuildReports.BuildReport as Report
-import Distribution.Server.Features.BuildReports.BuildReports (BuildReports(..), BuildCovg(..), PkgBuildReports(..), BuildReportId(..), BuildLog(..), TestLog(..))
+import Distribution.Server.Features.BuildReports.BuildReports (BuildReports(..), BuildCovg(..), PkgBuildReports(..), BuildReportId(..), BuildLog(..), TestLog(..), TestReportLog)
 import qualified Distribution.Server.Features.BuildReports.BuildReports as Reports
 
 import qualified Distribution.Server.Framework.BlobStorage as BlobStorage
@@ -94,8 +94,8 @@ packageReportsToExport :: PackageId -> PkgBuildReports -> [BackupEntry]
 packageReportsToExport pkgId pkgReports = concatMap (uncurry $ reportToExport prefix) (Map.toList $ Reports.reports pkgReports)
     where prefix = ["package", display pkgId]
 
-reportToExport :: [FilePath] -> BuildReportId -> (BuildReport, Maybe BuildLog, Maybe TestLog, Maybe BuildCovg ) -> [BackupEntry]
-reportToExport prefix reportId (report, mlog, _, _) = BackupByteString (getPath ".txt") (packUTF8 $ Report.show report) :
+reportToExport :: [FilePath] -> BuildReportId -> (BuildReport, Maybe BuildLog, Maybe TestLog, Maybe BuildCovg, Maybe TestReportLog) -> [BackupEntry]
+reportToExport prefix reportId (report, mlog, _, _, _) = BackupByteString (getPath ".txt") (packUTF8 $ Report.show report) :
     case mlog of Nothing -> []; Just (BuildLog blobId) -> [blobToBackup (getPath ".log") blobId]
   where
     getPath ext = prefix ++ [display reportId ++ ext]

--- a/src/Distribution/Server/Features/BuildReports/BuildReport.hs
+++ b/src/Distribution/Server/Features/BuildReports/BuildReport.hs
@@ -276,6 +276,16 @@ data BuildCovg = BuildCovg {
   topLevel          :: (Int,Int)
 } deriving (Eq, Typeable, Show)
 
+instance Arbitrary BuildCovg where
+  arbitrary =
+    BuildCovg
+      <$> intPair
+      <*> liftA3 BooleanCovg intPair intPair intPair
+      <*> intPair
+      <*> intPair
+      <*> intPair
+    where intPair = liftA2 (,) arbitrary arbitrary
+
 instance MemSize BuildCovg where
     memSize (BuildCovg a (BooleanCovg b c d) e f g) = memSize7 a b c d e f g
 
@@ -500,6 +510,10 @@ instance Arbitrary Outcome where
 
 data BuildStatus = BuildOK | BuildFailCnt Int
   deriving (Eq, Ord, Typeable, Show)
+
+instance Arbitrary BuildStatus where
+  arbitrary = oneof [ pure BuildOK, BuildFailCnt <$> arbitrary ]
+
 instance ToJSON BuildStatus where
   toJSON (BuildFailCnt a) = toJSON a
   toJSON BuildOK          = toJSON ((-1)::Int)

--- a/src/Distribution/Server/Features/BuildReports/BuildReport.hs
+++ b/src/Distribution/Server/Features/BuildReports/BuildReport.hs
@@ -620,6 +620,7 @@ data BuildFiles = BuildFiles {
   logContent :: Maybe String,
   testContent :: Maybe String,
   coverageContent :: Maybe String,
+  testReportContent :: Maybe String,
   buildFail :: Bool
 } deriving Show
 
@@ -630,6 +631,7 @@ instance Data.Aeson.FromJSON BuildFiles where
       <*> o .:? "log"
       <*> o .:? "test"
       <*> o .:? "coverage"
+      <*> o .:? "testReport"
       <*> o .: "buildFail"
 
 instance Data.Aeson.ToJSON BuildFiles where
@@ -638,6 +640,7 @@ instance Data.Aeson.ToJSON BuildFiles where
     "log"       .= logContent  p,
     "test"      .= testContent p,
     "coverage"  .= coverageContent  p,
+    "testReport".= testReportContent p,
     "buildFail" .= buildFail  p ]
 
 data PkgDetails = PkgDetails {

--- a/src/Distribution/Server/Features/BuildReports/BuildReports.hs
+++ b/src/Distribution/Server/Features/BuildReports/BuildReports.hs
@@ -1,11 +1,10 @@
 {-# LANGUAGE DeriveDataTypeable, GeneralizedNewtypeDeriving, TemplateHaskell,
              TypeFamilies #-}
-{-# OPTIONS_GHC -fno-warn-orphans #-}
 module Distribution.Server.Features.BuildReports.BuildReports (
     BuildReport(..),
     BuildReports(..),
-    BuildReports_v3,
     BuildReportId(..),
+    PkgBuildReports_v4(..),
     PkgBuildReports(..),
     BuildLog(..),
     TestLog(..),
@@ -55,12 +54,13 @@ import Data.Typeable (Typeable)
 import qualified Data.List as L
 import qualified Data.Char as Char
 import Data.Maybe (fromMaybe)
+import Test.QuickCheck (Arbitrary(..))
 
 import Text.StringTemplate (ToSElem(..))
 
 
 newtype BuildReportId = BuildReportId Int
-  deriving (Eq, Ord, Typeable, Show, MemSize, Pretty)
+  deriving (Eq, Ord, Typeable, Show, MemSize, Pretty, Arbitrary)
 
 incrementReportId :: BuildReportId -> BuildReportId
 incrementReportId (BuildReportId n) = BuildReportId (n+1)
@@ -82,10 +82,10 @@ instance Parsec BuildReportId where
       f c = Char.ord c - Char.ord '0'
 
 newtype BuildLog = BuildLog BlobStorage.BlobId
-  deriving (Eq, Typeable, Show, MemSize)
+  deriving (Eq, Typeable, Show, MemSize, Arbitrary)
 
 newtype TestLog = TestLog BlobStorage.BlobId
-  deriving (Eq, Typeable, Show, MemSize)
+  deriving (Eq, Typeable, Show, MemSize, Arbitrary)
 
 newtype TestReportLog = TestReportLog BlobStorage.BlobId
   deriving (Eq, Typeable, Show, MemSize)
@@ -306,6 +306,10 @@ data PkgBuildReports_v4 = PkgBuildReports_v4 {
     buildStatus_v4  :: !BuildStatus,
     runTests_v4     :: !Bool
 } deriving (Eq, Typeable, Show)
+
+instance Arbitrary PkgBuildReports_v4 where
+  arbitrary = PkgBuildReports_v4 <$> arbitrary <*> arbitrary
+                                 <*> arbitrary <*> arbitrary
 
 instance SafeCopy PkgBuildReports_v4 where
     version = 4

--- a/src/Distribution/Server/Features/BuildReports/State.hs
+++ b/src/Distribution/Server/Features/BuildReports/State.hs
@@ -5,7 +5,7 @@
 module Distribution.Server.Features.BuildReports.State where
 
 import Distribution.Server.Features.BuildReports.BuildReports
-                (BuildReportId, BuildLog, TestLog, BuildReport, BuildReports,BuildCovg, BuildStatus)
+                (BuildReportId, BuildLog, TestLog, TestReportLog, BuildReport, BuildReports,BuildCovg, BuildStatus)
 import qualified Distribution.Server.Features.BuildReports.BuildReports as BuildReports
 
 import Distribution.Package
@@ -39,10 +39,10 @@ deleteReport pkgid reportId = do
         Nothing -> return False
         Just reports -> State.put reports >> return True
 
-lookupReport :: PackageId -> BuildReportId -> Query BuildReports (Maybe (BuildReport, Maybe BuildLog, Maybe TestLog))
+lookupReport :: PackageId -> BuildReportId -> Query BuildReports (Maybe (BuildReport, Maybe BuildLog, Maybe TestLog, Maybe TestReportLog))
 lookupReport pkgid reportId = asks (BuildReports.lookupReport pkgid reportId)
 
-lookupPackageReports :: PackageId -> Query BuildReports [(BuildReportId, (BuildReport, Maybe BuildLog, Maybe TestLog))]
+lookupPackageReports :: PackageId -> Query BuildReports [(BuildReportId, (BuildReport, Maybe BuildLog, Maybe TestLog, Maybe TestReportLog))]
 lookupPackageReports pkgid = asks (BuildReports.lookupPackageReports pkgid)
 
 getBuildReports :: Query BuildReports BuildReports
@@ -51,14 +51,14 @@ getBuildReports = ask
 replaceBuildReports :: BuildReports -> Update BuildReports ()
 replaceBuildReports = State.put
 
-addRptLogCovg :: PackageId -> (BuildReport, Maybe BuildLog, Maybe BuildCovg ) -> Update BuildReports BuildReportId
-addRptLogCovg pkgid (bRpt, blog, bcovg) = do
+addRptLogCovg :: PackageId -> (BuildReport, Maybe BuildLog, Maybe BuildCovg, Maybe TestReportLog) -> Update BuildReports BuildReportId
+addRptLogCovg pkgid (bRpt, blog, bcovg, testReportLog) = do
     buildReports <- State.get
-    let (reports, reportId) = BuildReports.addRptLogTestCovg pkgid (bRpt, blog, Nothing, bcovg) buildReports
+    let (reports, reportId) = BuildReports.addRptLogTestCovg pkgid (bRpt, blog, Nothing, bcovg, testReportLog) buildReports
     State.put reports
     return reportId
 
-lookupReportCovg :: PackageId -> BuildReportId -> Query BuildReports (Maybe (BuildReport, Maybe BuildLog, Maybe TestLog, Maybe BuildCovg))
+lookupReportCovg :: PackageId -> BuildReportId -> Query BuildReports (Maybe (BuildReport, Maybe BuildLog, Maybe TestLog, Maybe BuildCovg, Maybe TestReportLog))
 lookupReportCovg pkgid reportId = asks (BuildReports.lookupReportCovg pkgid reportId)
 
 setFailStatus :: PackageId -> Bool -> Update BuildReports ()
@@ -77,13 +77,13 @@ resetFailCount pkgid = do
 lookupFailCount :: PackageId -> Query BuildReports (Maybe BuildStatus)
 lookupFailCount pkgid = asks (BuildReports.lookupFailCount pkgid)
 
-lookupLatestReport :: PackageId -> Query BuildReports (Maybe (BuildReportId, BuildReport, Maybe BuildLog, Maybe TestLog, Maybe BuildCovg))
+lookupLatestReport :: PackageId -> Query BuildReports (Maybe (BuildReportId, BuildReport, Maybe BuildLog, Maybe TestLog, Maybe BuildCovg, Maybe TestReportLog))
 lookupLatestReport pkgid = asks (BuildReports.lookupLatestReport pkgid)
 
-addRptLogTestCovg :: PackageId -> (BuildReport, Maybe BuildLog, Maybe TestLog, Maybe BuildCovg ) -> Update BuildReports BuildReportId
-addRptLogTestCovg pkgid (bRpt, blog, btest, bcovg) = do
+addRptLogTestCovg :: PackageId -> (BuildReport, Maybe BuildLog, Maybe TestLog, Maybe BuildCovg, Maybe TestReportLog) -> Update BuildReports BuildReportId
+addRptLogTestCovg pkgid (bRpt, blog, btest, bcovg, testReportLog) = do
     buildReports <- State.get
-    let (reports, reportId) = BuildReports.addRptLogTestCovg pkgid (bRpt, blog, btest, bcovg) buildReports
+    let (reports, reportId) = BuildReports.addRptLogTestCovg pkgid (bRpt, blog, btest, bcovg, testReportLog) buildReports
     State.put reports
     return reportId
 

--- a/src/Distribution/Server/Features/Security/MD5.hs
+++ b/src/Distribution/Server/Features/Security/MD5.hs
@@ -27,6 +27,7 @@ import qualified Data.ByteString.Char8                 as BS.Char8
 import qualified Data.ByteString.Lazy                  as BS.Lazy
 import           Data.SafeCopy
 import qualified Data.Serialize                        as Ser
+import           Test.QuickCheck (Arbitrary(..))
 
 -- cryptohash
 import qualified Crypto.Hash.MD5                       as MD5
@@ -38,6 +39,9 @@ import           Distribution.Server.Util.ReadDigest
 -- | MD5 digest
 data MD5Digest = MD5Digest {-# UNPACK #-} !Word64 {-# UNPACK #-} !Word64
                deriving (Eq,Ord)
+
+instance Arbitrary MD5Digest where
+  arbitrary = MD5Digest <$> arbitrary <*> arbitrary
 
 instance NFData MD5Digest where
     rnf !_ = () -- 'MD5Digest' has only strict primitive fields, hence WHNF==NF

--- a/src/Distribution/Server/Framework/BlobStorage.hs
+++ b/src/Distribution/Server/Framework/BlobStorage.hs
@@ -53,6 +53,7 @@ import System.Directory
 import System.IO
 import Data.Aeson
 import System.Posix.Files as Posix (createLink)
+import Test.QuickCheck (Arbitrary)
 
 -- For fsync
 import System.Posix.Types (Fd(..))
@@ -71,7 +72,7 @@ import System.Posix.IO (
 -- | An id for a blob. The content of the blob is stable.
 --
 newtype BlobId = BlobId MD5Digest
-  deriving (Eq, Ord, Show, Typeable, MemSize)
+  deriving (Eq, Ord, Show, Typeable, MemSize, Arbitrary)
 
 instance ToJSON BlobId where
   toJSON = toJSON . blobMd5

--- a/src/Distribution/Server/Framework/MemSize.hs
+++ b/src/Distribution/Server/Framework/MemSize.hs
@@ -159,6 +159,9 @@ instance (MemSize a, MemSize b, MemSize c) => MemSize (a,b,c) where
 instance (MemSize a, MemSize b, MemSize c, MemSize d) => MemSize (a,b,c,d) where
   memSize (a,b,c,d) = memSize4 a b c d
 
+instance (MemSize a, MemSize b, MemSize c, MemSize d, MemSize e) => MemSize (a,b,c,d,e) where
+  memSize (a,b,c,d,e) = memSize5 a b c d e
+
 instance MemSize a => MemSize (Maybe a) where
   memSize Nothing  = memSize0
   memSize (Just a) = memSize1 a

--- a/src/Distribution/Server/Framework/ResponseContentTypes.hs
+++ b/src/Distribution/Server/Framework/ResponseContentTypes.hs
@@ -186,6 +186,12 @@ instance ToMessage TestLog where
     toContentType _ = "text/plain"
     toMessage (TestLog bs) = bs
 
+newtype TestReportLog = TestReportLog BS.Lazy.ByteString
+
+instance ToMessage TestReportLog where
+    toContentType _ = "text/plain"
+    toMessage (TestReportLog bs) = bs
+
 newtype BuildCovg = BuildCovg BS.Lazy.ByteString
 
 instance ToMessage BuildCovg where


### PR DESCRIPTION
The test report log contains the actual output emitted by the test-suite
in a given Cabal package.

The test log only contains the logs of the *build* of the test.

Fixes #1397.

Demo
---

<img width="894" height="1084" alt="image" src="https://github.com/user-attachments/assets/527985fa-f24d-4495-9bda-20ff82785ebf" />

These were the logs as emitted by `cabal run exe:hackage-build -- build testpkg -v`:

```
Downloading
http://localhost:8080/package/testpkg-0.4.0.1/testpkg-0.4.0.1.tar.gz
Unpacking to testpkg-0.4.0.1/
Building testpkg-0.4.0.1
cabal
--config-file=/home/janus/flipstone/hackage-server/build-cache/cabal-config
v1-install --enable-documentation
--htmldir=/home/janus/flipstone/hackage-server/build-cache/tmp-install/haddocks/$pkgid-docs
--disable-optimization --ghc-option -O0 --disable-library-for-ghci
--package-db=clear --package-db=global
--package-db=/home/janus/flipstone/hackage-server/build-cache/tmp-install/packages.db
--reinstall --force-reinstalls
--haddock-html-location=/package/$pkg-$version/docs
--haddock-contents-location=/package/$pkg-$version --haddock-hyperlink-source
--prefix=/home/janus/flipstone/hackage-server/build-cache/tmp-install
--build-summary=/home/janus/flipstone/hackage-server/build-cache/tmp-install/reports/$pkgid.report
--report-planning-failure --haddock-html --haddock-hoogle
--haddock-option=--quickjump testpkg-0.4.0.1
Build results for testpkg-0.4.0.1:
/home/janus/flipstone/hackage-server/build-cache/results/testpkg-0.4.0.1.report
/home/janus/flipstone/hackage-server/build-cache/results/testpkg-0.4.0.1-docs.tar.gz
/home/janus/flipstone/hackage-server/build-cache/results/testpkg-0.4.0.1.log
Testing testpkg-0.4.0.1
cabal
--config-file=/home/janus/flipstone/hackage-server/build-cache/cabal-config
v2-test all --enable-coverage
--test-log=/home/janus/flipstone/hackage-server/build-cache/tmp-install/reports/testpkg-0.4.0.1.test
--test-show-details=never --disable-optimization
Test results for testpkg-0.4.0.1:
/home/janus/flipstone/hackage-server/build-cache/results/testpkg-0.4.0.1.test
```

Cabal file fragment:

```
test-suite simple
    main-is: Main.hs
    hs-source-dirs: test
    type: exitcode-stdio-1.0
    build-depends: base >=4 && <5
    default-language: Haskell2010
```

Main.hs (of test-suite) contents:

```
main = putStrLn "this is printed from custom test suite"
```