### PR TITLE
Fix #1422: Fix unreadable markdown tables in dark mode

### DIFF
--- a/datafiles/static/hackage.css
+++ b/datafiles/static/hackage.css
@@ -1314,9 +1314,4 @@ a.deprecated[href]:visited {
       background-color: #5E5184;
       color: #e0e0e0;
   }
-
-  tbody td{
-      background-color: #926efa;
-      color: white;
-  }
 }


### PR DESCRIPTION
Previously, tables in rendered READMEs had low contrast (white on white or black on black) in dark mode. This change adds high-contrast colors using the Hackage purple theme to ensure readability.