### PR TITLE
package: display Uploaded before Revised

### DIFF
--- a/datafiles/templates/Html/package-page.html.st
+++ b/datafiles/templates/Html/package-page.html.st
@@ -173,6 +173,11 @@
               <td class="word-wrap">$package.maintainer$</td>
             </tr>
 
+            <tr>
+              <th>Uploaded</th>
+              <td>$hackage.uploadTime$</td>
+            </tr>
+
             $if(hackage.hasUpdateTime)$
             <tr>
               <th>Revised</th>
@@ -219,12 +224,6 @@
               <td class="word-wrap">$package.optional.sourceRepository$</td>
             </tr>
             $endif$
-
-            <tr>
-              <th>Uploaded</th>
-              <td>$hackage.uploadTime$</td>
-            </tr>
-
 
             $if(hackage.hasDistributions)$
             <tr>


### PR DESCRIPTION
A small but useful change to package pages:
list the original Upload date before the Revision date

(I often find myself scanning package pages to find when the version was original released (or revised).
Placing the two dates next to each other makes them easier to find.)