### PR TITLE
bump version to 0.6

### DIFF
--- a/hackage-server.cabal
+++ b/hackage-server.cabal
@@ -1,6 +1,6 @@
 cabal-version: 3.0
 name:         hackage-server
-version:      0.5.1
+version:      0.6
 
 category:     Distribution
 synopsis:     The Hackage web server


### PR DESCRIPTION
Although releases of *hackage-server* have not been published on `hackage.haskell.org` for a long time, given recent changes it will be useful to bump the version so we can specify a "fix version" in security advisories.

(Currently advisory DB tooling does not enable us to specify affected version ranges using Git commit hashes, although this is possible in the OSV format).