### PR TITLE
constraints: actually forbid the unwanted packages

### DIFF
--- a/cabal.project
+++ b/cabal.project
@@ -9,8 +9,8 @@ packages:
 -----------------------------------------------------------------------------
 -- Anti-constraints
 
--- make sure we don't accidentally pick up blacklisted packages
-constraints: foundation -none, cryptonite -none, cryptohash -none
+-- make sure we don't accidentally pick up forbidden packages
+constraints: foundation < 0, cryptonite < 0, cryptohash < 0
 
 -----------------------------------------------------------------------------
 -- Modded lib:Cabal


### PR DESCRIPTION
Intent of "forbidden packages" constraint in `cabal.project` is not effected.  The current constraint does not prevent inclusion in build plan - it only ensures the packages are build without the `none` flag.

Change to a `< 0` version constraint to actually prevent the unwanted packages from being used.