### PR TITLE
Fix for mirroring hackage

### DIFF
--- a/exes/MirrorClient.hs
+++ b/exes/MirrorClient.hs
@@ -1,3 +1,5 @@
+{-# LANGUAGE ScopedTypeVariables #-}
+
 module Main (main) where
 
 -- stdlib
@@ -212,8 +214,9 @@ mirrorPackage verbosity opts sourceRepo targetRepo pkginfo = do
             notifyResponse (GetPackageFailed theError pkgid)
           Nothing -> do
             notifyResponse GetPackageOk
-            liftIO $ sanitiseTarball verbosity (stateDir opts) locTgz
-            uploadPackage targetRepo (mirrorUploaders opts) pkginfo locCab locTgz
+            mirrorHandle (\(e :: SomeException) -> liftIO $ putStrLn $ "An error occurred: " <> show e) $ do
+              liftIO $ sanitiseTarball verbosity (stateDir opts) locTgz
+              uploadPackage targetRepo (mirrorUploaders opts) pkginfo locCab locTgz
 
     removeTempFiles :: MirrorSession ()
     removeTempFiles = liftIO $ handle ignoreDoesNotExist $ do

--- a/src/Distribution/Client/Mirror/Session.hs
+++ b/src/Distribution/Client/Mirror/Session.hs
@@ -19,6 +19,7 @@ module Distribution.Client.Mirror.Session (
   , Unlift(..)
   , askUnlift
   , mirrorFinally
+  , mirrorHandle
     -- * Errors
   , MirrorError(..)
   , Entity(..)
@@ -221,6 +222,11 @@ mirrorFinally :: MirrorSession a -> MirrorSession b -> MirrorSession a
 mirrorFinally a b = do
     run <- askUnlift
     liftIO $ unlift run a `finally` unlift run b
+
+mirrorHandle :: Exception e => (e -> MirrorSession a) -> MirrorSession a -> MirrorSession a
+mirrorHandle k m = do
+    run <- askUnlift
+    liftIO $ handle (\e -> unlift run $ k e) $ unlift run m
 
 mirrorAskHttpLib :: MirrorSession Sec.HttpLib
 mirrorAskHttpLib = MirrorSession $ do


### PR DESCRIPTION
When attempting to mirror hackage, I received the following error:

```
mirroring OGL-0.0.2
packAscii: only ASCII inputs are supported, but got Administratörer
CallStack (from HasCallStack):
  error, called at ./Codec/Archive/Tar/PackAscii.hs:44:17 in tar-0.7.0.0-KJyftX2xMxi7opmJZqZodj-tar-internal:Codec.Archive.Tar.PackAscii
  packAscii, called at ./Codec/Archive/Tar/Write.hs:188:28 in tar-0.7.0.0-KJyftX2xMxi7opmJZqZodj-tar-internal:Codec.Archive.Tar.Write
```

which then crashed `hackage-mirror`. This PR adds a little `handle` wrapper around the offending call.