### PR TITLE
fix Mac Nix build

### DIFF
--- a/flake.nix
+++ b/flake.nix
@@ -55,6 +55,7 @@
               { custom = _: super.Cabal_3_14_2_0; };
             fourmolu.check = false;
             doctest.check = false;
+            network.check = false;
             system-filepath.check = false;
             hls-plugin-api.jailbreak = true;
             ghcide.jailbreak = true;


### PR DESCRIPTION
```
       >
       >   Network/Socket/Types.hsc:1162:33:
       >   1) Network.Socket.bind successfully binds to a unix socket
       >        uncaught exception: ErrorCall
       >        pokeSockAddr: path is too long in SockAddrUnix "/nix/var/nix/builds/nix-build-network-3.2.7.0.drv-3248-1626469880/haskell-network-d017fe594dac3be4/socket-file", length 110, unixPathMax 104
       >        CallStack (from HasCallStack):
       >          error, called at Network/Socket/Types.hsc:1162:33 in network-3.2.7.0-KQkhLwYK8QI1PXUI2ELCp1:Network.Socket.Types
       >
```