### PR TITLE
bump version to 0.6.1

### DIFF
--- a/hackage-server.cabal
+++ b/hackage-server.cabal
@@ -1,6 +1,6 @@
 cabal-version: 3.0
 name:         hackage-server
-version:      0.6
+version:      0.6.1
 
 category:     Distribution
 synopsis:     The Hackage web server


### PR DESCRIPTION
Although releases of hackage-server have not been published on
hackage.haskell.org for a long time, it is useful to bump the
version so we can declare a "fixed version" for the recent security
advisories (HSEC-2026-0002 and HSEC-2026-0004).