### PR TITLE
Set Content-Length for permanent redirection

### DIFF
--- a/src/Distribution/Server/Features/LegacyRedirects.hs
+++ b/src/Distribution/Server/Features/LegacyRedirects.hs
@@ -82,7 +82,7 @@ serveLegacyGets = msum
         (fileName', ".gz") -> case Posix.splitExtension fileName' of
           (packageStr, ".tar") -> case simpleParse packageStr of
             Just pkgid ->
-              movedPermanently (packageTarball pkgid) $ toResponse ""
+              movedPermanently (packageTarball pkgid) $ contentLength $ toResponse ()
             _ -> mzero
           _ -> mzero
         _ -> mzero


### PR DESCRIPTION
Issuing a GET request to `/package/<name-version>.tar.gz` on hackage.haskell.org sometimes
(for whatever reason) responds with an invalid header when using chunked transfer
encoding.

See https://discourse.haskell.org/t/hackage-errors-invalid-hash-s-5170-invalidchunkheaders/12935

Specifying a content length explicitly (hopefully) circumvents the problem.

Note, it's not really clear if that solves the problem, but this should also be a tiny bit more efficient.