### PR TITLE
Support GHC 9.14

### DIFF
--- a/.github/workflows/haskell-ci.yml
+++ b/.github/workflows/haskell-ci.yml
@@ -8,9 +8,9 @@
 #
 # For more information, see https://github.com/haskell-CI/haskell-ci
 #
-# version: 0.19.20250506
+# version: 0.19.20260209
 #
-# REGENDATA ("0.19.20250506",["github","hackage-server.cabal"])
+# REGENDATA ("0.19.20260209",["github","hackage-server.cabal"])
 #
 name: Haskell-CI
 on:
@@ -20,6 +20,11 @@ on:
   pull_request:
     branches:
       - master
+  merge_group:
+    branches:
+      - master
+  workflow_dispatch:
+    {}
 jobs:
   linux:
     name: Haskell-CI - Linux - ${{ matrix.compiler }}
@@ -32,14 +37,19 @@ jobs:
     strategy:
       matrix:
         include:
-          - compiler: ghc-9.12.2
+          - compiler: ghc-9.14.1
             compilerKind: ghc
-            compilerVersion: 9.12.2
+            compilerVersion: 9.14.1
             setup-method: ghcup
             allow-failure: false
-          - compiler: ghc-9.10.2
+          - compiler: ghc-9.12.4
             compilerKind: ghc
-            compilerVersion: 9.10.2
+            compilerVersion: 9.12.4
+            setup-method: ghcup
+            allow-failure: false
+          - compiler: ghc-9.10.3
+            compilerKind: ghc
+            compilerVersion: 9.10.3
             setup-method: ghcup
             allow-failure: false
           - compiler: ghc-9.8.4
@@ -66,8 +76,8 @@ jobs:
           chmod a+x "$HOME/.ghcup/bin/ghcup"
       - name: Install cabal-install
         run: |
-          "$HOME/.ghcup/bin/ghcup" install cabal 3.14.2.0 || (cat "$HOME"/.ghcup/logs/*.* && false)
-          echo "CABAL=$HOME/.ghcup/bin/cabal-3.14.2.0 -vnormal+nowrap" >> "$GITHUB_ENV"
+          "$HOME/.ghcup/bin/ghcup" install cabal 3.16.0.0 || (cat "$HOME"/.ghcup/logs/*.* && false)
+          echo "CABAL=$HOME/.ghcup/bin/cabal-3.16.0.0 -vnormal+nowrap" >> "$GITHUB_ENV"
       - name: Install GHC (GHCup)
         if: matrix.setup-method == 'ghcup'
         run: |
@@ -168,7 +178,7 @@ jobs:
           touch cabal.project.local
           echo "packages: ${PKGDIR_hackage_server}" >> cabal.project
           echo "package hackage-server" >> cabal.project
-          echo "    ghc-options: -Werror=missing-methods" >> cabal.project
+          echo "    ghc-options: -Werror=missing-methods -Werror=missing-fields" >> cabal.project
           cat >> cabal.project <<EOF
           EOF
           $HCPKG list --simple-output --names-only | perl -ne 'for (split /\s+/) { print "constraints: any.$_ installed\n" unless /^(Cabal|Cabal-syntax|hackage-server|parsec|process|text)$/; }' >> cabal.project.local

--- a/.github/workflows/haskell-ci.yml
+++ b/.github/workflows/haskell-ci.yml
@@ -177,8 +177,6 @@ jobs:
           touch cabal.project
           touch cabal.project.local
           echo "packages: ${PKGDIR_hackage_server}" >> cabal.project
-          echo "package hackage-server" >> cabal.project
-          echo "    ghc-options: -Werror=missing-methods -Werror=missing-fields" >> cabal.project
           cat >> cabal.project <<EOF
           EOF
           $HCPKG list --simple-output --names-only | perl -ne 'for (split /\s+/) { print "constraints: any.$_ installed\n" unless /^(Cabal|Cabal-syntax|hackage-server|parsec|process|text)$/; }' >> cabal.project.local

--- a/cabal.haskell-ci
+++ b/cabal.haskell-ci
@@ -1,5 +1,8 @@
 branches: master
 
+error-incomplete-patterns: False
+error-unused-packages: False
+
 installed: +all -Cabal -Cabal-syntax -text -parsec -process
 
 -- Does not work with GHA:

--- a/cabal.haskell-ci
+++ b/cabal.haskell-ci
@@ -2,6 +2,7 @@ branches: master
 
 error-incomplete-patterns: False
 error-unused-packages: False
+error-missing-methods: none
 
 installed: +all -Cabal -Cabal-syntax -text -parsec -process
 

--- a/hackage-server.cabal
+++ b/hackage-server.cabal
@@ -165,8 +165,8 @@ common defaults
   -- other dependencies shared by most components
   build-depends:
     , aeson                  >= 2.1.0.0 && < 2.3
-    , Cabal                  >= 3.14.2.0 && < 3.18
-    , Cabal-syntax           >= 3.14.2.0 && < 3.18
+    , Cabal                  >= 3.16.0.0 && < 3.18
+    , Cabal-syntax           >= 3.16.0.0 && < 3.18
         -- Cabal-syntax needs to be bound to constrain hackage-security
         -- see https://github.com/haskell/hackage-server/issues/1130
     , network-bsd           ^>= 2.8

--- a/hackage-server.cabal
+++ b/hackage-server.cabal
@@ -28,8 +28,9 @@ license:      BSD-3-Clause
 license-file: LICENSE
 
 tested-with:
-  GHC == 9.12.2
-  GHC == 9.10.2
+  GHC == 9.14.1
+  GHC == 9.12.4
+  GHC == 9.10.3
   GHC == 9.8.4
   GHC == 9.6.7
   -- Constraint transformers >= 0.6 forces GHC >= 9.6 for CI

--- a/hackage-server.cabal
+++ b/hackage-server.cabal
@@ -147,7 +147,7 @@ common defaults
   -- see `cabal.project.local-ghc-${VERSION}` files
   build-depends:
     , array                  >= 0.5   && < 0.6
-    , base                   >= 4.18  && < 4.22
+    , base                   >= 4.18  && < 4.23
     , binary                 >= 0.8   && < 0.9
     , bytestring             >= 0.11.2 && < 0.13
     , containers             >= 0.6.0 && < 0.9
@@ -158,7 +158,7 @@ common defaults
         -- we use Control.Monad.Except, introduced in mtl-2.2.1
     , pretty                 >= 1.1   && < 1.2
     , text                  ^>= 1.2.5.0 || >= 2.0 && < 2.2
-    , time                   >= 1.9   && < 1.15
+    , time                   >= 1.9   && < 1.16
     , transformers           >= 0.5   && < 0.7
     , unix                   >= 2.7   && < 2.9
     , scientific
@@ -431,11 +431,11 @@ library
   -- NB: see also build-depends in `common defaults`!
   build-depends:
     , HStringTemplate       ^>= 0.8
-    , HTTP                  ^>= 4000.3.16 || ^>= 4000.4.1
+    , HTTP                   >= 4000.3.16 && < 4000.6
     , http-client           ^>= 0.7       && < 0.8
     , http-client-tls       ^>= 0.3
     , http-types             >= 0.10      && < 0.13
-    , QuickCheck             >= 2.14      && < 2.16
+    , QuickCheck             >= 2.14      && < 2.19
     , acid-state            ^>= 0.16
     , safecopy               >= 0.6       && < 0.11
     , async                 ^>= 2.2.1
@@ -639,7 +639,7 @@ test-suite ReverseDependenciesTest
     , tasty-hedgehog ^>= 1.4
     , tasty-hunit  ^>= 0.10
     , HUnit        ^>= 1.6
-    , hedgehog      >= 1.4 && < 1.6
+    , hedgehog      >= 1.4 && < 1.8
     , exceptions
     , bimap
     , mime-mail
@@ -654,7 +654,7 @@ benchmark RevDeps
   main-is: RevDeps.hs
   build-tool-depends: hackage-server:hackage-server
   build-depends:
-    , random       ^>= 1.2
+    , random       >= 1.2
     , gauge
   -- gauge does not support base-4.20
   if impl(ghc >= 9.10)

--- a/src/Distribution/Server/Features/UserNotify/Backup.hs
+++ b/src/Distribution/Server/Features/UserNotify/Backup.hs
@@ -11,9 +11,7 @@ import Distribution.Server.Framework.BackupRestore
 
 import qualified Data.Map as Map
 
-import Data.Maybe (fromJust)
-import Data.Time (defaultTimeLocale)
-import Data.Time.Format.Internal (buildTime)
+import Data.Time.Clock.POSIX (posixSecondsToUTCTime)
 import Distribution.Text (display)
 import Text.CSV (CSV, Record)
 
@@ -38,7 +36,7 @@ userNotifyBackup = go []
          _ -> return (go st)
 
      , restoreFinalize =
-        return (Acid.NotifyData (Map.fromList st, fromJust (buildTime defaultTimeLocale []))) -- defaults to unixstart time
+        return (Acid.NotifyData (Map.fromList st, posixSecondsToUTCTime 0)) -- unixstart time
      }
 
 importNotifyPref :: CSV -> Restore [(UserId, Acid.NotifyPref)]


### PR DESCRIPTION
Blocked on:
- [x] https://github.com/phadej/boring/issues/48

Commits:

- **Support time-1.15: more direct encoding of unix time 0**
  time-1.15 no longer exports its Internal module.
  So use a more direct method to get unix start of epoch.
  

- **Relax upper bounds for GHC 9.14**
  

- **Bump Cabal to 3.16**
  

- **Bump Haskell-CI to GHC 9.14.1**
  
Closes #1456.